### PR TITLE
Treat authentication_error as ProviderExhaustion to trigger failover chain

### DIFF
--- a/crates/workflow-runner-v2/src/phase_failover.rs
+++ b/crates/workflow-runner-v2/src/phase_failover.rs
@@ -96,6 +96,12 @@ fn extract_provider_exhaustion_reason(text: &str) -> Option<String> {
     if normalized.contains("secondary") && normalized.contains("used_percent") {
         return Some("secondary token budget exhausted".to_string());
     }
+    if normalized.contains("authentication_error")
+        || normalized.contains("invalid authentication credentials")
+        || normalized.contains("failed to authenticate")
+    {
+        return Some("provider authentication failed".to_string());
+    }
 
     None
 }
@@ -188,6 +194,8 @@ fn provider_exhaustion_reason_from_payload(payload: &Value) -> Option<String> {
             || kind.contains("quota")
             || kind.contains("rate_limit")
             || kind.contains("rate-limit")
+            || kind.contains("authentication_error")
+            || kind.contains("auth_error")
         {
             return Some(format!("provider returned {}", kind));
         }


### PR DESCRIPTION
A 401 authentication_error from the Anthropic API was classified as
PhaseFailureKind::Unknown, causing should_failover_target() to return
false and the workflow to fail outright instead of falling back to the
next model in the chain.

Add authentication_error / auth_error to the JSON error-type check in
provider_exhaustion_reason_from_payload, and add text-pattern matches
for the literal strings that appear in the 401 error message body
("authentication_error", "invalid authentication credentials",
"failed to authenticate") in extract_provider_exhaustion_reason.

This causes the existing failover chain to activate on auth failures,
allowing the workflow to continue with the next configured model.
