### PR TITLE
[TASK-1295] Add Cargo build caching to all Rust CI workflows

### DIFF
--- a/.github/workflows/rust-only-dependency-policy.yml
+++ b/.github/workflows/rust-only-dependency-policy.yml
@@ -19,5 +19,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Validate dependency policy
         run: cargo test -p orchestrator-cli --test rust_only_dependency_policy


### PR DESCRIPTION
Automated update for task TASK-1295.

Add Cargo build caching configuration to all Rust CI workflows (GitHub Actions, etc.) to speed up CI builds. Use actions/cache or equivalent to cache:
- Cargo target directory
- Cargo registry cache
- sccache or ccache for native compilation

This reduces CI time and costs significantly for Rust projects.

Source: REQ-253