### PR TITLE
[TASK-756] Document replace_linked_architecture_entities in ao.task.update tool description and mcp-tools.md

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/task_mutation_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/task_mutation_tools.rs
@@ -66,7 +66,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "ao.task.update",
-        description = "Update task fields. Purpose: Modify task properties like title, description, priority, status, or assignee. Prerequisites: Task must exist. Example: {\"id\": \"TASK-001\", \"priority\": \"high\", \"description\": \"Updated description\"}. Sequencing: Use ao.task.get first to see current values, or ao.task.status for simple status changes.",
+        description = "Update task fields. Purpose: Modify task properties like title, description, priority, status, or assignee. Prerequisites: Task must exist. Example: {\"id\": \"TASK-001\", \"priority\": \"high\", \"description\": \"Updated description\"}. Sequencing: Use ao.task.get first to see current values, or ao.task.status for simple status changes. Pass replace_linked_architecture_entities: true to replace all linked architecture entities instead of appending.",
         input_schema = ao_schema_for_type::<TaskUpdateInput>()
     )]
     async fn ao_task_update(&self, params: Parameters<TaskUpdateInput>) -> Result<CallToolResult, McpError> {

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -52,7 +52,7 @@ Every tool accepts an optional `project_root` parameter to override the default 
 | Tool | Description | Key Parameters |
 |---|---|---|
 | `ao.task.create` | Create a new task | `title`, `description`, `priority`, `task_type`, `tags[]`, `linked_requirement[]`, `assignee` |
-| `ao.task.update` | Update task fields | `id`, `title`, `description`, `priority`, `status`, `assignee`, `linked_architecture_entity[]`, `input_json` |
+| `ao.task.update` | Update task fields | `id`, `title`, `description`, `priority`, `status`, `assignee`, `linked_architecture_entity[]`, `replace_linked_architecture_entities`, `input_json` |
 | `ao.task.delete` | Delete a task (destructive) | `id`, `confirm`, `dry_run` |
 | `ao.task.status` | Update task status | `id`, `status` |
 | `ao.task.assign` | Assign task to user or agent | `id`, `assignee`, `assignee_type`, `agent_role`, `model` |


### PR DESCRIPTION
Automated update for task TASK-756.

`TaskUpdateInput` in `crates/orchestrator-cli/src/services/operations/ops_mcp/task_inputs.rs:120-121` has `replace_linked_architecture_entities: bool`, and `ao_task_update` in `task_mutation_tools.rs:84-86` correctly passes `--replace-linked-architecture-entities` when true.

However:
- The tool description at `task_mutation_tools.rs:69` only mentions `linked_architecture_entity[]` — no mention of the replace flag
- `docs/reference/mcp-tools.md:55` key parameters for `ao.task.update` don't list `replace_linked_architecture_entities`

Without knowing this flag exists, MCP callers can only *append* linked architecture entities, never *replace* them. Passing `--linked-architecture-entity` multiple times will always accumulate.

Fix:
- Add `replace_linked_architecture_entities` to the tool description in `task_mutation_tools.rs:69`, e.g. "Pass replace_linked_architecture_entities: true to replace all linked architecture entities instead of appending."
- Add `replace_linked_architecture_entities` to the `ao.task.update` key parameters row in `docs/reference/mcp-tools.md:55`