### PR TITLE
Add ao.runner.orphans-cleanup MCP tool

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/common_types.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/common_types.rs
@@ -20,6 +20,13 @@ pub(super) struct ExecutionIdInput {
     pub(super) project_root: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(super) struct RunnerOrphansCleanupInput {
+    pub(super) run_id: Vec<String>,
+    #[serde(default)]
+    pub(super) project_root: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum OnError {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/runner_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/runner_tools.rs
@@ -38,4 +38,22 @@ impl AoMcpServer {
         )
         .await
     }
+
+    #[tool(
+        name = "ao.runner.orphans-cleanup",
+        description = "Clean up orphaned runner processes. Purpose: Remove runner processes that are no longer managed by the daemon. Prerequisites: Use ao.runner.orphans-detect first to identify orphaned run IDs. Example: {\"run_id\": [\"abc123\"]}. Sequencing: Use after ao.runner.orphans-detect to find orphan IDs, then ao.runner.health to verify cleanup.",
+        input_schema = ao_schema_for_type::<RunnerOrphansCleanupInput>()
+    )]
+    async fn ao_runner_orphans_cleanup(&self, params: Parameters<RunnerOrphansCleanupInput>) -> Result<CallToolResult, McpError> {
+        let mut args = vec![
+            "runner".to_string(),
+            "orphans".to_string(),
+            "cleanup".to_string(),
+        ];
+        for id in &params.0.run_id {
+            args.push("--run-id".to_string());
+            args.push(id.clone());
+        }
+        self.run_tool("ao.runner.orphans-cleanup", args, params.0.project_root).await
+    }
 }

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -141,12 +141,13 @@ Every tool accepts an optional `project_root` parameter to override the default 
 
 ---
 
-## Runner (3 tools)
+## Runner (4 tools)
 
 | Tool | Description | Key Parameters |
 |---|---|---|
 | `ao.runner.health` | Check runner process health and capacity | `project_root` |
 | `ao.runner.orphans-detect` | Find orphaned runner processes | `project_root` |
+| `ao.runner.orphans-cleanup` | Clean up orphaned runner processes by run ID | `run_id`, `project_root` |
 | `ao.runner.restart-stats` | View runner uptime and restart history | `project_root` |
 
 ---


### PR DESCRIPTION
Exposes the existing `runner orphans cleanup` CLI command as an MCP tool.
Adds RunnerOrphansCleanupInput with run_id: Vec<String> and project_root,
builds repeated --run-id flags per ID, and updates mcp-tools.md Runner section.
