### PR TITLE
[TASK-1290] Add Cargo build caching to CI and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Compute release version
         id: version
         shell: bash

--- a/.github/workflows/rust-workspace-ci.yml
+++ b/.github/workflows/rust-workspace-ci.yml
@@ -26,6 +26,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -42,6 +44,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --locked
 
@@ -71,6 +75,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Check package
         run: cargo check --locked --all-targets -p ${{ matrix.package }}
 
@@ -88,6 +95,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Smoke test ao help
         run: cargo run --locked -p orchestrator-cli --bin ao -- --help


### PR DESCRIPTION
Automated update for task TASK-1290.

Add Cargo build caching to CI and release workflows to reduce build times.

**Current Problem:**
- Neither rust-workspace-ci.yml nor release.yml use any Cargo build cache
- Every PR and release run compiles all 16 workspace crates from scratch
- This makes CI slow and wastes compute

**Implementation:**
1. Add Swatinem/rust-cache or equivalent action to all Rust jobs in rust-workspace-ci.yml
2. Add caching to release.yml build matrix for all 4 platforms
3. Ensure cache keys include Cargo.lock to invalidate on dependency changes
4. Consider parallel job caching strategy

**Expected Impact:**
- Significantly faster CI runs on cache hits
- Reduced compute costs
- Faster feedback loop for developers

Source: REQ-284