### PR TITLE
TASK-736: Fix persistent agent-runner process leak (zombie reaping)

### DIFF
--- a/crates/llm-cli-wrapper/src/session/claude/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/claude/transport.rs
@@ -177,14 +177,14 @@ async fn wait_for_claude_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = &mut timeout_sleep => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!(
                         "claude session timed out after {} seconds",
                         secs
                     )))
                 }
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed("claude session cancelled".to_string()))
                 }
             }
@@ -193,7 +193,7 @@ async fn wait_for_claude_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed("claude session cancelled".to_string()))
                 }
             }

--- a/crates/llm-cli-wrapper/src/session/codex/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/codex/transport.rs
@@ -172,14 +172,14 @@ async fn wait_for_codex_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = &mut timeout_sleep => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!(
                         "codex session timed out after {} seconds",
                         secs
                     )))
                 }
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed("codex session cancelled".to_string()))
                 }
             }
@@ -188,7 +188,7 @@ async fn wait_for_codex_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed("codex session cancelled".to_string()))
                 }
             }

--- a/crates/llm-cli-wrapper/src/session/gemini/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/gemini/transport.rs
@@ -211,14 +211,14 @@ async fn wait_for_gemini_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = &mut timeout_sleep => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!(
                         "gemini session timed out after {} seconds",
                         secs
                     )))
                 }
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed("gemini session cancelled".to_string()))
                 }
             }
@@ -227,7 +227,7 @@ async fn wait_for_gemini_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed("gemini session cancelled".to_string()))
                 }
             }

--- a/crates/llm-cli-wrapper/src/session/mod.rs
+++ b/crates/llm-cli-wrapper/src/session/mod.rs
@@ -14,6 +14,18 @@ pub mod session_run;
 pub mod session_stability;
 pub mod subprocess_session_backend;
 
+pub(crate) async fn kill_and_reap_child(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        let _ = std::process::Command::new("kill")
+            .args(["-9", &format!("-{}", pid)])
+            .output();
+    }
+    #[cfg(not(unix))]
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
 pub use claude::ClaudeSessionBackend;
 pub use codex::CodexSessionBackend;
 pub use gemini::GeminiSessionBackend;

--- a/crates/llm-cli-wrapper/src/session/oai_runner/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/oai_runner/transport.rs
@@ -166,11 +166,11 @@ async fn wait_for_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = &mut timeout_sleep => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!("{label} session timed out after {secs} seconds")))
                 }
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!("{label} session cancelled")))
                 }
             }
@@ -179,7 +179,7 @@ async fn wait_for_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!("{label} session cancelled")))
                 }
             }

--- a/crates/llm-cli-wrapper/src/session/opencode/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/opencode/transport.rs
@@ -162,11 +162,11 @@ async fn wait_for_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = &mut timeout_sleep => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!("{label} session timed out after {secs} seconds")))
                 }
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!("{label} session cancelled")))
                 }
             }
@@ -175,7 +175,7 @@ async fn wait_for_child(
             tokio::select! {
                 status = child.wait() => Ok(status?.code()),
                 _ = cancel_rx => {
-                    child.kill().await?;
+                    crate::session::kill_and_reap_child(child).await;
                     Err(Error::ExecutionFailed(format!("{label} session cancelled")))
                 }
             }


### PR DESCRIPTION
## Summary

- Adds `kill_and_reap_child()` helper in `crates/agent-runner/src/runner/session/mod.rs` that sends SIGKILL to the entire process group (covering grandchildren) and then calls `child.wait()` to reap the zombie
- Replaces all 15 bare `child.kill()` call sites across all 5 session transport backends (claude, codex, gemini, oai_runner, opencode) with `kill_and_reap_child()`
- Process group kill (`kill -9 -<pgid>`) is used on Unix; all 5 backends already call `command.process_group(0)` at spawn time, validating this approach
- Non-unix fallback handled via `#[cfg(not(unix))]` path in the helper

## Root Cause

Bare `child.kill()` sends SIGKILL but does not reap the child process. Without `child.wait()`, the kernel keeps the zombie entry in the process table until the parent exits. With long-running daemon phases, this caused hundreds of zombie agent-runner processes to accumulate (observed counts: 30, 92, 99, 177, 222, 225, 264).

## Test Plan

- [x] `cargo test --workspace` — 99 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — lint clean
- [x] Code review: no blocking issues; implementation correct and scoped to root cause

## Follow-up

Pre-existing `kill`-without-`wait` patterns in `workflow-runner-v2/phase_command.rs:400` and `oai-runner/tools/bash.rs:62` are out of scope for this fix and should be tracked separately.

Closes TASK-736