### PR TITLE
[TASK-1169] [REQ-287] Fix ao.task.create - implement tags[] and assignee or remove from docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,6 +2,10 @@
   "mcpServers": {
     "ao": {
       "args": [
+        "run",
+        "--manifest-path",
+        "/Users/samishukri/ao-cli/crates/orchestrator-cli/Cargo.toml",
+        "--",
         "--project-root",
         "/Users/samishukri/ao-cli",
         "mcp",


### PR DESCRIPTION
Automated update for task TASK-1169.

Human review required: Task has escalated multiple times (triage rework budget exceeded). No merged PR exists. The task description is about implementing tags[] and assignee fields in TaskCreateInput or removing them from docs.

RECONCILER NOTE: Task has been escalated 4+ times without producing a PR. Based on triage decision history, the work may already be partially implemented or the task scope needs clarification.