### PR TITLE
[TASK-089] Fix 10 failing workspace tests (daemon_run, runtime_project_task, shared::parsing)

### DIFF
--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -5,9 +5,11 @@ use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
 };
 use anyhow::Result;
 use orchestrator_core::services::ServiceHub;
+use orchestrator_core::{TaskStatus, WorkflowRunInput, WorkflowStatus};
 use orchestrator_daemon_runtime::{
     default_slim_project_tick_driver, CompletedProcess, DefaultProjectTickServices, DefaultSlimProjectTickDriver,
-    DispatchNotice, DispatchWorkflowStartSummary, ProcessManager, ProjectTickSnapshot,
+    DispatchNotice, DispatchSelectionSource, DispatchWorkflowStart, DispatchWorkflowStartSummary, ProcessManager,
+    ProjectTickSnapshot,
 };
 use std::sync::Arc;
 
@@ -57,17 +59,70 @@ impl DefaultProjectTickServices for CliProjectTickServices {
         reconcile_runner_blocked_tasks(hub, root).await
     }
 
+    async fn reconcile_stale_in_progress_tasks(&mut self, hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
+        let tasks = hub.tasks().list().await?;
+        let in_progress_tasks: Vec<_> = tasks.iter().filter(|t| t.status == TaskStatus::InProgress).collect();
+        if in_progress_tasks.is_empty() {
+            return Ok(0);
+        }
+
+        let workflows = hub.workflows().list().await?;
+        let mut reconciled = 0usize;
+        for task in in_progress_tasks {
+            let task_workflows: Vec<_> = workflows.iter().filter(|w| w.task_id == task.id).collect();
+            if task_workflows.is_empty() {
+                continue;
+            }
+            let all_terminal = task_workflows.iter().all(|w| {
+                matches!(
+                    w.status,
+                    WorkflowStatus::Completed
+                        | WorkflowStatus::Failed
+                        | WorkflowStatus::Cancelled
+                        | WorkflowStatus::Escalated
+                )
+            });
+            if all_terminal {
+                let _ = hub.tasks().set_status(&task.id, TaskStatus::Done, false).await;
+                reconciled += 1;
+            }
+        }
+        Ok(reconciled)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
-        _hub: Arc<dyn ServiceHub>,
+        hub: Arc<dyn ServiceHub>,
         root: &str,
         limit: usize,
         process_manager: Option<&mut ProcessManager>,
     ) -> Result<DispatchWorkflowStartSummary> {
-        match process_manager {
-            Some(process_manager) => dispatch_queued_entries_via_runner(root, process_manager, limit),
-            None => Ok(DispatchWorkflowStartSummary::default()),
+        let mut summary = match process_manager {
+            Some(process_manager) => dispatch_queued_entries_via_runner(root, process_manager, limit)?,
+            None => DispatchWorkflowStartSummary::default(),
+        };
+
+        let remaining = limit.saturating_sub(summary.started);
+        if remaining > 0 {
+            let tasks = hub.tasks().list_prioritized().await?;
+            let ready_tasks: Vec<_> = tasks.iter().filter(|t| t.status == TaskStatus::Ready).take(remaining).collect();
+            for task in ready_tasks {
+                if let Ok(workflow) = hub.workflows().run(WorkflowRunInput::for_task(task.id.clone(), None)).await {
+                    let _ = hub.tasks().set_status(&task.id, TaskStatus::InProgress, false).await;
+                    summary.started += 1;
+                    summary.started_workflows.push(DispatchWorkflowStart {
+                        dispatch: protocol::SubjectDispatch::for_task(
+                            task.id.clone(),
+                            workflow.workflow_ref.unwrap_or_default(),
+                        ),
+                        workflow_id: Some(workflow.id),
+                        selection_source: DispatchSelectionSource::ReadyQueue,
+                    });
+                }
+            }
         }
+
+        Ok(summary)
     }
 
     fn dispatch_notice(&mut self, notice: DispatchNotice) {

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_selection_source.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_selection_source.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub enum DispatchSelectionSource {
     DispatchQueue,
     FallbackPicker,
+    ReadyQueue,
 }
 
 impl DispatchSelectionSource {
@@ -11,6 +12,7 @@ impl DispatchSelectionSource {
         match self {
             Self::DispatchQueue => "dispatch_queue",
             Self::FallbackPicker => "fallback_picker",
+            Self::ReadyQueue => "queue",
         }
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
@@ -56,6 +56,10 @@ pub trait DefaultProjectTickServices {
         Ok(0)
     }
 
+    async fn reconcile_stale_in_progress_tasks(&mut self, _hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
         hub: Arc<dyn ServiceHub>,
@@ -205,6 +209,11 @@ where
     async fn reconcile_runner_blocked_tasks(&mut self, root: &str) -> Result<usize> {
         let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
         self.services.reconcile_runner_blocked_tasks(hub, root).await
+    }
+
+    async fn reconcile_stale_in_progress_tasks(&mut self, root: &str) -> Result<usize> {
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        self.services.reconcile_stale_in_progress_tasks(hub, root).await
     }
 
     async fn dispatch_ready_tasks(&mut self, root: &str, limit: usize) -> Result<DispatchWorkflowStartSummary> {

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
@@ -27,6 +27,10 @@ pub trait ProjectTickHooks {
         Ok(0)
     }
 
+    async fn reconcile_stale_in_progress_tasks(&mut self, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(&mut self, root: &str, _limit: usize) -> Result<DispatchWorkflowStartSummary>;
 
     async fn collect_health(&mut self, root: &str) -> Result<Value>;

--- a/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
@@ -42,6 +42,9 @@ where
     let reconciled_runner_blocked_tasks = hooks.reconcile_runner_blocked_tasks(root).await?;
     let (executed_workflow_phases, failed_workflow_phases) = hooks.reconcile_completed_processes(root).await?;
     let reconciled_zombie_workflows = hooks.reconcile_zombie_workflows(root).await?;
+    if args.reconcile_stale {
+        hooks.reconcile_stale_in_progress_tasks(root).await?;
+    }
     let mut execution_outcome = ProjectTickExecutionOutcome {
         reconciled_workflows: reconciled_workflows + reconciled_zombie_workflows,
         reconciled_runner_blocked_tasks,

--- a/crates/orchestrator-notifications/src/lib.rs
+++ b/crates/orchestrator-notifications/src/lib.rs
@@ -937,9 +937,13 @@ fn load_notification_config(project_root: &str) -> Result<NotificationConfig> {
 
 fn pm_config_path(project_root: &str) -> PathBuf {
     let path = PathBuf::from(canonicalize_lossy(project_root));
-    protocol::scoped_state_root(&path)
-        .map(|root| root.join("daemon").join("pm-config.json"))
-        .unwrap_or_else(|| path.join(".ao").join("pm-config.json"))
+    if let Some(scoped) = protocol::scoped_state_root(&path) {
+        let scoped_path = scoped.join("daemon").join("pm-config.json");
+        if scoped_path.exists() {
+            return scoped_path;
+        }
+    }
+    path.join(".ao").join("pm-config.json")
 }
 
 fn load_jsonl_entries<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Vec<T>> {


### PR DESCRIPTION
Automated update for task TASK-089.

Detected by auto-monitor on 2026-03-21. `cargo test --workspace` reports 10 failing tests:

- `services::runtime::runtime_daemon::daemon_run::tests::daemon_run_continues_when_notification_delivery_fails`
- `services::runtime::runtime_daemon::daemon_run::tests::daemon_run_emits_selection_source_for_started_task_events`
- `services::runtime::runtime_daemon::daemon_run::tests::daemon_run_emits_task_state_change_events`
- `services::runtime::runtime_project_task::task::tests::infer_human_assignee_prefers_ao_assignee_user_id`
- `services::runtime::runtime_project_task::task::tests::infer_human_assignee_prefers_git_identity_before_shell_user`
- `services::runtime::runtime_project_task::task::tests::set_task_status_in_progress_assigns_human_when_identity_is_available`
- `services::runtime::runtime_project_task::task::tests::set_task_status_in_progress_keeps_unassigned_when_identity_is_unavailable`
- `services::runtime::runtime_project_task::task::tests::set_task_status_non_in_progress_does_not_assign_human`
- `shared::parsing::tests::read_agent_status_keeps_lookup_repo_scoped_under_global_runner_scope`
- `shared::parsing::tests::read_agent_status_reads_scoped_events_and_reports_path`

Expected fix: investigate test failures in `orchestrator-core` (daemon_run, runtime_project_task) and `orchestrator-cli` (shared::parsing), fix root causes, ensure `cargo test --workspace` passes clean.