### PR TITLE
TASK-776: Fix regression: ops_doctor, ops_queue, ops_workflow tests failing again after TASK-750

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_doctor.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_doctor.rs
@@ -100,11 +100,15 @@ fn failed_action(id: &str, details: String) -> DoctorFixAction {
 
 #[cfg(test)]
 mod tests {
+    use protocol::test_utils::EnvVarGuard;
+
     use super::*;
 
     #[test]
     fn doctor_fix_creates_default_daemon_config_when_missing() {
         let temp = tempfile::tempdir().expect("tempdir should be created");
+        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let report = DoctorReport::run_for_project(temp.path());
         let actions = apply_doctor_fixes(temp.path().to_string_lossy().as_ref(), &report);
         assert!(actions.iter().any(|action| action.id == "create_default_daemon_config" && action.status == "applied"));

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -145,7 +145,7 @@ mod tests {
     use orchestrator_core::{
         builtin_agent_runtime_config, builtin_workflow_config, write_agent_runtime_config, write_workflow_config,
         InMemoryServiceHub, RequirementItem, RequirementLinks, RequirementPriority, RequirementStatus,
-        WorkflowDefinition, REQUIREMENT_TASK_GENERATION_WORKFLOW_REF,
+        REQUIREMENT_TASK_GENERATION_WORKFLOW_REF,
     };
     use serde_json::json;
 
@@ -154,15 +154,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_enqueue_dispatch_uses_requirement_workflow_default() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let mut workflow_config = builtin_workflow_config();
-        workflow_config.workflows.push(WorkflowDefinition {
-            id: REQUIREMENT_TASK_GENERATION_WORKFLOW_REF.to_string(),
-            name: "Requirement Task Generation".to_string(),
-            description: "test workflow".to_string(),
-            phases: vec!["requirements".to_string().into()],
-            post_success: None,
-            variables: Vec::new(),
-        });
+        let workflow_config = builtin_workflow_config();
         write_workflow_config(temp.path(), &workflow_config).expect("write config");
         write_agent_runtime_config(temp.path(), &builtin_agent_runtime_config()).expect("write runtime config");
 

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -202,13 +202,13 @@ async fn resolve_workflow_run_dispatch_from_raw_input(
         return Ok(dispatch);
     }
 
-    if let Ok(input) = serde_json::from_str::<WorkflowRunInput>(raw) {
-        return resolve_workflow_run_dispatch_from_input(hub, project_root, input).await;
-    }
-
     if let Some(input) = upgrade_legacy_workflow_run_input(raw)
         .with_context(|| "invalid --input-json payload for workflow run; run 'ao workflow run --help' for schema")?
     {
+        return resolve_workflow_run_dispatch_from_input(hub, project_root, input).await;
+    }
+
+    if let Ok(input) = serde_json::from_str::<WorkflowRunInput>(raw) {
         return resolve_workflow_run_dispatch_from_input(hub, project_root, input).await;
     }
 


### PR DESCRIPTION
## Summary
- Fixed `ops_doctor::tests::doctor_fix_creates_default_daemon_config_when_missing` by adding HOME env isolation via `test_env_lock` + `EnvVarGuard(HOME)`, matching the established pattern in `ops_workflow/phases.rs`
- Fixed `ops_queue::tests::resolve_enqueue_dispatch_uses_requirement_workflow_default` by removing duplicate `WorkflowDefinition` push — `builtin_workflow_config()` already contains `REQUIREMENT_TASK_GENERATION_WORKFLOW_REF`, so the extra push caused `write_workflow_config` to fail
- Fixed `ops_workflow::tests::resolve_workflow_run_dispatch_from_raw_input_accepts_legacy_task_payload` by moving `upgrade_legacy_workflow_run_input` check before `WorkflowRunInput` parse — the permissive serde defaults silently misparsed legacy payloads producing empty `task_id`

## Test plan
- [ ] `cargo test -p orchestrator-cli` — all 3 target tests pass
- [ ] `cargo test --workspace` — no new failures introduced (39 pre-existing unrelated failures remain)