### PR TITLE
Fix task-reconciler: auto-unblock tasks blocked by transient workflow runner failures

### DIFF
--- a/.ao/workflows/custom.yaml
+++ b/.ao/workflows/custom.yaml
@@ -87,6 +87,9 @@ agents:
          - If blocked_reason mentions "dependency gate", check each blocked_by dependency.
          - If ALL dependencies are "done"/"cancelled", set to "ready".
          - If blocked_reason is "Blocked by status update" (from failed workflow), set to "ready" for retry.
+         - If blocked_reason contains "workflow runner exited" OR starts with "workflow runner failed:" OR starts with "workflow runner cancelled:" (transient infrastructure failures):
+           - If consecutive_dispatch_failures >= 3, leave blocked — human review needed. Skip.
+           - Otherwise, set to "ready" for retry.
          - If task has a merged PR, set to "done".
 
       4. CLEAN STALE QUEUE ENTRIES:

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -172,3 +172,45 @@ fn workflow_is_waiting_on_manual_phase(project_root: &str, workflow: &orchestrat
         .map(|definition| matches!(definition.mode, orchestrator_core::PhaseExecutionMode::Manual))
         .unwrap_or(false)
 }
+
+pub async fn reconcile_runner_blocked_tasks(
+    hub: Arc<dyn ServiceHub>,
+    _project_root: &str,
+) -> Result<usize> {
+    let tasks = match hub.tasks().list().await {
+        Ok(tasks) => tasks,
+        Err(error) => {
+            eprintln!(
+                "{}: failed to list tasks for runner-blocked reconciliation: {}",
+                protocol::ACTOR_DAEMON,
+                error
+            );
+            return Ok(0);
+        }
+    };
+
+    let mut reconciled = 0usize;
+    for task in tasks {
+        if !orchestrator_core::is_workflow_runner_blocked(&task) {
+            continue;
+        }
+        match orchestrator_core::reconcile_runner_blocked_task(hub.clone(), &task).await {
+            Ok(true) => {
+                reconciled = reconciled.saturating_add(1);
+            }
+            Ok(false) => {
+                // Escalated to human review — task left blocked
+            }
+            Err(error) => {
+                eprintln!(
+                    "{}: failed to reconcile runner-blocked task {}: {}",
+                    protocol::ACTOR_DAEMON,
+                    task.id,
+                    error
+                );
+            }
+        }
+    }
+
+    Ok(reconciled)
+}

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run_host.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run_host.rs
@@ -113,6 +113,7 @@ impl DefaultDaemonRunHost {
                 "resumed_workflows": summary.resumed_workflows,
                 "cleaned_stale_workflows": summary.cleaned_stale_workflows,
                 "reconciled_workflows": summary.reconciled_workflows,
+                "reconciled_runner_blocked_tasks": summary.reconciled_runner_blocked_tasks,
                 "executed_workflow_phases": summary.executed_workflow_phases,
                 "failed_workflow_phases": summary.failed_workflow_phases,
             }),

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::services::runtime::execution_fact_projection::reconcile_completed_processes;
 use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
-    reconcile_manual_phase_timeouts, recover_orphaned_running_workflows,
+    reconcile_manual_phase_timeouts, reconcile_runner_blocked_tasks, recover_orphaned_running_workflows,
 };
 use anyhow::Result;
 use orchestrator_core::services::ServiceHub;
