### PR TITLE
Complete REQ-039 SubjectDispatch daemon extraction

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/mod.rs
+++ b/crates/orchestrator-cli/src/cli_types/mod.rs
@@ -432,4 +432,35 @@ mod tests {
             _ => panic!("expected workflow phase approve command"),
         }
     }
+
+    #[test]
+    fn parses_workflow_phase_reject_from_workflow_module() {
+        let cli = Cli::try_parse_from([
+            "ao",
+            "workflow",
+            "phase",
+            "reject",
+            "--id",
+            "WF-002",
+            "--phase",
+            "testing",
+            "--note",
+            "gate rejected",
+        ])
+        .expect("workflow phase reject should parse");
+
+        match cli.command {
+            Command::Workflow {
+                command:
+                    WorkflowCommand::Phase {
+                        command: WorkflowPhaseCommand::Reject(args),
+                    },
+            } => {
+                assert_eq!(args.id, "WF-002");
+                assert_eq!(args.phase, "testing");
+                assert_eq!(args.note, "gate rejected");
+            }
+            _ => panic!("expected workflow phase reject command"),
+        }
+    }
 }

--- a/crates/orchestrator-cli/src/cli_types/workflow_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/workflow_types.rs
@@ -65,6 +65,8 @@ pub(crate) enum WorkflowCommand {
 pub(crate) enum WorkflowPhaseCommand {
     /// Approve a pending phase gate.
     Approve(WorkflowPhaseApproveArgs),
+    /// Reject a pending phase gate.
+    Reject(WorkflowPhaseRejectArgs),
 }
 
 #[derive(Debug, Subcommand)]
@@ -325,6 +327,16 @@ pub(crate) struct WorkflowPhaseApproveArgs {
     #[arg(long, value_name = "PHASE_ID", help = "Phase identifier.")]
     pub(crate) phase: String,
     #[arg(long, value_name = "TEXT", help = "Approval note for the phase gate.")]
+    pub(crate) note: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowPhaseRejectArgs {
+    #[arg(long, value_name = "WORKFLOW_ID", help = "Workflow identifier.")]
+    pub(crate) id: String,
+    #[arg(long, value_name = "PHASE_ID", help = "Phase identifier.")]
+    pub(crate) phase: String,
+    #[arg(long, value_name = "TEXT", help = "Rejection note for the phase gate.")]
     pub(crate) note: String,
 }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_schedule.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_schedule.rs
@@ -4,11 +4,12 @@ use crate::{not_found_error, print_ok, print_value, ScheduleCommand};
 use anyhow::{Context, Result};
 use chrono::Utc;
 use orchestrator_core::{
-    load_schedule_state, load_workflow_config, project_schedule_completion_status,
-    project_schedule_dispatch_attempt,
+    load_schedule_state, load_workflow_config, project_schedule_dispatch_attempt,
+    project_schedule_execution_fact,
 };
 use orchestrator_daemon_runtime::{
-    build_runner_command_from_dispatch, ScheduleDispatch as RuntimeScheduleDispatch,
+    build_completion_reconciliation_plan, build_runner_command_from_dispatch, CompletedProcess,
+    RunnerEvent, ScheduleDispatch as RuntimeScheduleDispatch, SubjectDispatch,
 };
 use serde::Serialize;
 
@@ -124,14 +125,14 @@ fn fire_schedule(project_root: &str, schedule_id: &str) -> Result<()> {
         "manual-schedule-fire",
         |schedule_id, dispatch| {
             let mut cmd = build_runner_command_from_dispatch(dispatch, project_root);
-            cmd.stdout(Stdio::null()).stderr(Stdio::inherit());
+            cmd.stdout(Stdio::null()).stderr(Stdio::piped());
             let child = cmd.spawn().with_context(|| {
                 format!(
                     "failed to spawn ao-workflow-runner for schedule '{}'",
                     schedule_id
                 )
             })?;
-            spawn_completion_writeback(project_root, schedule_id, child);
+            spawn_completion_writeback(project_root, schedule_id, dispatch.clone(), child);
             Ok(())
         },
     )?;
@@ -143,18 +144,61 @@ fn fire_schedule(project_root: &str, schedule_id: &str) -> Result<()> {
 fn spawn_completion_writeback(
     project_root: &str,
     schedule_id: &str,
+    dispatch: SubjectDispatch,
     mut child: std::process::Child,
 ) {
     let root = project_root.to_string();
     let sched_id = schedule_id.to_string();
     std::thread::spawn(move || {
-        let status = match child.wait() {
-            Ok(exit) if exit.success() => "completed",
-            Ok(_) => "failed",
-            Err(_) => "failed",
+        let mut stderr_lines = Vec::new();
+        if let Some(stderr) = child.stderr.take() {
+            use std::io::BufRead as _;
+            let reader = std::io::BufReader::new(stderr);
+            for line in reader.lines().flatten() {
+                eprintln!("{line}");
+                stderr_lines.push(line);
+            }
+        }
+
+        let exit_code = child.wait().ok().and_then(|exit| exit.code());
+        let events = parse_runner_events(&stderr_lines);
+        let completed = CompletedProcess {
+            subject_id: dispatch.subject_id().to_string(),
+            task_id: dispatch.task_id().map(|value| value.to_string()),
+            workflow_id: latest_runner_workflow_id(&events),
+            workflow_ref: Some(dispatch.workflow_ref.clone()),
+            workflow_status: latest_runner_workflow_status(&events),
+            schedule_id: Some(sched_id.clone()),
+            exit_code,
+            success: exit_code == Some(0),
+            failure_reason: None,
+            events,
         };
-        project_schedule_completion_status(&root, &sched_id, status);
+        let plan = build_completion_reconciliation_plan(vec![completed]);
+        if let Some(fact) = plan.execution_facts.first() {
+            project_schedule_execution_fact(&root, fact);
+        }
     });
+}
+
+fn parse_runner_events(lines: &[String]) -> Vec<RunnerEvent> {
+    lines
+        .iter()
+        .filter_map(|line| serde_json::from_str::<RunnerEvent>(line).ok())
+        .collect()
+}
+
+fn latest_runner_workflow_id(events: &[RunnerEvent]) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find_map(|event| event.workflow_id.clone())
+}
+
+fn latest_runner_workflow_status(
+    events: &[RunnerEvent],
+) -> Option<orchestrator_core::WorkflowStatus> {
+    events.iter().rev().find_map(|event| event.workflow_status)
 }
 
 #[cfg(test)]

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -9,9 +9,10 @@ use super::ops_common::project_state_dir;
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use orchestrator_core::{
-    ensure_workflow_config_compiled, load_workflow_config, services::ServiceHub,
-    workflow_ref_for_task, WorkflowResumeManager, WorkflowRunInput, WorkflowSubject,
-    REQUIREMENT_TASK_GENERATION_WORKFLOW_REF, STANDARD_WORKFLOW_REF,
+    dispatch_workflow_event, ensure_workflow_config_compiled, load_workflow_config,
+    services::ServiceHub, workflow_ref_for_task, WorkflowEvent, WorkflowResumeManager,
+    WorkflowRunInput, WorkflowSubject, REQUIREMENT_TASK_GENERATION_WORKFLOW_REF,
+    STANDARD_WORKFLOW_REF,
 };
 use serde_json::Value;
 use uuid::Uuid;
@@ -312,7 +313,20 @@ pub(crate) async fn handle_workflow(
             execute::handle_workflow_execute(args, hub, project_root, json).await?;
             Ok(())
         }
-        WorkflowCommand::Resume(args) => print_value(workflows.resume(&args.id).await?, json),
+        WorkflowCommand::Resume(args) => {
+            let outcome = dispatch_workflow_event(
+                hub.clone(),
+                project_root,
+                WorkflowEvent::Resume {
+                    workflow_id: args.id.clone(),
+                },
+            )
+            .await?;
+            let workflow = outcome
+                .workflow
+                .ok_or_else(|| anyhow!("workflow '{}' not found", args.id))?;
+            print_value(workflow, json)
+        }
         WorkflowCommand::ResumeStatus(args) => {
             let workflow = workflows.get(&args.id).await?;
             let manager = WorkflowResumeManager::new(project_root)?;
@@ -351,7 +365,18 @@ pub(crate) async fn handle_workflow(
                 "workflow pause",
                 "--id",
             )?;
-            print_value(workflows.pause(&args.id).await?, json)
+            let outcome = dispatch_workflow_event(
+                hub.clone(),
+                project_root,
+                WorkflowEvent::Pause {
+                    workflow_id: args.id.clone(),
+                },
+            )
+            .await?;
+            let workflow = outcome
+                .workflow
+                .ok_or_else(|| anyhow!("workflow '{}' not found", args.id))?;
+            print_value(workflow, json)
         }
         WorkflowCommand::Cancel(args) => {
             let workflow = workflows.get(&args.id).await?;
@@ -377,11 +402,33 @@ pub(crate) async fn handle_workflow(
                 "workflow cancel",
                 "--id",
             )?;
-            print_value(workflows.cancel(&args.id).await?, json)
+            let outcome = dispatch_workflow_event(
+                hub.clone(),
+                project_root,
+                WorkflowEvent::Cancel {
+                    workflow_id: args.id.clone(),
+                },
+            )
+            .await?;
+            let workflow = outcome
+                .workflow
+                .ok_or_else(|| anyhow!("workflow '{}' not found", args.id))?;
+            print_value(workflow, json)
         }
         WorkflowCommand::Phase { command } => match command {
             WorkflowPhaseCommand::Approve(args) => print_value(
                 phases::approve_manual_phase(
+                    hub.clone(),
+                    project_root,
+                    &args.id,
+                    &args.phase,
+                    &args.note,
+                )
+                .await?,
+                json,
+            ),
+            WorkflowPhaseCommand::Reject(args) => print_value(
+                phases::reject_manual_phase(
                     hub.clone(),
                     project_root,
                     &args.id,

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use orchestrator_core::{
-    register_workflow_runner_pid, services::ServiceHub, unregister_workflow_runner_pid,
+    dispatch_workflow_event, register_workflow_runner_pid, services::ServiceHub,
+    unregister_workflow_runner_pid, WorkflowEvent,
 };
 use workflow_runner::workflow_execute::{execute_workflow, WorkflowExecuteParams};
 
@@ -270,66 +271,21 @@ pub(crate) async fn approve_manual_phase(
     phase_id: &str,
     note: &str,
 ) -> Result<Value> {
-    let workflow = hub.workflows().get(workflow_id).await?;
-    let current_phase = workflow
-        .current_phase
-        .clone()
-        .or_else(|| {
-            workflow
-                .phases
-                .get(workflow.current_phase_index)
-                .map(|phase| phase.phase_id.clone())
-        })
-        .ok_or_else(|| anyhow!("workflow '{}' has no active phase", workflow_id))?;
-
-    if !current_phase.eq_ignore_ascii_case(phase_id) {
-        return Err(anyhow!(
-            "workflow '{}' active phase is '{}' (requested '{}')",
-            workflow_id,
-            current_phase,
-            phase_id
-        ));
-    }
-
-    let runtime = orchestrator_core::load_agent_runtime_config(Path::new(project_root))?;
-    let definition = runtime
-        .phase_execution(phase_id)
-        .ok_or_else(|| anyhow!("phase '{}' is not configured", phase_id))?;
-
-    if !matches!(
-        definition.mode,
-        orchestrator_core::PhaseExecutionMode::Manual
-    ) {
-        return Err(anyhow!("phase '{}' is not in manual mode", phase_id));
-    }
-
-    let manual = definition
-        .manual
-        .as_ref()
-        .ok_or_else(|| anyhow!("phase '{}' missing manual configuration", phase_id))?;
-
-    if manual.approval_note_required && note.trim().is_empty() {
-        return Err(anyhow!(
-            "phase '{}' requires a non-empty approval note",
-            phase_id
-        ));
-    }
-
     let _runner_pid_guard = WorkflowRunnerPidGuard::register(project_root, workflow_id)?;
     let approval_timestamp = Utc::now().to_rfc3339();
-    let workflow = match workflow.status {
-        orchestrator_core::WorkflowStatus::Paused => hub.workflows().resume(workflow_id).await?,
-        orchestrator_core::WorkflowStatus::Running => workflow,
-        status => {
-            return Err(anyhow!(
-                "workflow '{}' is not waiting for manual approval (status: {})",
-                workflow_id,
-                format!("{status:?}").to_ascii_lowercase()
-            ));
-        }
-    };
-
-    let updated = hub.workflows().complete_current_phase(workflow_id).await?;
+    let outcome = dispatch_workflow_event(
+        hub.clone(),
+        project_root,
+        WorkflowEvent::ApproveManualPhase {
+            workflow_id: workflow_id.to_string(),
+            phase_id: phase_id.to_string(),
+            note: Some(note.to_string()),
+        },
+    )
+    .await?;
+    let updated = outcome
+        .workflow
+        .ok_or_else(|| anyhow!("workflow '{}' not found", workflow_id))?;
 
     let mut store = read_manual_approvals(project_root)?;
     store.approvals.push(ManualApprovalRecord {
@@ -342,7 +298,7 @@ pub(crate) async fn approve_manual_phase(
     write_manual_approvals(project_root, &store)?;
 
     let mut continued_execution = None;
-    if updated.status == orchestrator_core::WorkflowStatus::Running {
+    if outcome.requires_continuation {
         let continuation = match execute_workflow(WorkflowExecuteParams {
             project_root: project_root.to_string(),
             workflow_id: Some(updated.id.clone()),
@@ -407,7 +363,7 @@ pub(crate) async fn approve_manual_phase(
         "workflow-phase-manual-approved",
         serde_json::json!({
             "workflow_id": workflow_id,
-            "task_id": workflow.task_id,
+            "task_id": updated.task_id,
             "phase_id": phase_id,
             "note": note,
         }),
@@ -424,9 +380,63 @@ pub(crate) async fn approve_manual_phase(
     }))
 }
 
+pub(crate) async fn reject_manual_phase(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    workflow_id: &str,
+    phase_id: &str,
+    note: &str,
+) -> Result<Value> {
+    let outcome = dispatch_workflow_event(
+        hub.clone(),
+        project_root,
+        WorkflowEvent::RejectManualPhase {
+            workflow_id: workflow_id.to_string(),
+            phase_id: phase_id.to_string(),
+            note: Some(note.to_string()),
+        },
+    )
+    .await?;
+    let updated = outcome
+        .workflow
+        .ok_or_else(|| anyhow!("workflow '{}' not found", workflow_id))?;
+
+    project_terminal_workflow_result(
+        hub.clone(),
+        project_root,
+        updated.subject.id(),
+        Some(updated.task_id.as_str()),
+        updated.workflow_ref.as_deref(),
+        Some(updated.id.as_str()),
+        updated.status,
+        updated.failure_reason.as_deref(),
+    )
+    .await;
+
+    emit_daemon_event(
+        project_root,
+        "workflow-phase-manual-rejected",
+        serde_json::json!({
+            "workflow_id": workflow_id,
+            "task_id": updated.task_id,
+            "phase_id": phase_id,
+            "note": note,
+        }),
+    )?;
+
+    Ok(serde_json::json!({
+        "workflow": updated,
+        "manual_rejection": {
+            "phase_id": phase_id,
+            "note": note,
+            "rejected_at": Utc::now().to_rfc3339(),
+        },
+    }))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::approve_manual_phase;
+    use super::{approve_manual_phase, reject_manual_phase};
     use orchestrator_core::{
         load_agent_runtime_config, services::ServiceHub, write_agent_runtime_config,
         FileServiceHub, PhaseExecutionMode, PhaseManualDefinition, Priority, TaskCreateInput,
@@ -540,6 +550,7 @@ mod tests {
         current_definition.manual = Some(PhaseManualDefinition {
             instructions: "Approve this step".to_string(),
             approval_note_required: false,
+            timeout_secs: None,
         });
         runtime
             .phases
@@ -555,6 +566,7 @@ mod tests {
         next_definition.manual = Some(PhaseManualDefinition {
             instructions: "Approve the resumed phase".to_string(),
             approval_note_required: false,
+            timeout_secs: None,
         });
         runtime.phases.insert(next_phase.clone(), next_definition);
         write_agent_runtime_config(temp.path(), &runtime).expect("runtime config should write");
@@ -598,5 +610,89 @@ mod tests {
             response["continued_execution"]["phase_results"][0]["phase_id"].as_str(),
             Some(next_phase.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn reject_manual_phase_fails_workflow() {
+        let temp = TempDir::new().expect("temp dir");
+        init_git_repo(&temp);
+        let project_root = temp.path().to_string_lossy().to_string();
+        let hub = Arc::new(FileServiceHub::new(&project_root).expect("file service hub"));
+
+        let task = hub
+            .tasks()
+            .create(TaskCreateInput {
+                title: "manual rejection".to_string(),
+                description: "reject approval".to_string(),
+                task_type: Some(TaskType::Feature),
+                priority: Some(Priority::High),
+                created_by: Some("test".to_string()),
+                tags: Vec::new(),
+                linked_requirements: Vec::new(),
+                linked_architecture_entities: Vec::new(),
+            })
+            .await
+            .expect("task should be created");
+        hub.tasks()
+            .set_status(&task.id, TaskStatus::InProgress, false)
+            .await
+            .expect("task should be in progress");
+
+        let workflow = hub
+            .workflows()
+            .run(WorkflowRunInput::for_task(task.id.clone(), None))
+            .await
+            .expect("workflow should start");
+        let current_phase = workflow
+            .current_phase
+            .clone()
+            .expect("workflow should have current phase");
+
+        let mut runtime = load_agent_runtime_config(temp.path()).expect("runtime config");
+        let mut definition = runtime
+            .phase_execution(&current_phase)
+            .cloned()
+            .expect("current phase should exist");
+        definition.mode = PhaseExecutionMode::Manual;
+        definition.agent_id = None;
+        definition.command = None;
+        definition.manual = Some(PhaseManualDefinition {
+            instructions: "Approve or reject".to_string(),
+            approval_note_required: false,
+            timeout_secs: None,
+        });
+        runtime.phases.insert(current_phase.clone(), definition);
+        write_agent_runtime_config(temp.path(), &runtime).expect("runtime config should write");
+
+        let paused = hub
+            .workflows()
+            .pause(&workflow.id)
+            .await
+            .expect("workflow should pause");
+        assert_eq!(paused.status, WorkflowStatus::Paused);
+
+        reject_manual_phase(
+            hub.clone(),
+            &project_root,
+            &workflow.id,
+            &current_phase,
+            "rejected",
+        )
+        .await
+        .expect("manual rejection should succeed");
+
+        let updated = hub
+            .workflows()
+            .get(&workflow.id)
+            .await
+            .expect("workflow should reload");
+        let rejected_phase = updated
+            .phases
+            .iter()
+            .find(|phase| phase.phase_id == current_phase)
+            .expect("rejected phase should remain in workflow");
+
+        assert_eq!(rejected_phase.status, WorkflowPhaseStatus::Failed);
+        assert_eq!(updated.status, WorkflowStatus::Failed);
     }
 }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -1,7 +1,10 @@
 use super::*;
+use anyhow::Result;
+use crate::services::runtime::execution_fact_projection::project_terminal_workflow_result;
 use crate::services::runtime::workflow_mutation_surface::cancel_orphaned_running_workflow;
 use orchestrator_core::{
-    active_workflow_runner_ids, services::ServiceHub, WorkflowMachineState, WorkflowStatus,
+    active_workflow_runner_ids, dispatch_workflow_event, load_agent_runtime_config,
+    services::ServiceHub, WorkflowEvent, WorkflowMachineState, WorkflowStatus,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -32,7 +35,6 @@ pub async fn recover_orphaned_running_workflows(
         if active_subject_ids.contains(&workflow.id)
             || externally_active_workflows.contains(&workflow.id)
             || active_subject_ids.contains(workflow.subject.id())
-            || (!workflow.task_id.is_empty() && active_subject_ids.contains(&workflow.task_id))
         {
             continue;
         }
@@ -49,6 +51,99 @@ pub async fn recover_orphaned_running_workflows(
     }
 
     recovered
+}
+
+pub async fn reconcile_manual_phase_timeouts(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+) -> Result<usize> {
+    let runtime = load_agent_runtime_config(Path::new(project_root))?;
+    let workflows = hub.workflows().list().await.unwrap_or_default();
+    let mut reconciled = 0usize;
+    let now = chrono::Utc::now();
+
+    for workflow in workflows {
+        if workflow.status != WorkflowStatus::Paused {
+            continue;
+        }
+
+        let phase_id = workflow
+            .current_phase
+            .clone()
+            .or_else(|| {
+                workflow
+                    .phases
+                    .get(workflow.current_phase_index)
+                    .map(|phase| phase.phase_id.clone())
+            })
+            .unwrap_or_default();
+        if phase_id.is_empty() {
+            continue;
+        }
+
+        let definition = match runtime.phase_execution(&phase_id) {
+            Some(definition) => definition,
+            None => continue,
+        };
+        if !matches!(definition.mode, orchestrator_core::PhaseExecutionMode::Manual) {
+            continue;
+        }
+        let manual = match definition.manual.as_ref() {
+            Some(manual) => manual,
+            None => continue,
+        };
+        let timeout_secs = match manual.timeout_secs {
+            Some(timeout_secs) => timeout_secs,
+            None => continue,
+        };
+        if timeout_secs == 0 {
+            continue;
+        }
+
+        let started_at = workflow
+            .phases
+            .get(workflow.current_phase_index)
+            .and_then(|phase| phase.started_at)
+            .or(Some(workflow.started_at));
+        let Some(started_at) = started_at else {
+            continue;
+        };
+        let elapsed = now.signed_duration_since(started_at).num_seconds().max(0) as u64;
+        if elapsed < timeout_secs {
+            continue;
+        }
+
+        let reason = format!(
+            "manual phase '{}' timed out after {} seconds",
+            phase_id, timeout_secs
+        );
+        let outcome = dispatch_workflow_event(
+            hub.clone(),
+            project_root,
+            WorkflowEvent::RejectManualPhase {
+                workflow_id: workflow.id.clone(),
+                phase_id: phase_id.clone(),
+                note: Some(reason.clone()),
+            },
+        )
+        .await?;
+        if let Some(updated) = outcome.workflow {
+            project_terminal_workflow_result(
+                hub.clone(),
+                project_root,
+                updated.subject.id(),
+                Some(updated.task_id.as_str()),
+                updated.workflow_ref.as_deref(),
+                Some(updated.id.as_str()),
+                updated.status,
+                updated.failure_reason.as_deref(),
+            )
+            .await;
+        }
+        reconciled = reconciled.saturating_add(1);
+    }
+
+    Ok(reconciled)
 }
 
 fn workflow_is_waiting_on_manual_phase(

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation_test_support.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation_test_support.rs
@@ -2,9 +2,10 @@ use super::*;
 use crate::services::runtime::execution_fact_projection::project_terminal_workflow_result;
 use crate::services::runtime::runtime_daemon::daemon_reconciliation::recover_orphaned_running_workflows;
 use orchestrator_core::{
-    dependency_blocked_reason, dependency_gate_issues_for_task, is_dependency_gate_block,
-    is_merge_gate_block, project_task_blocked_with_reason, project_task_status,
-    services::ServiceHub, TaskStatus, WorkflowResumeManager, WorkflowStatus,
+    dependency_blocked_reason, dependency_gate_issues_for_task, dispatch_workflow_event,
+    is_dependency_gate_block, is_merge_gate_block, project_task_blocked_with_reason,
+    project_task_status, services::ServiceHub, TaskStatus, WorkflowEvent, WorkflowResumeManager,
+    WorkflowStatus,
 };
 use orchestrator_daemon_runtime::{active_workflow_task_ids, is_terminally_completed_workflow};
 use orchestrator_git_ops::is_branch_merged;
@@ -178,7 +179,18 @@ pub async fn reconcile_stale_in_progress_tasks_for_project(
         if age_minutes < threshold_minutes {
             continue;
         }
-        project_task_status(hub.clone(), &task.id, TaskStatus::Ready).await?;
+        let _ = dispatch_workflow_event(
+            hub.clone(),
+            project_root,
+            WorkflowEvent::StaleReset {
+                task_id: task.id.clone(),
+                reason: Some(format!(
+                    "stale in-progress task exceeded {} minutes",
+                    threshold_minutes
+                )),
+            },
+        )
+        .await?;
         reconciled = reconciled.saturating_add(1);
     }
 
@@ -196,19 +208,28 @@ pub async fn resume_interrupted_workflows_for_project(
 
     let mut resumed = 0usize;
     for (workflow, _) in resumable {
-        let updated = hub.workflows().resume(&workflow.id).await?;
-        resumed = resumed.saturating_add(1);
-        project_terminal_workflow_result(
+        let outcome = dispatch_workflow_event(
             hub.clone(),
             root,
-            &updated.task_id,
-            Some(updated.task_id.as_str()),
-            updated.workflow_ref.as_deref(),
-            Some(updated.id.as_str()),
-            updated.status,
-            None,
+            WorkflowEvent::Resume {
+                workflow_id: workflow.id.clone(),
+            },
         )
-        .await;
+        .await?;
+        if let Some(updated) = outcome.workflow {
+            resumed = resumed.saturating_add(1);
+            project_terminal_workflow_result(
+                hub.clone(),
+                root,
+                &updated.task_id,
+                Some(updated.task_id.as_str()),
+                updated.workflow_ref.as_deref(),
+                Some(updated.id.as_str()),
+                updated.status,
+                None,
+            )
+            .await;
+        }
     }
 
     Ok((cleaned, resumed))
@@ -377,6 +398,7 @@ mod tests {
         definition.manual = Some(PhaseManualDefinition {
             instructions: "Approve this step".to_string(),
             approval_note_required: false,
+            timeout_secs: None,
         });
         runtime.phases.insert(current_phase.clone(), definition);
         write_agent_runtime_config(temp.path(), &runtime).expect("runtime config should write");

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_scheduler_project_tick_tests.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_scheduler_project_tick_tests.rs
@@ -1,12 +1,18 @@
 use super::reconciliation_test_support::reconcile_stale_in_progress_tasks_for_project;
 use super::task_dispatch::run_ready_task_workflows_for_project;
 use super::*;
+use crate::services::runtime::runtime_daemon::daemon_reconciliation::reconcile_manual_phase_timeouts;
 use crate::services::runtime::execution_fact_projection::reconcile_completed_processes;
 use chrono::Utc;
 use orchestrator_core::ServiceHub;
-use orchestrator_core::{Priority, TaskCreateInput, TaskType, WorkflowStatus};
+use orchestrator_core::{
+    FileServiceHub, PhaseExecutionMode, PhaseManualDefinition, Priority, TaskCreateInput,
+    TaskStatus, TaskType, WorkflowRunInput, WorkflowStatus,
+};
 use orchestrator_daemon_runtime::CompletedProcess;
+use serde_json::json;
 use std::path::Path;
+use std::time::Duration;
 use tempfile::TempDir;
 use workflow_runner::executor::parse_merge_conflict_recovery_response;
 
@@ -113,6 +119,7 @@ async fn run_ready_prefers_dispatch_queue_and_marks_selected_entry_assigned() {
         &DispatchQueueState {
             entries: vec![
                 DispatchQueueEntry {
+                    subject_id: None,
                     task_id: queue_task.id.clone(),
                     dispatch: None,
                     status: DispatchQueueEntryStatus::Pending,
@@ -121,6 +128,7 @@ async fn run_ready_prefers_dispatch_queue_and_marks_selected_entry_assigned() {
                     held_at: None,
                 },
                 DispatchQueueEntry {
+                    subject_id: None,
                     task_id: fallback_task.id.clone(),
                     dispatch: None,
                     status: DispatchQueueEntryStatus::Pending,
@@ -161,7 +169,7 @@ async fn run_ready_prefers_dispatch_queue_and_marks_selected_entry_assigned() {
     assert_eq!(queue_entry.status, DispatchQueueEntryStatus::Assigned);
     assert_eq!(
         queue_entry.workflow_id.as_deref(),
-        Some(started.workflow_id.as_str())
+        started.workflow_id.as_deref()
     );
 
     let fallback_entry = queue_state
@@ -170,6 +178,65 @@ async fn run_ready_prefers_dispatch_queue_and_marks_selected_entry_assigned() {
         .find(|entry| entry.task_id == fallback_task.id)
         .expect("fallback queue entry should remain present");
     assert_eq!(fallback_entry.status, DispatchQueueEntryStatus::Pending);
+}
+
+#[tokio::test]
+async fn run_ready_dispatches_custom_subjects_from_queue() {
+    let _lock = crate::shared::test_env_lock()
+        .lock()
+        .expect("env lock should be available");
+    let home = TempDir::new().expect("home temp dir");
+    let _home_guard = EnvVarGuard::set("HOME", Some(home.path().to_string_lossy().as_ref()));
+
+    let hub = Arc::new(orchestrator_core::InMemoryServiceHub::new());
+    let project_root = TempDir::new().expect("project temp dir");
+    let project_root_str = project_root.path().to_string_lossy().to_string();
+
+    let dispatch = SubjectDispatch::for_custom(
+        "custom-dispatch",
+        "non-task workflow",
+        orchestrator_core::STANDARD_WORKFLOW_REF,
+        Some(json!({"scope":"non-task"})),
+        "manual-queue-enqueue",
+    );
+
+    save_dispatch_queue_state(
+        &project_root_str,
+        &DispatchQueueState {
+            entries: vec![DispatchQueueEntry::from_dispatch(dispatch.clone())],
+        },
+    )
+    .expect("queue state should be stored");
+
+    let summary = run_ready_task_workflows_for_project(
+        hub.clone() as Arc<dyn ServiceHub>,
+        &project_root_str,
+        1,
+    )
+    .await
+    .expect("ready runner should succeed");
+
+    assert_eq!(summary.started, 1);
+    assert_eq!(summary.started_workflows.len(), 1);
+    let started = &summary.started_workflows[0];
+    assert_eq!(started.task_id(), None);
+    assert_eq!(started.subject_id(), "custom-dispatch");
+    assert!(started.workflow_id.is_some());
+    assert_eq!(
+        started.selection_source,
+        DispatchSelectionSource::DispatchQueue
+    );
+
+    let queue_state = load_dispatch_queue_state(&project_root_str)
+        .expect("queue should load")
+        .expect("queue should exist");
+    let queue_entry = queue_state
+        .entries
+        .iter()
+        .find(|entry| entry.subject_id() == "custom-dispatch")
+        .expect("custom queue entry should remain present");
+    assert_eq!(queue_entry.status, DispatchQueueEntryStatus::Assigned);
+    assert_eq!(queue_entry.workflow_id.as_deref(), started.workflow_id.as_deref());
 }
 
 #[tokio::test]
@@ -226,6 +293,7 @@ async fn run_ready_uses_fallback_headroom_after_dispatching_queue_entries() {
         &project_root_str,
         &DispatchQueueState {
             entries: vec![DispatchQueueEntry {
+                subject_id: None,
                 task_id: queue_task.id.clone(),
                 dispatch: None,
                 status: DispatchQueueEntryStatus::Pending,
@@ -275,7 +343,7 @@ async fn run_ready_uses_fallback_headroom_after_dispatching_queue_entries() {
     assert_eq!(queue_entry.status, DispatchQueueEntryStatus::Assigned);
     assert_eq!(
         queue_entry.workflow_id.as_deref(),
-        Some(summary.started_workflows[0].workflow_id.as_str())
+        summary.started_workflows[0].workflow_id.as_deref()
     );
 }
 
@@ -353,6 +421,7 @@ async fn run_ready_dispatches_multiple_tasks_from_dispatch_queue_before_fallback
         &DispatchQueueState {
             entries: vec![
                 DispatchQueueEntry {
+                    subject_id: None,
                     task_id: queue_task_one.id.clone(),
                     dispatch: None,
                     status: DispatchQueueEntryStatus::Pending,
@@ -361,6 +430,7 @@ async fn run_ready_dispatches_multiple_tasks_from_dispatch_queue_before_fallback
                     held_at: None,
                 },
                 DispatchQueueEntry {
+                    subject_id: None,
                     task_id: queue_task_two.id.clone(),
                     dispatch: None,
                     status: DispatchQueueEntryStatus::Pending,
@@ -416,7 +486,7 @@ async fn run_ready_dispatches_multiple_tasks_from_dispatch_queue_before_fallback
         assert_eq!(queue_entry.status, DispatchQueueEntryStatus::Assigned);
         assert_eq!(
             queue_entry.workflow_id.as_deref(),
-            Some(started.workflow_id.as_str())
+            started.workflow_id.as_deref()
         );
     }
 }
@@ -471,6 +541,7 @@ async fn run_ready_falls_back_when_queue_has_no_dispatchable_entries() {
         &project_root_str,
         &DispatchQueueState {
             entries: vec![DispatchQueueEntry {
+                subject_id: None,
                 task_id: queue_only_task.id.clone(),
                 dispatch: None,
                 status: DispatchQueueEntryStatus::Pending,
@@ -593,6 +664,7 @@ async fn reconcile_completed_processes_removes_assigned_queue_entries_on_complet
         &project_root_str,
         &DispatchQueueState {
             entries: vec![DispatchQueueEntry {
+                subject_id: None,
                 task_id: task.id.clone(),
                 dispatch: Some(dispatch.clone()),
                 status: DispatchQueueEntryStatus::Assigned,
@@ -677,6 +749,7 @@ async fn reconcile_completed_processes_removes_assigned_queue_entries_on_failure
         &project_root_str,
         &DispatchQueueState {
             entries: vec![DispatchQueueEntry {
+                subject_id: None,
                 task_id: task.id.clone(),
                 dispatch: Some(dispatch.clone()),
                 status: DispatchQueueEntryStatus::Assigned,
@@ -762,6 +835,7 @@ async fn reconcile_stale_in_progress_removes_assigned_queue_entries_for_failed_w
         &project_root_str,
         &DispatchQueueState {
             entries: vec![DispatchQueueEntry {
+                subject_id: None,
                 task_id: task.id.clone(),
                 dispatch: None,
                 status: DispatchQueueEntryStatus::Assigned,
@@ -842,6 +916,7 @@ async fn reconcile_stale_in_progress_removes_assigned_queue_entries_for_cancelle
         &project_root_str,
         &DispatchQueueState {
             entries: vec![DispatchQueueEntry {
+                subject_id: None,
                 task_id: task.id.clone(),
                 dispatch: None,
                 status: DispatchQueueEntryStatus::Assigned,
@@ -1061,4 +1136,80 @@ async fn priority_ordering_high_first() {
         Some(high_task.id.as_str()),
         "high priority should start first"
     );
+}
+
+#[tokio::test]
+async fn reconcile_manual_phase_timeouts_fails_workflow() {
+    let temp = TempDir::new().expect("temp dir should be created");
+    let project_root = temp.path().to_string_lossy().to_string();
+    let hub = Arc::new(FileServiceHub::new(&project_root).expect("file service hub"));
+
+    let task = hub
+        .tasks()
+        .create(TaskCreateInput {
+            title: "manual timeout".to_string(),
+            description: "manual phase timeout".to_string(),
+            task_type: Some(TaskType::Feature),
+            priority: Some(Priority::High),
+            created_by: Some("test".to_string()),
+            tags: Vec::new(),
+            linked_requirements: Vec::new(),
+            linked_architecture_entities: Vec::new(),
+        })
+        .await
+        .expect("task should be created");
+    hub.tasks()
+        .set_status(&task.id, TaskStatus::InProgress, false)
+        .await
+        .expect("task should be in progress");
+
+    let workflow = hub
+        .workflows()
+        .run(WorkflowRunInput::for_task(task.id.clone(), None))
+        .await
+        .expect("workflow should start");
+    let current_phase = workflow
+        .current_phase
+        .clone()
+        .expect("workflow should have current phase");
+
+    let mut runtime = orchestrator_core::load_agent_runtime_config(temp.path())
+        .expect("runtime config should load");
+    let mut definition = runtime
+        .phase_execution(&current_phase)
+        .cloned()
+        .expect("current phase should exist");
+    definition.mode = PhaseExecutionMode::Manual;
+    definition.agent_id = None;
+    definition.command = None;
+    definition.manual = Some(PhaseManualDefinition {
+        instructions: "Approve or reject".to_string(),
+        approval_note_required: false,
+        timeout_secs: Some(1),
+    });
+    runtime.phases.insert(current_phase.clone(), definition);
+    orchestrator_core::write_agent_runtime_config(temp.path(), &runtime)
+        .expect("runtime config should write");
+
+    let paused = hub
+        .workflows()
+        .pause(&workflow.id)
+        .await
+        .expect("workflow should pause");
+    assert_eq!(paused.status, WorkflowStatus::Paused);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let reconciled =
+        reconcile_manual_phase_timeouts(hub.clone() as Arc<dyn ServiceHub>, &project_root)
+            .await
+            .expect("manual timeout reconciliation should succeed");
+    assert_eq!(reconciled, 1);
+
+    let updated = hub
+        .workflows()
+        .get(&workflow.id)
+        .await
+        .expect("workflow should reload");
+    assert_eq!(updated.status, WorkflowStatus::Failed);
 }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_task_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_task_dispatch.rs
@@ -7,9 +7,10 @@ use orchestrator_core::{
 };
 pub use orchestrator_daemon_runtime::{
     active_workflow_subject_ids, active_workflow_task_ids, is_terminally_completed_workflow,
-    load_dispatch_queue_state, mark_dispatch_queue_entry_assigned, plan_ready_dispatch,
-    DispatchCandidate, DispatchQueueEntryStatus, DispatchQueueState, DispatchSelectionSource,
-    DispatchWorkflowStart, DispatchWorkflowStartSummary, SubjectDispatch,
+    execute_dispatch_plan_via_runner, load_dispatch_queue_state, mark_dispatch_queue_entry_assigned,
+    plan_ready_dispatch, DispatchCandidate, DispatchNotice, DispatchNoticeSink,
+    DispatchQueueEntryStatus, DispatchQueueState, DispatchSelectionSource, DispatchWorkflowStart,
+    DispatchWorkflowStartSummary, SubjectDispatch,
 };
 #[cfg(test)]
 pub use orchestrator_daemon_runtime::{
@@ -73,21 +74,20 @@ pub async fn run_ready_task_workflows_for_project(
             break;
         }
 
-        let Some(task_id) = planned_start.task_id() else {
-            continue;
-        };
-        let Some(task) = task_lookup.get(task_id).cloned() else {
-            continue;
-        };
-        let dependency_issues =
-            dependency_gate_issues_for_task(hub.clone(), project_root, &task).await;
-        if !dependency_issues.is_empty() {
-            eprintln!(
-                "{}: skipping queued task dispatch for {} until dependency gates clear",
-                protocol::ACTOR_DAEMON,
-                task.id
-            );
-            continue;
+        if let Some(task_id) = planned_start.task_id() {
+            let Some(task) = task_lookup.get(task_id).cloned() else {
+                continue;
+            };
+            let dependency_issues =
+                dependency_gate_issues_for_task(hub.clone(), project_root, &task).await;
+            if !dependency_issues.is_empty() {
+                eprintln!(
+                    "{}: skipping queued task dispatch for {} until dependency gates clear",
+                    protocol::ACTOR_DAEMON,
+                    task.id
+                );
+                continue;
+            }
         }
 
         let workflow =
@@ -96,7 +96,7 @@ pub async fn run_ready_task_workflows_for_project(
             if let Err(error) = mark_dispatch_queue_entry_assigned(
                 project_root,
                 &planned_start.dispatch,
-                workflow.id.as_str(),
+                Some(workflow.id.as_str()),
             ) {
                 eprintln!(
                     "{}: failed to mark dispatch queue entry assigned for task {}: {}",
@@ -108,7 +108,7 @@ pub async fn run_ready_task_workflows_for_project(
         }
         started_workflows.push(DispatchWorkflowStart {
             dispatch: planned_start.dispatch.clone(),
-            workflow_id: workflow.id.clone(),
+            workflow_id: Some(workflow.id.clone()),
             selection_source: planned_start.selection_source,
         });
     }
@@ -157,10 +157,10 @@ pub async fn dispatch_ready_tasks_via_runner(
         &prepared.fallback_candidates,
         &prepared.completed_subject_ids,
     );
-    let mut started_workflows = Vec::new();
+    let mut planned_starts = Vec::new();
 
     for planned_start in plan.ordered_starts {
-        if started_workflows.len() >= limit {
+        if planned_starts.len() >= limit {
             break;
         }
 
@@ -179,43 +179,43 @@ pub async fn dispatch_ready_tasks_via_runner(
             }
         }
 
-        match process_manager.spawn_workflow_runner(&planned_start.dispatch, root) {
-            Ok(_) => {
-                if planned_start.selection_source == DispatchSelectionSource::DispatchQueue {
-                    if let Err(error) = mark_dispatch_queue_entry_assigned(
-                        root,
-                        &planned_start.dispatch,
-                        planned_start.dispatch.subject_id(),
-                    ) {
-                        eprintln!(
-                            "{}: failed to mark dispatch queue entry assigned for subject {}: {}",
-                            protocol::ACTOR_DAEMON,
-                            planned_start.dispatch.subject_id(),
-                            error
-                        );
-                    }
-                }
-                started_workflows.push(DispatchWorkflowStart {
-                    dispatch: planned_start.dispatch.clone(),
-                    workflow_id: planned_start.dispatch.subject_id().to_string(),
-                    selection_source: planned_start.selection_source,
-                });
-            }
-            Err(error) => {
+        planned_starts.push(planned_start);
+    }
+
+    let mut notice_sink = CliDispatchNoticeSink;
+    Ok(execute_dispatch_plan_via_runner(
+        root,
+        process_manager,
+        &planned_starts,
+        limit,
+        &mut notice_sink,
+    ))
+}
+
+struct CliDispatchNoticeSink;
+
+impl DispatchNoticeSink for CliDispatchNoticeSink {
+    fn notice(&mut self, notice: DispatchNotice) {
+        match notice {
+            DispatchNotice::QueueAssignmentFailed { dispatch, error } => {
                 eprintln!(
-                    "{}: failed to start workflow runner for subject {}: {}",
+                    "{}: failed to mark dispatch queue entry assigned for subject {}: {}",
                     protocol::ACTOR_DAEMON,
-                    planned_start.dispatch.subject_id(),
+                    dispatch.subject_id(),
                     error
                 );
             }
+            DispatchNotice::Failed { dispatch, error } => {
+                eprintln!(
+                    "{}: failed to start workflow runner for subject {}: {}",
+                    protocol::ACTOR_DAEMON,
+                    dispatch.subject_id(),
+                    error
+                );
+            }
+            _ => {}
         }
     }
-
-    Ok(DispatchWorkflowStartSummary {
-        started: started_workflows.len(),
-        started_workflows,
-    })
 }
 
 struct PreparedReadyDispatchCandidates {
@@ -232,10 +232,10 @@ fn prepare_ready_dispatch_candidates(
     requested_at: chrono::DateTime<chrono::Utc>,
 ) -> PreparedReadyDispatchCandidates {
     let active_task_ids = active_workflow_task_ids(workflows);
-    let completed_task_ids: std::collections::HashSet<String> = workflows
+    let completed_subject_id_set: std::collections::HashSet<String> = workflows
         .iter()
         .filter(|workflow| is_terminally_completed_workflow(workflow))
-        .map(|workflow| workflow.task_id.clone())
+        .map(|workflow| workflow.subject.id().to_string())
         .collect();
     let task_lookup: std::collections::HashMap<&str, &orchestrator_core::OrchestratorTask> =
         tasks.iter().map(|task| (task.id.as_str(), task)).collect();
@@ -287,9 +287,9 @@ fn prepare_ready_dispatch_candidates(
     }
 
     for task in tasks {
-        if should_include_completed_task(
+        if should_include_completed_subject(
             task,
-            &completed_task_ids,
+            &completed_subject_id_set,
             &mut completed_subject_ids,
             &mut seen_completed_ids,
         ) {
@@ -352,13 +352,13 @@ fn is_dispatch_eligible(
     true
 }
 
-fn should_include_completed_task(
+fn should_include_completed_subject(
     task: &orchestrator_core::OrchestratorTask,
-    completed_task_ids: &std::collections::HashSet<String>,
+    completed_subject_ids: &std::collections::HashSet<String>,
     completed_targets: &mut Vec<String>,
     seen_completed_ids: &mut std::collections::HashSet<String>,
 ) -> bool {
-    if !completed_task_ids.contains(&task.id) {
+    if !completed_subject_ids.contains(&task.id) {
         return false;
     }
     if seen_completed_ids.insert(task.id.clone()) {

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -1,13 +1,11 @@
 use super::*;
+use crate::services::runtime::runtime_daemon::daemon_reconciliation::reconcile_manual_phase_timeouts;
 use crate::services::runtime::execution_fact_projection::reconcile_completed_processes;
-#[path = "daemon_default_project_tick_driver.rs"]
-mod default_project_tick_driver;
-
-use default_project_tick_driver::{
-    default_slim_project_tick_driver, DefaultProjectTickServices, DefaultSlimProjectTickDriver,
-};
 use orchestrator_core::{promote_backlog_tasks_to_ready, retry_failed_task_workflows};
-use orchestrator_daemon_runtime::{CompletedProcess, DispatchWorkflowStartSummary, ProcessManager};
+use orchestrator_daemon_runtime::{
+    default_slim_project_tick_driver, CompletedProcess, DefaultProjectTickServices,
+    DefaultSlimProjectTickDriver, DispatchNotice, DispatchWorkflowStartSummary, ProcessManager,
+};
 
 pub(crate) struct CliProjectTickServices;
 
@@ -20,6 +18,14 @@ impl DefaultProjectTickServices for CliProjectTickServices {
         completed_processes: Vec<CompletedProcess>,
     ) -> Result<(usize, usize)> {
         Ok(reconcile_completed_processes(hub, root, completed_processes).await)
+    }
+
+    async fn reconcile_manual_timeouts(
+        &mut self,
+        hub: Arc<dyn ServiceHub>,
+        root: &str,
+    ) -> Result<usize> {
+        reconcile_manual_phase_timeouts(hub, root).await
     }
 
     async fn dispatch_ready_tasks(
@@ -36,6 +42,52 @@ impl DefaultProjectTickServices for CliProjectTickServices {
                 dispatch_ready_tasks_via_runner(hub, root, process_manager, limit).await
             }
             None => run_ready_task_workflows_for_project(hub, root, limit).await,
+        }
+    }
+
+    fn dispatch_notice(&mut self, notice: DispatchNotice) {
+        match notice {
+            DispatchNotice::ScheduleDispatched {
+                schedule_id,
+                dispatch,
+            } => {
+                eprintln!(
+                    "{}: schedule '{}' fired workflow '{}'",
+                    protocol::ACTOR_DAEMON,
+                    schedule_id,
+                    dispatch.workflow_ref
+                );
+            }
+            DispatchNotice::ScheduleDispatchFailed {
+                schedule_id,
+                dispatch,
+                error,
+            } => {
+                eprintln!(
+                    "{}: schedule '{}' workflow '{}' dispatch failed: {}",
+                    protocol::ACTOR_DAEMON,
+                    schedule_id,
+                    dispatch.workflow_ref,
+                    error
+                );
+            }
+            DispatchNotice::QueueAssignmentFailed { dispatch, error } => {
+                eprintln!(
+                    "{}: failed to mark dispatch queue entry assigned for subject {}: {}",
+                    protocol::ACTOR_DAEMON,
+                    dispatch.subject_id(),
+                    error
+                );
+            }
+            DispatchNotice::Failed { dispatch, error } => {
+                eprintln!(
+                    "{}: failed to start workflow runner for subject {}: {}",
+                    protocol::ACTOR_DAEMON,
+                    dispatch.subject_id(),
+                    error
+                );
+            }
+            DispatchNotice::Started { .. } => {}
         }
     }
 }

--- a/crates/orchestrator-cli/src/services/runtime/workflow_mutation_surface/cancel_orphaned_running_workflow.rs
+++ b/crates/orchestrator-cli/src/services/runtime/workflow_mutation_surface/cancel_orphaned_running_workflow.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use orchestrator_core::{services::ServiceHub, OrchestratorWorkflow};
+use orchestrator_core::{dispatch_workflow_event, services::ServiceHub, OrchestratorWorkflow, WorkflowEvent};
 
 use crate::services::runtime::execution_fact_projection::project_terminal_workflow_result;
 
@@ -9,19 +9,32 @@ pub(crate) async fn cancel_orphaned_running_workflow(
     project_root: &str,
     workflow: &OrchestratorWorkflow,
 ) -> bool {
-    if hub.workflows().cancel(&workflow.id).await.is_err() {
-        return false;
-    }
+    let outcome = match dispatch_workflow_event(
+        hub.clone(),
+        project_root,
+        WorkflowEvent::Cancel {
+            workflow_id: workflow.id.clone(),
+        },
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(_) => return false,
+    };
+    let updated = match outcome.workflow {
+        Some(workflow) => workflow,
+        None => return false,
+    };
 
     project_terminal_workflow_result(
         hub,
         project_root,
-        workflow.subject.id(),
-        Some(workflow.task_id.as_str()),
-        workflow.workflow_ref.as_deref(),
-        Some(workflow.id.as_str()),
+        updated.subject.id(),
+        Some(updated.task_id.as_str()),
+        updated.workflow_ref.as_deref(),
+        Some(updated.id.as_str()),
         orchestrator_core::WorkflowStatus::Cancelled,
-        workflow.failure_reason.as_deref(),
+        updated.failure_reason.as_deref(),
     )
     .await;
     true

--- a/crates/orchestrator-config/src/agent_runtime_config.rs
+++ b/crates/orchestrator-config/src/agent_runtime_config.rs
@@ -306,6 +306,8 @@ pub struct PhaseManualDefinition {
     pub instructions: String,
     #[serde(default)]
     pub approval_note_required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1443,6 +1445,15 @@ fn validate_phase_definition(
                 ));
             }
 
+            if let Some(timeout_secs) = manual.timeout_secs {
+                if timeout_secs == 0 {
+                    return Err(anyhow!(
+                        "phases['{}'].manual.timeout_secs must be greater than 0",
+                        phase_id
+                    ));
+                }
+            }
+
             if definition.agent_id.is_some() {
                 return Err(anyhow!(
                     "phases['{}'] mode 'manual' must not include agent_id",
@@ -2196,6 +2207,7 @@ mod tests {
                 manual: Some(PhaseManualDefinition {
                     instructions: "Wait for approval".to_string(),
                     approval_note_required: false,
+                    timeout_secs: None,
                 }),
             },
         );

--- a/crates/orchestrator-config/src/workflow_config.rs
+++ b/crates/orchestrator-config/src/workflow_config.rs
@@ -1277,6 +1277,14 @@ pub fn validate_workflow_config(config: &WorkflowConfig) -> Result<()> {
                         phase_id
                     ));
                 }
+                if let Some(timeout_secs) = manual.timeout_secs {
+                    if timeout_secs == 0 {
+                        errors.push(format!(
+                            "phase_definitions['{}'].manual.timeout_secs must be greater than 0",
+                            phase_id
+                        ));
+                    }
+                }
                 if definition.command.is_some() {
                     errors.push(format!(
                         "phase_definitions['{}'] mode 'manual' must not include command block",
@@ -1590,6 +1598,8 @@ struct YamlManualDefinition {
     instructions: String,
     #[serde(default)]
     approval_note_required: Option<bool>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1689,6 +1699,7 @@ fn yaml_phase_to_execution_definition(
         (PhaseExecutionMode::Manual, Some(m)) => Some(PhaseManualDefinition {
             instructions: m.instructions,
             approval_note_required: m.approval_note_required.unwrap_or(false),
+            timeout_secs: m.timeout_secs,
         }),
         (PhaseExecutionMode::Manual, None) => {
             return Err(anyhow!(
@@ -3211,6 +3222,7 @@ phases:
     manual:
       instructions: "Review and approve the deployment plan"
       approval_note_required: true
+      timeout_secs: 3600
 
 workflows:
   - id: standard
@@ -3231,6 +3243,7 @@ workflows:
             "Review and approve the deployment plan"
         );
         assert!(manual.approval_note_required);
+        assert_eq!(manual.timeout_secs, Some(3600));
     }
 
     #[test]

--- a/crates/orchestrator-core/src/lib.rs
+++ b/crates/orchestrator-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod task_gate;
 pub mod types;
 pub mod workflow;
 pub mod workflow_config;
+pub mod workflow_events;
 pub mod workflow_runner_registry;
 
 pub use agent_runtime_config::{
@@ -116,6 +117,7 @@ pub use workflow::{
     REQUIREMENT_TASK_GENERATION_RUN_WORKFLOW_REF, REQUIREMENT_TASK_GENERATION_WORKFLOW_REF,
     STANDARD_WORKFLOW_REF, UI_UX_WORKFLOW_REF,
 };
+pub use workflow_events::{dispatch_workflow_event, WorkflowEvent, WorkflowEventOutcome};
 pub use workflow_config::{
     builtin_workflow_config, compile_and_write_yaml_workflows, compile_yaml_workflow_files,
     ensure_workflow_config_compiled, ensure_workflow_config_file, expand_variables,

--- a/crates/orchestrator-core/src/workflow_events.rs
+++ b/crates/orchestrator-core/src/workflow_events.rs
@@ -1,0 +1,219 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+
+use crate::{
+    load_agent_runtime_config, project_task_status, services::ServiceHub, OrchestratorTask,
+    OrchestratorWorkflow, PhaseExecutionMode, PhaseManualDefinition, TaskStatus, WorkflowStatus,
+};
+
+#[derive(Debug, Clone)]
+pub enum WorkflowEvent {
+    Pause {
+        workflow_id: String,
+    },
+    Resume {
+        workflow_id: String,
+    },
+    Cancel {
+        workflow_id: String,
+    },
+    ApproveManualPhase {
+        workflow_id: String,
+        phase_id: String,
+        note: Option<String>,
+    },
+    RejectManualPhase {
+        workflow_id: String,
+        phase_id: String,
+        note: Option<String>,
+    },
+    ResearchRequested {
+        workflow_id: String,
+        reason: String,
+    },
+    StaleReset {
+        task_id: String,
+        reason: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowEventOutcome {
+    pub workflow: Option<OrchestratorWorkflow>,
+    pub task: Option<OrchestratorTask>,
+    pub requires_continuation: bool,
+}
+
+pub async fn dispatch_workflow_event(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    event: WorkflowEvent,
+) -> Result<WorkflowEventOutcome> {
+    match event {
+        WorkflowEvent::Pause { workflow_id } => {
+            let workflow = hub.workflows().pause(&workflow_id).await?;
+            Ok(WorkflowEventOutcome {
+                workflow: Some(workflow),
+                ..WorkflowEventOutcome::default()
+            })
+        }
+        WorkflowEvent::Resume { workflow_id } => {
+            let workflow = hub.workflows().resume(&workflow_id).await?;
+            Ok(WorkflowEventOutcome {
+                workflow: Some(workflow),
+                ..WorkflowEventOutcome::default()
+            })
+        }
+        WorkflowEvent::Cancel { workflow_id } => {
+            let workflow = hub.workflows().cancel(&workflow_id).await?;
+            Ok(WorkflowEventOutcome {
+                workflow: Some(workflow),
+                ..WorkflowEventOutcome::default()
+            })
+        }
+        WorkflowEvent::ApproveManualPhase {
+            workflow_id,
+            phase_id,
+            note,
+        } => {
+            let manual = ensure_manual_phase(project_root, &phase_id)?;
+            let note = note.unwrap_or_default();
+            if manual.approval_note_required && note.trim().is_empty() {
+                return Err(anyhow!(
+                    "phase '{}' requires a non-empty approval note",
+                    phase_id
+                ));
+            }
+
+            let workflow = hub.workflows().get(&workflow_id).await?;
+            let current_phase = current_phase_id(&workflow).ok_or_else(|| {
+                anyhow!("workflow '{}' has no active phase", workflow_id)
+            })?;
+            if !current_phase.eq_ignore_ascii_case(&phase_id) {
+                return Err(anyhow!(
+                    "workflow '{}' active phase is '{}' (requested '{}')",
+                    workflow_id,
+                    current_phase,
+                    phase_id
+                ));
+            }
+
+            match workflow.status {
+                WorkflowStatus::Paused => {
+                    let _ = hub.workflows().resume(&workflow_id).await?;
+                }
+                WorkflowStatus::Running => {}
+                status => {
+                    return Err(anyhow!(
+                        "workflow '{}' is not waiting for manual approval (status: {})",
+                        workflow_id,
+                        format!("{status:?}").to_ascii_lowercase()
+                    ));
+                }
+            };
+
+            let updated = hub.workflows().complete_current_phase(&workflow_id).await?;
+            Ok(WorkflowEventOutcome {
+                requires_continuation: updated.status == WorkflowStatus::Running,
+                workflow: Some(updated),
+                ..WorkflowEventOutcome::default()
+            })
+        }
+        WorkflowEvent::RejectManualPhase {
+            workflow_id,
+            phase_id,
+            note,
+        } => {
+            let manual = ensure_manual_phase(project_root, &phase_id)?;
+            let note = note.unwrap_or_default();
+            if manual.approval_note_required && note.trim().is_empty() {
+                return Err(anyhow!(
+                    "phase '{}' requires a non-empty rejection note",
+                    phase_id
+                ));
+            }
+
+            let workflow = hub.workflows().get(&workflow_id).await?;
+            let current_phase = current_phase_id(&workflow).ok_or_else(|| {
+                anyhow!("workflow '{}' has no active phase", workflow_id)
+            })?;
+            if !current_phase.eq_ignore_ascii_case(&phase_id) {
+                return Err(anyhow!(
+                    "workflow '{}' active phase is '{}' (requested '{}')",
+                    workflow_id,
+                    current_phase,
+                    phase_id
+                ));
+            }
+
+            match workflow.status {
+                WorkflowStatus::Paused => {
+                    let _ = hub.workflows().resume(&workflow_id).await?;
+                }
+                WorkflowStatus::Running => {}
+                status => {
+                    return Err(anyhow!(
+                        "workflow '{}' is not waiting for manual approval (status: {})",
+                        workflow_id,
+                        format!("{status:?}").to_ascii_lowercase()
+                    ));
+                }
+            };
+
+            let failure_reason = if note.trim().is_empty() {
+                "manual approval rejected".to_string()
+            } else {
+                note
+            };
+            let updated = hub
+                .workflows()
+                .fail_current_phase(&workflow_id, failure_reason)
+                .await?;
+            Ok(WorkflowEventOutcome {
+                workflow: Some(updated),
+                ..WorkflowEventOutcome::default()
+            })
+        }
+        WorkflowEvent::ResearchRequested { workflow_id, reason } => {
+            let workflow = hub.workflows().request_research(&workflow_id, reason).await?;
+            Ok(WorkflowEventOutcome {
+                workflow: Some(workflow),
+                ..WorkflowEventOutcome::default()
+            })
+        }
+        WorkflowEvent::StaleReset { task_id, reason } => {
+            project_task_status(hub.clone(), &task_id, TaskStatus::Ready).await?;
+            let task = hub.tasks().get(&task_id).await.ok();
+            let _ = reason;
+            Ok(WorkflowEventOutcome {
+                task,
+                ..WorkflowEventOutcome::default()
+            })
+        }
+    }
+}
+
+fn current_phase_id(workflow: &OrchestratorWorkflow) -> Option<String> {
+    workflow.current_phase.clone().or_else(|| {
+        workflow
+            .phases
+            .get(workflow.current_phase_index)
+            .map(|phase| phase.phase_id.clone())
+    })
+}
+
+fn ensure_manual_phase(project_root: &str, phase_id: &str) -> Result<PhaseManualDefinition> {
+    let runtime = load_agent_runtime_config(Path::new(project_root))?;
+    let definition = runtime
+        .phase_execution(phase_id)
+        .ok_or_else(|| anyhow!("phase '{}' is not configured", phase_id))?;
+    if !matches!(definition.mode, PhaseExecutionMode::Manual) {
+        return Err(anyhow!("phase '{}' is not in manual mode", phase_id));
+    }
+    definition
+        .manual
+        .clone()
+        .ok_or_else(|| anyhow!("phase '{}' missing manual configuration", phase_id))
+}

--- a/crates/orchestrator-daemon-runtime/src/dispatch/completion_reconciliation_plan.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/completion_reconciliation_plan.rs
@@ -17,7 +17,7 @@ pub fn build_completion_reconciliation_plan(
         let workflow_success = completed
             .workflow_status
             .map(workflow_status_is_success)
-            .unwrap_or(completed.success);
+            .unwrap_or(false);
         let failure_reason = completion_failure_reason(&completed);
 
         match completed.workflow_status {
@@ -30,9 +30,6 @@ pub fn build_completion_reconciliation_plan(
                 plan.failed_workflow_phases = plan.failed_workflow_phases.saturating_add(1);
             }
             Some(WorkflowStatus::Pending | WorkflowStatus::Running | WorkflowStatus::Paused) => {}
-            None if completed.success => {
-                plan.executed_workflow_phases = plan.executed_workflow_phases.saturating_add(1);
-            }
             None => {
                 plan.failed_workflow_phases = plan.failed_workflow_phases.saturating_add(1);
             }
@@ -80,9 +77,8 @@ fn completion_failure_reason(completed: &CompletedProcess) -> Option<String> {
             "workflow runner cancelled: {}",
             completion_reason(completed)
         )),
-        None if completed.success => None,
         None => Some(format!(
-            "workflow runner failed: {}",
+            "workflow runner exited without workflow status: {}",
             completion_reason(completed)
         )),
     }
@@ -231,5 +227,29 @@ mod tests {
             plan.execution_facts[0].failure_reason.as_deref(),
             Some("workflow runner cancelled: operator cancelled the workflow")
         );
+    }
+
+    #[test]
+    fn missing_workflow_status_is_not_inferred_from_exit_code() {
+        let plan = build_completion_reconciliation_plan(vec![CompletedProcess {
+            subject_id: "TASK-505".to_string(),
+            task_id: Some("TASK-505".to_string()),
+            workflow_id: None,
+            workflow_ref: Some("standard".to_string()),
+            workflow_status: None,
+            schedule_id: None,
+            exit_code: Some(0),
+            success: true,
+            failure_reason: None,
+            events: Vec::new(),
+        }]);
+
+        assert_eq!(plan.executed_workflow_phases, 0);
+        assert_eq!(plan.failed_workflow_phases, 1);
+        assert!(!plan.execution_facts[0].success);
+        assert!(plan.execution_facts[0]
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("without workflow status")));
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_execution.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_execution.rs
@@ -1,0 +1,63 @@
+use crate::{
+    mark_dispatch_queue_entry_assigned, DispatchNotice, DispatchNoticeSink, DispatchSelectionSource,
+    DispatchWorkflowStart, DispatchWorkflowStartSummary, PlannedDispatchStart, ProcessManager,
+};
+
+pub fn execute_dispatch_plan_via_runner<S>(
+    project_root: &str,
+    process_manager: &mut ProcessManager,
+    starts: &[PlannedDispatchStart],
+    limit: usize,
+    notice_sink: &mut S,
+) -> DispatchWorkflowStartSummary
+where
+    S: DispatchNoticeSink,
+{
+    if limit == 0 {
+        return DispatchWorkflowStartSummary::default();
+    }
+
+    let mut started_workflows = Vec::new();
+    for planned_start in starts {
+        if started_workflows.len() >= limit {
+            break;
+        }
+
+        match process_manager.spawn_workflow_runner(&planned_start.dispatch, project_root) {
+            Ok(()) => {
+                if planned_start.selection_source == DispatchSelectionSource::DispatchQueue {
+                    if let Err(error) = mark_dispatch_queue_entry_assigned(
+                        project_root,
+                        &planned_start.dispatch,
+                        None,
+                    ) {
+                        notice_sink.notice(DispatchNotice::QueueAssignmentFailed {
+                            dispatch: planned_start.dispatch.clone(),
+                            error: error.to_string(),
+                        });
+                    }
+                }
+                notice_sink.notice(DispatchNotice::Started {
+                    dispatch: planned_start.dispatch.clone(),
+                    selection_source: planned_start.selection_source,
+                });
+                started_workflows.push(DispatchWorkflowStart {
+                    dispatch: planned_start.dispatch.clone(),
+                    workflow_id: None,
+                    selection_source: planned_start.selection_source,
+                });
+            }
+            Err(error) => {
+                notice_sink.notice(DispatchNotice::Failed {
+                    dispatch: planned_start.dispatch.clone(),
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    DispatchWorkflowStartSummary {
+        started: started_workflows.len(),
+        started_workflows,
+    }
+}

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_notice.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_notice.rs
@@ -1,0 +1,39 @@
+use protocol::SubjectDispatch;
+
+use crate::DispatchSelectionSource;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DispatchNotice {
+    Started {
+        dispatch: SubjectDispatch,
+        selection_source: DispatchSelectionSource,
+    },
+    Failed {
+        dispatch: SubjectDispatch,
+        error: String,
+    },
+    QueueAssignmentFailed {
+        dispatch: SubjectDispatch,
+        error: String,
+    },
+    ScheduleDispatched {
+        schedule_id: String,
+        dispatch: SubjectDispatch,
+    },
+    ScheduleDispatchFailed {
+        schedule_id: String,
+        dispatch: SubjectDispatch,
+        error: String,
+    },
+}
+
+pub trait DispatchNoticeSink {
+    fn notice(&mut self, notice: DispatchNotice);
+}
+
+#[derive(Default)]
+pub struct NoopDispatchNoticeSink;
+
+impl DispatchNoticeSink for NoopDispatchNoticeSink {
+    fn notice(&mut self, _notice: DispatchNotice) {}
+}

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_workflow_start.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_workflow_start.rs
@@ -5,12 +5,17 @@ use crate::{DispatchSelectionSource, SubjectDispatch};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DispatchWorkflowStart {
     pub dispatch: SubjectDispatch,
-    pub workflow_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
     pub selection_source: DispatchSelectionSource,
 }
 
 impl DispatchWorkflowStart {
     pub fn task_id(&self) -> Option<&str> {
         self.dispatch.task_id()
+    }
+
+    pub fn subject_id(&self) -> &str {
+        self.dispatch.subject_id()
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
@@ -3,6 +3,8 @@ mod completed_process;
 mod completion_reconciliation_plan;
 mod dispatch_selection_source;
 mod dispatch_support;
+mod dispatch_execution;
+mod dispatch_notice;
 mod dispatch_workflow_start;
 mod dispatch_workflow_start_summary;
 mod process_manager;
@@ -14,6 +16,8 @@ pub use completion_reconciliation_plan::{
     build_completion_reconciliation_plan, CompletionReconciliationPlan,
 };
 pub use dispatch_selection_source::DispatchSelectionSource;
+pub use dispatch_execution::execute_dispatch_plan_via_runner;
+pub use dispatch_notice::{DispatchNotice, DispatchNoticeSink, NoopDispatchNoticeSink};
 pub use dispatch_support::{
     active_workflow_subject_ids, active_workflow_task_ids, is_terminally_completed_workflow,
     ready_dispatch_limit, ready_dispatch_limit_for_options, workflow_current_phase_id,

--- a/crates/orchestrator-daemon-runtime/src/lib.rs
+++ b/crates/orchestrator-daemon-runtime/src/lib.rs
@@ -10,11 +10,12 @@ pub use daemon::{
 };
 pub use dispatch::{
     active_workflow_subject_ids, active_workflow_task_ids, build_completion_reconciliation_plan,
-    build_runner_command_from_dispatch, is_terminally_completed_workflow, plan_ready_dispatch,
-    ready_dispatch_limit, ready_dispatch_limit_for_options, workflow_current_phase_id,
-    CompletedProcess, CompletionReconciliationPlan, DispatchCandidate, DispatchSelectionSource,
-    DispatchWorkflowStart, DispatchWorkflowStartSummary, PlannedDispatchStart, ProcessManager,
-    ReadyDispatchPlan,
+    build_runner_command_from_dispatch, execute_dispatch_plan_via_runner,
+    is_terminally_completed_workflow, plan_ready_dispatch, ready_dispatch_limit,
+    ready_dispatch_limit_for_options, workflow_current_phase_id, CompletedProcess,
+    CompletionReconciliationPlan, DispatchCandidate, DispatchNotice, DispatchNoticeSink,
+    DispatchSelectionSource, DispatchWorkflowStart, DispatchWorkflowStartSummary,
+    NoopDispatchNoticeSink, PlannedDispatchStart, ProcessManager, ReadyDispatchPlan,
 };
 pub use protocol::{RunnerEvent, SubjectDispatch, SubjectExecutionFact};
 pub use queue::{
@@ -26,8 +27,9 @@ pub use queue::{
 };
 pub use schedule::{ScheduleDispatch, ScheduleDispatchOutcome};
 pub use tick::{
-    run_project_tick, run_project_tick_at, ProjectTickContext, ProjectTickExecutionOutcome,
-    ProjectTickHooks, ProjectTickPlan, ProjectTickPreparation, ProjectTickRunMode,
-    ProjectTickSnapshot, ProjectTickSummary, ProjectTickSummaryInput, ProjectTickTime,
-    TickSummaryBuilder,
+    default_slim_project_tick_driver, run_project_tick, run_project_tick_at,
+    DefaultProjectTickServices, DefaultSlimProjectTickDriver, ProjectTickContext,
+    ProjectTickExecutionOutcome, ProjectTickHooks, ProjectTickPlan, ProjectTickPreparation,
+    ProjectTickRunMode, ProjectTickSnapshot, ProjectTickSummary, ProjectTickSummaryInput,
+    ProjectTickTime, TickSummaryBuilder,
 };

--- a/crates/orchestrator-daemon-runtime/src/queue/dispatch_queue_state.rs
+++ b/crates/orchestrator-daemon-runtime/src/queue/dispatch_queue_state.rs
@@ -19,6 +19,8 @@ impl Default for DispatchQueueEntryStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DispatchQueueEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
     pub task_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dispatch: Option<SubjectDispatch>,
@@ -41,6 +43,7 @@ pub struct DispatchQueueState {
 impl DispatchQueueEntry {
     pub fn from_dispatch(dispatch: SubjectDispatch) -> Self {
         Self {
+            subject_id: Some(dispatch.subject_id().to_string()),
             task_id: dispatch.task_id().unwrap_or_default().to_string(),
             dispatch: Some(dispatch),
             status: DispatchQueueEntryStatus::Pending,
@@ -51,10 +54,18 @@ impl DispatchQueueEntry {
     }
 
     pub fn subject_id(&self) -> &str {
-        self.dispatch
-            .as_ref()
-            .map(|dispatch| dispatch.subject_id())
-            .unwrap_or(self.task_id.as_str())
+        if let Some(subject_id) = self
+            .subject_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return subject_id;
+        }
+        if let Some(dispatch) = &self.dispatch {
+            return dispatch.subject_id();
+        }
+        self.task_id.as_str()
     }
 
     pub fn task_id(&self) -> Option<&str> {

--- a/crates/orchestrator-daemon-runtime/src/queue/dispatch_queue_store.rs
+++ b/crates/orchestrator-daemon-runtime/src/queue/dispatch_queue_store.rs
@@ -77,7 +77,7 @@ pub fn save_dispatch_queue_state(project_root: &str, state: &DispatchQueueState)
 pub fn mark_dispatch_queue_entry_assigned(
     project_root: &str,
     dispatch: &SubjectDispatch,
-    workflow_id: &str,
+    workflow_id: Option<&str>,
 ) -> Result<bool> {
     let Some(mut state) = load_dispatch_queue_state(project_root)? else {
         return Ok(false);
@@ -102,7 +102,9 @@ pub fn mark_dispatch_queue_entry_assigned(
             continue;
         }
         entry.status = DispatchQueueEntryStatus::Assigned;
-        entry.workflow_id = Some(workflow_id.to_string());
+        if let Some(workflow_id) = workflow_id {
+            entry.workflow_id = Some(workflow_id.to_string());
+        }
         entry.assigned_at = Some(Utc::now().to_rfc3339());
         updated = true;
         break;

--- a/crates/orchestrator-daemon-runtime/src/queue/queue_service.rs
+++ b/crates/orchestrator-daemon-runtime/src/queue/queue_service.rs
@@ -63,11 +63,14 @@ pub fn enqueue_subject_dispatch(
     if state.entries.iter().any(|entry| {
         entry.subject_id() == subject_id
             && entry.status != DispatchQueueEntryStatus::Unknown
-            && entry
-                .dispatch
-                .as_ref()
-                .map(|existing| existing.workflow_ref == dispatch.workflow_ref)
-                .unwrap_or_else(|| entry.task_id() == dispatch.task_id())
+            && if let Some(existing) = entry.dispatch.as_ref() {
+                existing.workflow_ref == dispatch.workflow_ref
+            } else {
+                match (entry.task_id(), dispatch.task_id()) {
+                    (Some(existing), Some(incoming)) => existing == incoming,
+                    _ => false,
+                }
+            }
     }) {
         return Ok(QueueEnqueueResult {
             enqueued: false,

--- a/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
@@ -6,12 +6,13 @@ use orchestrator_core::{
     project_schedule_dispatch_attempt, services::ServiceHub, DaemonStatus, DaemonTickMetrics,
     FileServiceHub,
 };
-use orchestrator_daemon_runtime::{
-    CompletedProcess, DaemonRuntimeOptions, DispatchWorkflowStartSummary, ProcessManager,
-    ProjectTickHooks, ProjectTickSnapshot, ProjectTickSummary, ProjectTickSummaryInput,
-    ScheduleDispatch, SubjectDispatch, TickSummaryBuilder,
-};
 use serde_json::Value;
+
+use crate::{
+    CompletedProcess, DaemonRuntimeOptions, DispatchNotice, DispatchWorkflowStartSummary,
+    ProcessManager, ProjectTickHooks, ProjectTickSnapshot, ProjectTickSummary,
+    ProjectTickSummaryInput, ScheduleDispatch, TickSummaryBuilder,
+};
 
 #[async_trait::async_trait(?Send)]
 pub trait DefaultProjectTickServices {
@@ -43,6 +44,14 @@ pub trait DefaultProjectTickServices {
         completed_processes: Vec<CompletedProcess>,
     ) -> Result<(usize, usize)>;
 
+    async fn reconcile_manual_timeouts(
+        &mut self,
+        _hub: Arc<dyn ServiceHub>,
+        _root: &str,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
         hub: Arc<dyn ServiceHub>,
@@ -66,6 +75,18 @@ pub trait DefaultProjectTickServices {
         let metrics = DaemonTickMetrics::collect(hub, args.stale_threshold_hours).await?;
         TickSummaryBuilder::build(args, input, metrics)
     }
+
+    fn record_schedule_dispatch_attempt(
+        &mut self,
+        project_root: &str,
+        schedule_id: &str,
+        run_at: DateTime<Utc>,
+        status: &str,
+    ) {
+        project_schedule_dispatch_attempt(project_root, schedule_id, run_at, status);
+    }
+
+    fn dispatch_notice(&mut self, _notice: DispatchNotice) {}
 }
 
 pub type DefaultSlimProjectTickDriver<'a, S> = DefaultSlimProjectTickHooks<'a, S>;
@@ -94,23 +115,6 @@ impl<S> DefaultSlimProjectTickHooks<'_, S> {
     }
 }
 
-fn spawn_schedule_pipeline(
-    process_manager: &mut ProcessManager,
-    project_root: &str,
-    schedule_id: &str,
-    dispatch: &SubjectDispatch,
-) -> Result<()> {
-    process_manager.spawn_workflow_runner(dispatch, project_root)?;
-
-    eprintln!(
-        "{}: schedule '{}' fired workflow '{}'",
-        protocol::ACTOR_DAEMON,
-        schedule_id,
-        dispatch.workflow_ref
-    );
-    Ok(())
-}
-
 #[async_trait::async_trait(?Send)]
 impl<S> ProjectTickHooks for DefaultSlimProjectTickHooks<'_, S>
 where
@@ -119,10 +123,34 @@ where
     fn process_due_schedules(&mut self, root: &str, now: DateTime<Utc>) {
         let outcomes =
             ScheduleDispatch::process_due_schedules(root, now, |schedule_id, dispatch| {
-                spawn_schedule_pipeline(self.process_manager, root, schedule_id, dispatch)
+                match self
+                    .process_manager
+                    .spawn_workflow_runner(dispatch, root)
+                {
+                    Ok(()) => {
+                        self.services.dispatch_notice(DispatchNotice::ScheduleDispatched {
+                            schedule_id: schedule_id.to_string(),
+                            dispatch: dispatch.clone(),
+                        });
+                        Ok(())
+                    }
+                    Err(error) => {
+                        self.services.dispatch_notice(DispatchNotice::ScheduleDispatchFailed {
+                            schedule_id: schedule_id.to_string(),
+                            dispatch: dispatch.clone(),
+                            error: error.to_string(),
+                        });
+                        Err(error)
+                    }
+                }
             });
         for outcome in outcomes {
-            project_schedule_dispatch_attempt(root, &outcome.schedule_id, now, &outcome.status);
+            self.services.record_schedule_dispatch_attempt(
+                root,
+                &outcome.schedule_id,
+                now,
+                &outcome.status,
+            );
         }
     }
 
@@ -136,6 +164,11 @@ where
         self.services
             .reconcile_completed_processes(hub, root, completed_processes)
             .await
+    }
+
+    async fn reconcile_manual_timeouts(&mut self, root: &str) -> Result<usize> {
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        self.services.reconcile_manual_timeouts(hub, root).await
     }
 
     async fn dispatch_ready_tasks(

--- a/crates/orchestrator-daemon-runtime/src/tick/mod.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/mod.rs
@@ -23,3 +23,7 @@ pub use project_tick_summary_input::ProjectTickSummaryInput;
 pub use project_tick_time::ProjectTickTime;
 pub use run_project_tick::{run_project_tick, run_project_tick_at};
 pub use tick_summary_builder::TickSummaryBuilder;
+mod default_project_tick_driver;
+pub use default_project_tick_driver::{
+    default_slim_project_tick_driver, DefaultProjectTickServices, DefaultSlimProjectTickDriver,
+};

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
@@ -15,6 +15,10 @@ pub trait ProjectTickHooks {
 
     async fn reconcile_completed_processes(&mut self, root: &str) -> Result<(usize, usize)>;
 
+    async fn reconcile_manual_timeouts(&mut self, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
         root: &str,

--- a/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
@@ -51,6 +51,7 @@ where
     let snapshot = hooks.capture_snapshot(root).await?;
     let preparation = mode.build_preparation(&context, args, now, pool_draining, &snapshot);
     let mut execution_outcome = ProjectTickExecutionOutcome::default();
+    let _ = hooks.reconcile_manual_timeouts(root).await?;
     let (executed_workflow_phases, failed_workflow_phases) =
         hooks.reconcile_completed_processes(root).await?;
     execution_outcome.executed_workflow_phases = executed_workflow_phases;

--- a/crates/orchestrator-web-api/src/services/web_api_service/workflows_handlers.rs
+++ b/crates/orchestrator-web-api/src/services/web_api_service/workflows_handlers.rs
@@ -1,8 +1,8 @@
 use orchestrator_core::{
-    workflow_ref_for_task, FileServiceHub, ServiceHub, REQUIREMENT_TASK_GENERATION_WORKFLOW_REF,
-    STANDARD_WORKFLOW_REF,
+    dispatch_workflow_event, workflow_ref_for_task, FileServiceHub, ServiceHub, WorkflowEvent,
+    REQUIREMENT_TASK_GENERATION_WORKFLOW_REF, STANDARD_WORKFLOW_REF,
 };
-use protocol::orchestrator::WorkflowSubject;
+use protocol::orchestrator::{WorkflowRunInput, WorkflowSubject};
 use serde_json::{json, Value};
 
 use super::{parsing::parse_json_body, requests::WorkflowRunRequest, WebApiError, WebApiService};
@@ -66,6 +66,72 @@ async fn resolve_workflow_run_dispatch(
             2,
         )),
     }
+}
+
+async fn resolve_workflow_run_dispatch_from_input(
+    hub: &dyn ServiceHub,
+    project_root: &str,
+    input: WorkflowRunInput,
+) -> Result<protocol::SubjectDispatch, WebApiError> {
+    let WorkflowRunInput {
+        subject,
+        workflow_ref,
+        input,
+        ..
+    } = input;
+    match subject {
+        WorkflowSubject::Task { id } => {
+            let task = hub.tasks().get(&id).await.map_err(WebApiError::from)?;
+            Ok(protocol::SubjectDispatch::for_task_with_metadata(
+                task.id.clone(),
+                workflow_ref.unwrap_or_else(|| workflow_ref_for_task(&task)),
+                "web-api-run",
+                chrono::Utc::now(),
+            )
+            .with_input(input))
+        }
+        WorkflowSubject::Requirement { id } => {
+            hub.planning()
+                .get_requirement(&id)
+                .await
+                .map_err(WebApiError::from)?;
+            let workflow_ref = match workflow_ref {
+                Some(workflow_ref) => workflow_ref,
+                None => resolve_requirement_workflow_ref(project_root)
+                    .map_err(|message| WebApiError::new("invalid_input", message, 2))?,
+            };
+            Ok(protocol::SubjectDispatch::for_requirement(
+                id,
+                workflow_ref,
+                "web-api-run",
+            )
+            .with_input(input))
+        }
+        WorkflowSubject::Custom { title, description } => {
+            Ok(protocol::SubjectDispatch::for_custom(
+                title,
+                description,
+                workflow_ref.unwrap_or_else(|| STANDARD_WORKFLOW_REF.to_string()),
+                input,
+                "web-api-run",
+            ))
+        }
+    }
+}
+
+async fn resolve_workflow_run_dispatch_from_body(
+    hub: &dyn ServiceHub,
+    project_root: &str,
+    body: Value,
+) -> Result<protocol::SubjectDispatch, WebApiError> {
+    if let Ok(dispatch) = serde_json::from_value::<protocol::SubjectDispatch>(body.clone()) {
+        return Ok(dispatch);
+    }
+    if let Ok(input) = serde_json::from_value::<WorkflowRunInput>(body.clone()) {
+        return resolve_workflow_run_dispatch_from_input(hub, project_root, input).await;
+    }
+    let request: WorkflowRunRequest = parse_json_body(body)?;
+    resolve_workflow_run_dispatch(hub, project_root, request).await
 }
 
 fn resolve_requirement_workflow_ref(project_root: &str) -> Result<String, String> {
@@ -135,11 +201,10 @@ impl WebApiService {
     }
 
     pub async fn workflows_run(&self, body: Value) -> Result<Value, WebApiError> {
-        let request: WorkflowRunRequest = parse_json_body(body)?;
-        let dispatch = resolve_workflow_run_dispatch(
+        let dispatch = resolve_workflow_run_dispatch_from_body(
             self.context.hub.as_ref(),
             &self.context.project_root,
-            request,
+            body,
         )
         .await?;
         let workflow = self
@@ -164,7 +229,17 @@ impl WebApiService {
     }
 
     pub async fn workflows_resume(&self, id: &str) -> Result<Value, WebApiError> {
-        let workflow = self.context.hub.workflows().resume(id).await?;
+        let outcome = dispatch_workflow_event(
+            self.context.hub.clone(),
+            &self.context.project_root,
+            WorkflowEvent::Resume {
+                workflow_id: id.to_string(),
+            },
+        )
+        .await?;
+        let workflow = outcome
+            .workflow
+            .ok_or_else(|| WebApiError::new("not_found", "workflow not found".to_string(), 3))?;
         self.publish_event(
             "workflow-resume",
             json!({ "workflow_id": workflow.id, "status": workflow.status }),
@@ -173,7 +248,17 @@ impl WebApiService {
     }
 
     pub async fn workflows_pause(&self, id: &str) -> Result<Value, WebApiError> {
-        let workflow = self.context.hub.workflows().pause(id).await?;
+        let outcome = dispatch_workflow_event(
+            self.context.hub.clone(),
+            &self.context.project_root,
+            WorkflowEvent::Pause {
+                workflow_id: id.to_string(),
+            },
+        )
+        .await?;
+        let workflow = outcome
+            .workflow
+            .ok_or_else(|| WebApiError::new("not_found", "workflow not found".to_string(), 3))?;
         self.publish_event(
             "workflow-pause",
             json!({ "workflow_id": workflow.id, "status": workflow.status }),
@@ -182,7 +267,17 @@ impl WebApiService {
     }
 
     pub async fn workflows_cancel(&self, id: &str) -> Result<Value, WebApiError> {
-        let workflow = self.context.hub.workflows().cancel(id).await?;
+        let outcome = dispatch_workflow_event(
+            self.context.hub.clone(),
+            &self.context.project_root,
+            WorkflowEvent::Cancel {
+                workflow_id: id.to_string(),
+            },
+        )
+        .await?;
+        let workflow = outcome
+            .workflow
+            .ok_or_else(|| WebApiError::new("not_found", "workflow not found".to_string(), 3))?;
         self.publish_event(
             "workflow-cancel",
             json!({ "workflow_id": workflow.id, "status": workflow.status }),
@@ -224,6 +319,30 @@ mod tests {
         .expect("dispatch should resolve");
 
         assert_eq!(dispatch.input, Some(json!({"scope":"req-39"})));
+    }
+
+    #[tokio::test]
+    async fn resolve_workflow_run_dispatch_from_body_accepts_subject_dispatch() {
+        let hub = InMemoryServiceHub::new();
+        let dispatch = protocol::SubjectDispatch::for_custom(
+            "custom",
+            "custom input",
+            "ops",
+            Some(json!({"scope":"req-39"})),
+            "web-api-run",
+        );
+
+        let resolved = resolve_workflow_run_dispatch_from_body(
+            &hub,
+            "/tmp/unused",
+            serde_json::to_value(dispatch.clone()).expect("dispatch should serialize"),
+        )
+        .await
+        .expect("dispatch should resolve");
+
+        assert_eq!(resolved.subject_id(), "custom");
+        assert_eq!(resolved.workflow_ref, "ops");
+        assert_eq!(resolved.input, Some(json!({"scope":"req-39"})));
     }
 
     #[tokio::test]

--- a/crates/workflow-runner/src/main.rs
+++ b/crates/workflow-runner/src/main.rs
@@ -135,18 +135,27 @@ async fn run_execute(args: WorkflowExecuteArgs) -> anyhow::Result<u8> {
         Err(_) => 1,
     };
 
-    let completion = RunnerEvent {
-        event: "runner_complete",
-        task_id: subject_id,
-        workflow_id: result.as_ref().ok().map(|value| value.workflow_id.clone()),
-        workflow_ref: result.as_ref().ok().and_then(|value| {
+    let workflow_ref = match &result {
+        Ok(value) => {
             if value.workflow_ref.trim().is_empty() {
                 args.workflow_ref.clone()
             } else {
                 Some(value.workflow_ref.clone())
             }
-        }),
-        workflow_status: result.as_ref().ok().map(|value| value.workflow_status),
+        }
+        Err(_) => args.workflow_ref.clone(),
+    };
+    let workflow_status = match &result {
+        Ok(value) => Some(value.workflow_status),
+        Err(_) => Some(WorkflowStatus::Failed),
+    };
+
+    let completion = RunnerEvent {
+        event: "runner_complete",
+        task_id: subject_id,
+        workflow_id: result.as_ref().ok().map(|value| value.workflow_id.clone()),
+        workflow_ref,
+        workflow_status,
         exit_code: Some(exit_code),
     };
     eprintln!("{}", serde_json::to_string(&completion).unwrap_or_default());

--- a/crates/workflow-runner/src/workflow_execute.rs
+++ b/crates/workflow-runner/src/workflow_execute.rs
@@ -8,12 +8,13 @@ use tokio::process::Command;
 
 use orchestrator_config::workflow_config::MergeStrategy;
 use orchestrator_core::{
-    ensure_workflow_config_compiled, load_workflow_config, project_requirement_workflow_status,
+    dispatch_workflow_event, ensure_workflow_config_compiled, load_workflow_config,
+    project_requirement_workflow_status,
     providers::{BuiltinGitProvider, GitProvider},
     register_workflow_runner_pid,
     services::ServiceHub,
     unregister_workflow_runner_pid, FileServiceHub, OrchestratorTask, OrchestratorWorkflow,
-    PhaseDecisionVerdict, WorkflowRunInput, WorkflowStatus, WorkflowSubject,
+    PhaseDecisionVerdict, WorkflowEvent, WorkflowRunInput, WorkflowStatus, WorkflowSubject,
 };
 
 use crate::executor::{
@@ -505,10 +506,18 @@ pub async fn execute_workflow(params: WorkflowExecuteParams) -> Result<WorkflowE
                         continue;
                     }
                     PhaseExecutionOutcome::NeedsResearch { reason } => {
-                        workflow = hub
-                            .workflows()
-                            .request_research(&workflow.id, reason.clone())
-                            .await?;
+                        let outcome = dispatch_workflow_event(
+                            hub.clone(),
+                            &params.project_root,
+                            WorkflowEvent::ResearchRequested {
+                                workflow_id: workflow.id.clone(),
+                                reason: reason.clone(),
+                            },
+                        )
+                        .await?;
+                        workflow = outcome.workflow.ok_or_else(|| {
+                            anyhow!("workflow '{}' not found for research request", workflow.id)
+                        })?;
                         reported_workflow_status = workflow.status;
                         phases_to_run = workflow
                             .phases
@@ -532,7 +541,17 @@ pub async fn execute_workflow(params: WorkflowExecuteParams) -> Result<WorkflowE
                         continue;
                     }
                     PhaseExecutionOutcome::ManualPending { .. } => {
-                        workflow = hub.workflows().pause(&workflow.id).await?;
+                        let outcome = dispatch_workflow_event(
+                            hub.clone(),
+                            &params.project_root,
+                            WorkflowEvent::Pause {
+                                workflow_id: workflow.id.clone(),
+                            },
+                        )
+                        .await?;
+                        workflow = outcome.workflow.ok_or_else(|| {
+                            anyhow!("workflow '{}' not found for manual pause", workflow.id)
+                        })?;
                         reported_workflow_status = workflow.status;
                         emit(PhaseEvent::Completed {
                             phase_id: &phase_id,
@@ -968,6 +987,7 @@ mod requirement_workflow_tests {
         definition.manual = Some(PhaseManualDefinition {
             instructions: "Wait for approval".to_string(),
             approval_note_required: false,
+            timeout_secs: None,
         });
         runtime.phases.insert(current_phase.clone(), definition);
         write_agent_runtime_config(temp.path(), &runtime).expect("runtime config should write");


### PR DESCRIPTION
## Summary\n- unify SubjectDispatch across dispatch queue/daemon paths and web API ingress\n- extract default project tick driver + dispatch notice/execution ports into orchestrator-daemon-runtime\n- add workflow event dispatcher + manual reject/timeout handling\n- make workflow-runner emit workflow_status on error to avoid exit-code inference\n\n## Linked tasks\n- TASK-299\n- TASK-300\n- TASK-319\n- TASK-321\n- TASK-322\n- TASK-339\n\n## Tests\n- cargo test -p orchestrator-config yaml_parses_manual_phase\n- cargo test -p orchestrator-cli approve_manual_phase_continues_non_terminal_workflow\n- cargo test -p orchestrator-cli reject_manual_phase_fails_workflow\n- cargo test -p orchestrator-cli reconcile_manual_phase_timeouts_fails_workflow\n- cargo test -p orchestrator-daemon-runtime completion_reconciliation_plan::tests::missing_workflow_status_is_not_inferred_from_exit_code\n- cargo test -p orchestrator-cli run_ready_dispatches_custom_subjects_from_queue\n- cargo test -p orchestrator-web-api resolve_workflow_run_dispatch_from_body_accepts_subject_dispatch\n- cargo test -p workflow-runner runner_event_serialization\n