@@ -51,6 +51,10 @@ impl DefaultProjectTickServices for CliProjectTickServices {
 
     async fn reconcile_manual_timeouts(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {
         reconcile_manual_phase_timeouts(hub, root).await
+    }
+
+    async fn reconcile_runner_blocked_tasks(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {
+        reconcile_runner_blocked_tasks(hub, root).await
     }
 
     async fn dispatch_ready_tasks(

--- a/crates/orchestrator-core/src/execution_projection.rs
+++ b/crates/orchestrator-core/src/execution_projection.rs
@@ -19,6 +19,72 @@ pub use projector_registry::{
     builtin_execution_projector_registry, execution_fact_subject_kind, ExecutionProjector, ExecutionProjectorRegistry,
 };
 
+pub const WORKFLOW_RUNNER_BLOCKED_PREFIX: &str = "workflow runner failed: ";
+pub const WORKFLOW_RUNNER_CANCELLED_PREFIX: &str = "workflow runner cancelled: ";
+pub const WORKFLOW_RUNNER_EXITED_PREFIX: &str = "workflow runner exited without workflow status";
+pub const MAX_RUNNER_FAILURE_RESETS: u32 = 3;
+
+/// Returns true when a task is blocked specifically because a workflow runner
+/// exited with a non-zero status (a transient infrastructure failure), not
+/// because of a dependency gate or human-required input.
+pub fn is_workflow_runner_blocked(task: &OrchestratorTask) -> bool {
+    if !task.status.is_blocked() || !task.paused {
+        return false;
+    }
+    task.blocked_reason.as_deref().is_some_and(|reason| {
+        reason.starts_with(WORKFLOW_RUNNER_BLOCKED_PREFIX)
+            || reason.starts_with(WORKFLOW_RUNNER_CANCELLED_PREFIX)
+            || reason.starts_with(WORKFLOW_RUNNER_EXITED_PREFIX)
+    })
+}
+
+/// Resets a runner-blocked task back to `Ready` so the daemon can retry it.
+///
+/// Uses `consecutive_dispatch_failures` to track how many times this task has
+/// been reset.  Once the count reaches `MAX_RUNNER_FAILURE_RESETS` the task is
+/// left blocked and an error message is logged, signalling that human
+/// intervention is needed.
+pub async fn reconcile_runner_blocked_task(
+    hub: Arc<dyn ServiceHub>,
+    task: &OrchestratorTask,
+) -> anyhow::Result<bool> {
+    let count = task.consecutive_dispatch_failures.unwrap_or(0).saturating_add(1);
+
+    if count > MAX_RUNNER_FAILURE_RESETS {
+        eprintln!(
+            "{}: task {} has been reset {} times after runner failures — escalating to human review (blocked_reason={:?})",
+            protocol::ACTOR_DAEMON,
+            task.id,
+            count,
+            task.blocked_reason,
+        );
+        return Ok(false);
+    }
+
+    let mut updated = task.clone();
+    updated.status = TaskStatus::Ready;
+    updated.paused = false;
+    updated.blocked_reason = None;
+    updated.blocked_at = None;
+    updated.blocked_phase = None;
+    updated.blocked_by = None;
+    updated.consecutive_dispatch_failures = Some(count);
+    updated.last_dispatch_failure_at = Some(Utc::now().to_rfc3339());
+    updated.metadata.updated_at = Utc::now();
+    updated.metadata.updated_by = protocol::ACTOR_DAEMON.to_string();
+    updated.metadata.version = updated.metadata.version.saturating_add(1);
+    hub.tasks().replace(updated).await?;
+    eprintln!(
+        "{}: unblocked task {} after runner failure (reset #{}/{}, previous reason: {:?})",
+        protocol::ACTOR_DAEMON,
+        task.id,
+        count,
+        MAX_RUNNER_FAILURE_RESETS,
+        task.blocked_reason,
+    );
+    Ok(true)
+}
+
 pub async fn project_task_status(hub: Arc<dyn ServiceHub>, task_id: &str, status: TaskStatus) -> Result<()> {
     hub.tasks().set_status(task_id, status, false).await?;
     Ok(())
@@ -177,7 +243,7 @@ mod tests {
     use chrono::Utc;
     use protocol::{SubjectExecutionFact, SUBJECT_KIND_TASK};
 
-    use super::{execution_fact_subject_kind, project_execution_fact};
+    use super::{execution_fact_subject_kind, is_workflow_runner_blocked, project_execution_fact, reconcile_runner_blocked_task, MAX_RUNNER_FAILURE_RESETS};
     use crate::{
         services::ServiceHub, InMemoryServiceHub, OrchestratorTask, Priority, ResourceRequirements, Scope,
         TaskMetadata, TaskStatus, TaskType, WorkflowMetadata,
@@ -306,5 +372,242 @@ mod tests {
         let projected = project_execution_fact(hub, ".", &fact).await;
 
         assert!(!projected);
+    }
+
+    // --- runner-blocked reconciliation tests ---
+
+    async fn upsert_runner_blocked_task(
+        hub: &Arc<InMemoryServiceHub>,
+        id: &str,
+        blocked_reason: &str,
+        dispatch_failures: Option<u32>,
+    ) -> OrchestratorTask {
+        let now = Utc::now();
+        let task = OrchestratorTask {
+            id: id.to_string(),
+            title: format!("Task {id}"),
+            description: "Runner blocked task".to_string(),
+            task_type: TaskType::Feature,
+            status: TaskStatus::Blocked,
+            blocked_reason: Some(blocked_reason.to_string()),
+            blocked_at: Some(now),
+            blocked_phase: None,
+            blocked_by: None,
+            priority: Priority::Medium,
+            risk: crate::RiskLevel::Medium,
+            scope: Scope::Medium,
+            complexity: crate::Complexity::default(),
+            impact_area: Vec::new(),
+            assignee: crate::Assignee::Unassigned,
+            estimated_effort: None,
+            linked_requirements: Vec::new(),
+            linked_architecture_entities: Vec::new(),
+            dependencies: Vec::new(),
+            checklist: Vec::new(),
+            tags: Vec::new(),
+            workflow_metadata: WorkflowMetadata::default(),
+            worktree_path: None,
+            branch_name: None,
+            metadata: TaskMetadata {
+                created_at: now,
+                updated_at: now,
+                created_by: "test".to_string(),
+                updated_by: "test".to_string(),
+                started_at: None,
+                completed_at: None,
+                version: 1,
+            },
+            deadline: None,
+            paused: true,
+            cancelled: false,
+            resolution: None,
+            resource_requirements: ResourceRequirements::default(),
+            consecutive_dispatch_failures: dispatch_failures,
+            last_dispatch_failure_at: None,
+            dispatch_history: Vec::new(),
+        };
+
+        hub.tasks().replace(task.clone()).await.expect("upsert task");
+        task
+    }
+
+    #[test]
+    fn is_workflow_runner_blocked_detects_runner_failure() {
+        let task = OrchestratorTask {
+            status: TaskStatus::Blocked,
+            paused: true,
+            blocked_reason: Some(
+                "workflow runner failed: workflow runner exited unsuccessfully with status Some(1)".to_string(),
+            ),
+            ..base_test_task("TASK-1")
+        };
+        assert!(is_workflow_runner_blocked(&task));
+    }
+
+    #[test]
+    fn is_workflow_runner_blocked_detects_exited_without_status() {
+        let task = OrchestratorTask {
+            status: TaskStatus::Blocked,
+            paused: true,
+            blocked_reason: Some(
+                "workflow runner exited without workflow status: workflow runner exited with status Some(1)".to_string(),
+            ),
+            ..base_test_task("TASK-1")
+        };
+        assert!(is_workflow_runner_blocked(&task));
+    }
+
+    #[test]
+    fn is_workflow_runner_blocked_detects_cancelled() {
+        let task = OrchestratorTask {
+            status: TaskStatus::Blocked,
+            paused: true,
+            blocked_reason: Some("workflow runner cancelled: operator requested".to_string()),
+            ..base_test_task("TASK-1")
+        };
+        assert!(is_workflow_runner_blocked(&task));
+    }
+
+    #[test]
+    fn is_workflow_runner_blocked_rejects_non_runner_reasons() {
+        let task = OrchestratorTask {
+            status: TaskStatus::Blocked,
+            paused: true,
+            blocked_reason: Some("dependency gate: waiting on TASK-001".to_string()),
+            ..base_test_task("TASK-1")
+        };
+        assert!(!is_workflow_runner_blocked(&task));
+    }
+
+    #[test]
+    fn is_workflow_runner_blocked_rejects_not_paused() {
+        let task = OrchestratorTask {
+            status: TaskStatus::Blocked,
+            paused: false,
+            blocked_reason: Some("workflow runner failed: something".to_string()),
+            ..base_test_task("TASK-1")
+        };
+        assert!(!is_workflow_runner_blocked(&task));
+    }
+
+    #[test]
+    fn is_workflow_runner_blocked_rejects_not_blocked() {
+        let task = OrchestratorTask {
+            status: TaskStatus::Ready,
+            paused: false,
+            blocked_reason: None,
+            ..base_test_task("TASK-1")
+        };
+        assert!(!is_workflow_runner_blocked(&task));
+    }
+
+    #[tokio::test]
+    async fn reconcile_resets_runner_blocked_task_to_ready() {
+        let hub = Arc::new(InMemoryServiceHub::new());
+        upsert_runner_blocked_task(
+            &hub,
+            "TASK-R1",
+            "workflow runner failed: workflow runner exited unsuccessfully with status Some(1)",
+            None,
+        )
+        .await;
+
+        let task = hub.tasks().get("TASK-R1").await.unwrap();
+        let result = reconcile_runner_blocked_task(hub.clone(), &task).await.unwrap();
+
+        assert!(result);
+        let updated = hub.tasks().get("TASK-R1").await.unwrap();
+        assert_eq!(updated.status, TaskStatus::Ready);
+        assert!(!updated.paused);
+        assert!(updated.blocked_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn reconcile_increments_and_persists_failure_counter() {
+        let hub = Arc::new(InMemoryServiceHub::new());
+        upsert_runner_blocked_task(
+            &hub,
+            "TASK-R3",
+            "workflow runner exited without workflow status: workflow runner exited with status Some(1)",
+            Some(1),
+        )
+        .await;
+
+        let task = hub.tasks().get("TASK-R3").await.unwrap();
+        let result = reconcile_runner_blocked_task(hub.clone(), &task).await.unwrap();
+
+        assert!(result);
+        let updated = hub.tasks().get("TASK-R3").await.unwrap();
+        assert_eq!(updated.status, TaskStatus::Ready);
+        assert!(!updated.paused);
+        assert!(updated.blocked_reason.is_none());
+        assert_eq!(updated.consecutive_dispatch_failures, Some(2));
+        assert!(updated.last_dispatch_failure_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn reconcile_stops_resetting_after_max_retries() {
+        let hub = Arc::new(InMemoryServiceHub::new());
+        upsert_runner_blocked_task(
+            &hub,
+            "TASK-R2",
+            "workflow runner failed: workflow runner exited unsuccessfully with status Some(1)",
+            Some(MAX_RUNNER_FAILURE_RESETS),
+        )
+        .await;
+
+        let task = hub.tasks().get("TASK-R2").await.unwrap();
+        let result = reconcile_runner_blocked_task(hub.clone(), &task).await.unwrap();
+
+        assert!(!result);
+        let still_blocked = hub.tasks().get("TASK-R2").await.unwrap();
+        assert_eq!(still_blocked.status, TaskStatus::Blocked);
+    }
+
+    fn base_test_task(id: &str) -> OrchestratorTask {
+        let now = Utc::now();
+        OrchestratorTask {
+            id: id.to_string(),
+            title: format!("Task {id}"),
+            description: String::new(),
+            task_type: TaskType::Feature,
+            status: TaskStatus::Backlog,
+            blocked_reason: None,
+            blocked_at: None,
+            blocked_phase: None,
+            blocked_by: None,
+            priority: Priority::Medium,
+            risk: crate::RiskLevel::Medium,
+            scope: Scope::Medium,
+            complexity: crate::Complexity::default(),
+            impact_area: Vec::new(),
+            assignee: crate::Assignee::Unassigned,
+            estimated_effort: None,
+            linked_requirements: Vec::new(),
+            linked_architecture_entities: Vec::new(),
+            dependencies: Vec::new(),
+            checklist: Vec::new(),
+            tags: Vec::new(),
+            workflow_metadata: WorkflowMetadata::default(),
+            worktree_path: None,
+            branch_name: None,
+            metadata: TaskMetadata {
+                created_at: now,
+                updated_at: now,
+                created_by: "test".to_string(),
+                updated_by: "test".to_string(),
+                started_at: None,
+                completed_at: None,
+                version: 1,
+            },
+            deadline: None,
+            paused: false,
+            cancelled: false,
+            resolution: None,
+            resource_requirements: ResourceRequirements::default(),
+            consecutive_dispatch_failures: None,
+            last_dispatch_failure_at: None,
+            dispatch_history: Vec::new(),
+        }
     }
 }

--- a/crates/orchestrator-core/src/lib.rs
+++ b/crates/orchestrator-core/src/lib.rs
@@ -43,10 +43,12 @@ pub use domain_state::{
     ReviewStore, ReviewerRole,
 };
 pub use execution_projection::{
-    builtin_execution_projector_registry, execution_fact_subject_kind, project_execution_fact,
-    project_requirement_workflow_status, project_schedule_dispatch_attempt, project_schedule_execution_fact,
-    project_task_blocked_with_reason, project_task_dispatch_failure, project_task_execution_fact, project_task_status,
-    project_task_terminal_workflow_status, project_task_workflow_start, ExecutionProjector, ExecutionProjectorRegistry,
+    builtin_execution_projector_registry, execution_fact_subject_kind, is_workflow_runner_blocked,
+    project_execution_fact, project_requirement_workflow_status, project_schedule_dispatch_attempt,
+    project_schedule_execution_fact, project_task_blocked_with_reason, project_task_dispatch_failure,
+    project_task_execution_fact, project_task_status, project_task_terminal_workflow_status,
+    project_task_workflow_start, reconcile_runner_blocked_task, ExecutionProjector, ExecutionProjectorRegistry,
+    MAX_RUNNER_FAILURE_RESETS, WORKFLOW_RUNNER_BLOCKED_PREFIX,
 };
 pub use model_quality::{
     is_model_suppressed_for_phase, load_model_quality_ledger, model_quality_ledger_path, record_model_phase_outcome,

--- a/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
@@ -52,6 +52,10 @@ pub trait DefaultProjectTickServices {
         Ok(0)
     }
 
+    async fn reconcile_runner_blocked_tasks(&mut self, _hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
         hub: Arc<dyn ServiceHub>,
@@ -196,6 +200,11 @@ where
     async fn reconcile_manual_timeouts(&mut self, root: &str) -> Result<usize> {
         let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
         self.services.reconcile_manual_timeouts(hub, root).await
+    }
+
+    async fn reconcile_runner_blocked_tasks(&mut self, root: &str) -> Result<usize> {
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        self.services.reconcile_runner_blocked_tasks(hub, root).await
     }
 
     async fn dispatch_ready_tasks(&mut self, root: &str, limit: usize) -> Result<DispatchWorkflowStartSummary> {

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_execution_outcome.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_execution_outcome.rs
@@ -9,6 +9,7 @@ pub struct ProjectTickExecutionOutcome {
     pub reconciled_workflows: usize,
     pub reconciled_dependency_tasks: usize,
     pub reconciled_merge_tasks: usize,
+    pub reconciled_runner_blocked_tasks: usize,
     pub ready_workflow_starts: DispatchWorkflowStartSummary,
     pub executed_workflow_phases: usize,
     pub failed_workflow_phases: usize,

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
@@ -23,6 +23,10 @@ pub trait ProjectTickHooks {
         Ok(0)
     }
 
+    async fn reconcile_runner_blocked_tasks(&mut self, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(&mut self, root: &str, _limit: usize) -> Result<DispatchWorkflowStartSummary>;
 
     async fn collect_health(&mut self, root: &str) -> Result<Value>;

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_snapshot.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_snapshot.rs
@@ -30,6 +30,7 @@ impl ProjectTickSnapshot {
             reconciled_workflows: execution_outcome.reconciled_workflows,
             reconciled_dependency_tasks: execution_outcome.reconciled_dependency_tasks,
             reconciled_merge_tasks: execution_outcome.reconciled_merge_tasks,
+            reconciled_runner_blocked_tasks: execution_outcome.reconciled_runner_blocked_tasks,
             ready_started_count: execution_outcome.ready_workflow_starts.started,
             ready_started_workflows: execution_outcome.ready_workflow_starts.started_workflows,
             executed_workflow_phases: execution_outcome.executed_workflow_phases,

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_summary.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_summary.rs
@@ -32,6 +32,7 @@ pub struct ProjectTickSummary {
     pub resumed_workflows: usize,
     pub cleaned_stale_workflows: usize,
     pub reconciled_workflows: usize,
+    pub reconciled_runner_blocked_tasks: usize,
     pub started_ready_workflows: usize,
     pub executed_workflow_phases: usize,
     pub failed_workflow_phases: usize,

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_summary_input.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_summary_input.rs
@@ -16,6 +16,7 @@ pub struct ProjectTickSummaryInput {
     pub reconciled_workflows: usize,
     pub reconciled_dependency_tasks: usize,
     pub reconciled_merge_tasks: usize,
+    pub reconciled_runner_blocked_tasks: usize,
     pub ready_started_count: usize,
     pub ready_started_workflows: Vec<DispatchWorkflowStart>,
     pub executed_workflow_phases: usize,

--- a/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
@@ -39,10 +39,12 @@ where
     let snapshot = hooks.capture_snapshot(root).await?;
     let preparation = mode.build_preparation(&context, args, now, pool_draining, &snapshot);
     let reconciled_workflows = hooks.reconcile_manual_timeouts(root).await?;
+    let reconciled_runner_blocked_tasks = hooks.reconcile_runner_blocked_tasks(root).await?;
     let (executed_workflow_phases, failed_workflow_phases) = hooks.reconcile_completed_processes(root).await?;
     let reconciled_zombie_workflows = hooks.reconcile_zombie_workflows(root).await?;
     let mut execution_outcome = ProjectTickExecutionOutcome {
         reconciled_workflows: reconciled_workflows + reconciled_zombie_workflows,
+        reconciled_runner_blocked_tasks,
         executed_workflow_phases,
         failed_workflow_phases,
         ..Default::default()

--- a/crates/orchestrator-daemon-runtime/src/tick/tick_summary_builder.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/tick_summary_builder.rs
@@ -32,6 +32,7 @@ impl TickSummaryBuilder {
                 .reconciled_workflows
                 .saturating_add(input.reconciled_dependency_tasks)
                 .saturating_add(input.reconciled_merge_tasks),
+            reconciled_runner_blocked_tasks: input.reconciled_runner_blocked_tasks,
             started_ready_workflows: input.ready_started_count,
             executed_workflow_phases: input.executed_workflow_phases,
             failed_workflow_phases: input.failed_workflow_phases,


### PR DESCRIPTION
Three bugs prevented TASK-706-style runner-blocked tasks from being auto-unblocked:

1. is_workflow_runner_blocked() only matched 'workflow runner failed:' prefix but
   completion_reconciliation_plan.rs produces 'workflow runner exited without workflow
   status: ...' for the actual crash scenario (AC1 gap).

2. reconcile_runner_blocked_task() called set_status() which internally runs
   apply_task_status(), which unconditionally clears consecutive_dispatch_failures=None
   on any non-blocked transition — so the retry counter was never persisted (AC4 gap).

3. The reconciler agent prompt step 3 only handled 'dependency gate' and 'Blocked by
   status update' patterns, not runner-failure blocked_reasons (AC5 gap).

Fixes:
- Add WORKFLOW_RUNNER_EXITED_PREFIX constant and check all three transient-failure
  prefixes in is_workflow_runner_blocked()
- Replace set_status() call in reconcile_runner_blocked_task() with a direct replace()
  that builds the ready-state task with the incremented counter preserved
- Update reconciler prompt step 3 to handle all runner-failure blocked_reason patterns
