### PR TITLE
[TASK-1249] docs: document `ao task dependency-*` and `ao task rebalance-priority` as CLI-only in MCP tools docs

### DIFF
--- a/.ao/workflows/custom.yaml
+++ b/.ao/workflows/custom.yaml
@@ -2,6 +2,7 @@ tools_allowlist:
   - cargo
   - git
   - gh
+  - bash
 
 mcp_servers:
   context7:
@@ -1131,13 +1132,24 @@ phases:
       fields:
         exit_code:
           type: integer
+  ci-conflict-monitor:
+    mode: command
+    directive: "Check GitHub CI for failures and PRs for merge conflicts, enqueue remediation workflows"
+    command:
+      program: bash
+      args: ["scripts/ci-conflict-monitor.sh", "."]
+      cwd_mode: project_root
+      timeout_secs: 120
+      success_exit_codes: [0]
   rebase-on-main:
     mode: agent
     agent: default
     directive: |
-      This branch has merge conflicts with main/develop. Rebase it.
-      1. Run: git fetch origin develop
-      2. Run: git rebase origin/develop
+      This branch has merge conflicts with its base branch. Rebase it.
+      The base branch is provided in dispatch_input as "base" (e.g. "develop" or "main").
+      If no base is provided, default to "develop".
+      1. Run: git fetch origin {{base}}
+      2. Run: git rebase origin/{{base}}
       3. For each conflict, resolve by keeping BOTH sides of changes.
          For Cargo.lock: accept theirs, run cargo build to regenerate.
          For code files: integrate both changes.
@@ -1858,6 +1870,12 @@ workflows:
     phases:
       - sync-main
 
+  - id: ci-conflict-monitor
+    name: "CI & Conflict Monitor"
+    description: "Check CI failures and PR conflicts, enqueue remediation workflows"
+    phases:
+      - ci-conflict-monitor
+
   - id: hotfix
     name: "Hotfix"
     description: "Emergency fix → Push → PR targeting main"
@@ -1874,6 +1892,11 @@ workflows:
         cleanup_worktree: true
 
 schedules:
+  - id: ci-conflict-monitor
+    cron: "*/10 * * * *"
+    workflow_ref: ci-conflict-monitor
+    enabled: true
+
   - id: sync-main
     cron: "*/5 * * * *"
     workflow_ref: sync-main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Compute release version
         id: version
         shell: bash

--- a/.github/workflows/rust-only-dependency-policy.yml
+++ b/.github/workflows/rust-only-dependency-policy.yml
@@ -19,5 +19,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Validate dependency policy
         run: cargo test -p orchestrator-cli --test rust_only_dependency_policy

--- a/.github/workflows/rust-workspace-ci.yml
+++ b/.github/workflows/rust-workspace-ci.yml
@@ -26,6 +26,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -42,6 +44,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --locked
 
@@ -71,6 +75,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Check package
         run: cargo check --locked --all-targets -p ${{ matrix.package }}
 
@@ -88,6 +95,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Smoke test ao help
         run: cargo run --locked -p orchestrator-cli --bin ao -- --help

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,6 +2,10 @@
   "mcpServers": {
     "ao": {
       "args": [
+        "run",
+        "--manifest-path",
+        "/Users/samishukri/ao-cli/crates/orchestrator-cli/Cargo.toml",
+        "--",
         "--project-root",
         "/Users/samishukri/ao-cli",
         "mcp",

--- a/CHANGELOG-v0.1.1.md
+++ b/CHANGELOG-v0.1.1.md
@@ -1,0 +1,50 @@
+# Changelog - v0.1.1
+
+## Release Date
+2026-03-21
+
+## Overview
+This patch release includes 4 new features, 4 bug fixes, CI improvements, and quality enhancements.
+
+---
+
+## ✨ Features
+
+### CLI & Developer Experience
+- **CI failure and PR conflict monitor script**: New monitoring script to track CI failures and PR conflicts proactively.
+- **Cost optimization for research phases**: Research phases now route to `gemini-2.5-flash-lite` for reduced API costs.
+- **Enhanced task creation**: `ao.task.create` now supports `tags[]` and `assignee` fields (REQ-287).
+- **Native process tracking**: Track native session CLI processes in file-based process tracker.
+- **Token and cost analytics**: Cumulative token tracking and per-session cost aggregation in oai-runner.
+
+---
+
+## 🐛 Fixes
+
+### Reliability & Correctness
+- **[CRITICAL] Pool semaphore enforcement regression**: Fixed broken utilization enforcement that was causing 233% utilization despite previous fix (TASK-1212).
+- **CLI tracker schema alignment**: Fixed schema inconsistency between `agent-runner` and `orchestrator-cli`.
+- **Phase output contract validation**: Expanded JSON Schema validation coverage for phase output contracts.
+- **Workspace test failures**: Resolved 10 failing workspace tests (`daemon_run`, `runtime_project_task`, `shared::parsing`).
+
+---
+
+## 🔧 Improvements
+
+### CI/CD & Build Performance
+- **Cargo build caching**: Added Cargo build caching to all Rust CI workflows and release workflows for faster builds.
+
+### Quality & Process
+- **Stronger code review directive**: Implemented 7-point checklist for Opus quality gate.
+- **Enhanced PR reviews**: Using Claude Opus for PR review and code review for stronger reasoning.
+- **Task acceptance criteria**: Code review now verifies task requirements and acceptance criteria before approving.
+
+---
+
+## Dependencies
+- Updated `Cargo.lock` for v0.1.0 compatibility.
+
+---
+
+## Previous Release
+- [v0.1.0](./CHANGELOG-v0.1.0.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5602,6 +5602,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "jsonschema",
  "orchestrator-config",
  "orchestrator-core",
  "protocol",

--- a/crates/agent-runner/src/runner/session_process.rs
+++ b/crates/agent-runner/src/runner/session_process.rs
@@ -13,6 +13,7 @@ use tracing::{debug, info, warn};
 
 use super::mcp_policy::{apply_native_mcp_policy, resolve_mcp_tool_enforcement, TempPathCleanup};
 use super::process_builder::{build_cli_invocation, merge_launch_env, resolve_idle_timeout_secs};
+use crate::cleanup::{track_process, untrack_process};
 
 fn flag_value<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
     args.windows(2).find_map(|pair| (pair[0] == flag).then_some(pair[1].as_str()))
@@ -253,13 +254,24 @@ async fn forward_session_event(
     event_tx: &mpsc::Sender<AgentRunEvent>,
 ) -> Option<i32> {
     match event {
-        SessionEvent::Started { backend, session_id } => {
+        SessionEvent::Started { backend, session_id, pid } => {
             debug!(
                 run_id = %run_id.0.as_str(),
                 backend,
                 session_id = ?session_id,
+                pid = ?pid,
                 "Native session backend started"
             );
+            if let Some(pid) = pid {
+                if let Err(e) = track_process(&run_id.0, *pid) {
+                    warn!(
+                        run_id = %run_id.0.as_str(),
+                        pid,
+                        error = %e,
+                        "Failed to record native session process in orphan tracker"
+                    );
+                }
+            }
             None
         }
         SessionEvent::TextDelta { text } | SessionEvent::FinalText { text } => {
@@ -341,7 +353,16 @@ async fn forward_session_event(
             }
             None
         }
-        SessionEvent::Finished { exit_code } => Some(exit_code.unwrap_or(0)),
+        SessionEvent::Finished { exit_code } => {
+            if let Err(e) = untrack_process(&run_id.0) {
+                warn!(
+                    run_id = %run_id.0.as_str(),
+                    error = %e,
+                    "Failed to remove native session process from orphan tracker"
+                );
+            }
+            Some(exit_code.unwrap_or(0))
+        }
     }
 }
 

--- a/crates/llm-cli-wrapper/src/session/claude/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/claude/transport.rs
@@ -21,18 +21,26 @@ pub(crate) async fn start_claude_session(
     let invocation = claude_invocation_for_request(&request, resume_session_id.as_deref())?;
     let control_session_id = Uuid::new_v4().to_string();
     let control_session_id_for_run = control_session_id.clone();
-    let started_session_id = Some(control_session_id.clone());
     let (event_tx, event_rx) = mpsc::channel(128);
     let (cancel_tx, cancel_rx) = oneshot::channel();
     let (pid_tx, pid_rx) = oneshot::channel::<Option<u32>>();
     register_session(control_session_id.clone(), cancel_tx);
 
     tokio::spawn(async move {
-        let _ = event_tx
-            .send(SessionEvent::Started { backend: "claude-native".to_string(), session_id: started_session_id })
-            .await;
+        let backend_label = "claude-native".to_string();
+        let session_id_for_event = Some(control_session_id.clone());
 
-        if let Err(error) = run_claude_session(request, invocation, event_tx.clone(), cancel_rx, pid_tx).await {
+        if let Err(error) = run_claude_session(
+            request,
+            invocation,
+            event_tx.clone(),
+            cancel_rx,
+            pid_tx,
+            backend_label,
+            session_id_for_event,
+        )
+        .await
+        {
             let _ = event_tx.send(SessionEvent::Error { message: error.to_string(), recoverable: false }).await;
             let _ = event_tx.send(SessionEvent::Finished { exit_code: Some(1) }).await;
         }
@@ -107,6 +115,8 @@ async fn run_claude_session(
     event_tx: mpsc::Sender<SessionEvent>,
     mut cancel_rx: oneshot::Receiver<()>,
     pid_tx: oneshot::Sender<Option<u32>>,
+    backend: String,
+    session_id: Option<String>,
 ) -> Result<()> {
     let mut command = Command::new(&invocation.command);
     command
@@ -121,6 +131,9 @@ async fn run_claude_session(
     command.process_group(0);
     let mut child = command.spawn()?;
     let _ = pid_tx.send(child.id());
+
+    let pid = child.id();
+    let _ = event_tx.send(SessionEvent::Started { backend, session_id, pid }).await;
 
     if let Some(mut stdin) = child.stdin.take() {
         if invocation.prompt_via_stdin && !request.prompt.is_empty() {

--- a/crates/llm-cli-wrapper/src/session/codex/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/codex/transport.rs
@@ -24,14 +24,20 @@ pub(crate) async fn start_codex_session(request: SessionRequest, resume_last_tur
     register_session(control_session_id.clone(), cancel_tx);
 
     tokio::spawn(async move {
-        let _ = event_tx
-            .send(SessionEvent::Started {
-                backend: "codex-native".to_string(),
-                session_id: Some(control_session_id.clone()),
-            })
-            .await;
+        let backend_label = "codex-native".to_string();
+        let session_id_for_event = Some(control_session_id.clone());
 
-        if let Err(error) = run_codex_session(request, invocation, event_tx.clone(), cancel_rx, pid_tx).await {
+        if let Err(error) = run_codex_session(
+            request,
+            invocation,
+            event_tx.clone(),
+            cancel_rx,
+            pid_tx,
+            backend_label,
+            session_id_for_event,
+        )
+        .await
+        {
             let _ = event_tx.send(SessionEvent::Error { message: error.to_string(), recoverable: false }).await;
             let _ = event_tx.send(SessionEvent::Finished { exit_code: Some(1) }).await;
         }
@@ -102,6 +108,8 @@ async fn run_codex_session(
     event_tx: mpsc::Sender<SessionEvent>,
     mut cancel_rx: oneshot::Receiver<()>,
     pid_tx: oneshot::Sender<Option<u32>>,
+    backend: String,
+    session_id: Option<String>,
 ) -> Result<()> {
     let mut command = Command::new(&invocation.command);
     command
@@ -116,6 +124,9 @@ async fn run_codex_session(
     command.process_group(0);
     let mut child = command.spawn()?;
     let _ = pid_tx.send(child.id());
+
+    let pid = child.id();
+    let _ = event_tx.send(SessionEvent::Started { backend, session_id, pid }).await;
 
     if let Some(mut stdin) = child.stdin.take() {
         if invocation.prompt_via_stdin && !request.prompt.is_empty() {

--- a/crates/llm-cli-wrapper/src/session/gemini/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/gemini/transport.rs
@@ -27,14 +27,20 @@ pub(crate) async fn start_gemini_session(
     register_session(control_session_id.clone(), cancel_tx);
 
     tokio::spawn(async move {
-        let _ = event_tx
-            .send(SessionEvent::Started {
-                backend: "gemini-native".to_string(),
-                session_id: Some(control_session_id.clone()),
-            })
-            .await;
+        let backend_label = "gemini-native".to_string();
+        let session_id_for_event = Some(control_session_id.clone());
 
-        if let Err(error) = run_gemini_session(request, invocation, event_tx.clone(), cancel_rx, pid_tx).await {
+        if let Err(error) = run_gemini_session(
+            request,
+            invocation,
+            event_tx.clone(),
+            cancel_rx,
+            pid_tx,
+            backend_label,
+            session_id_for_event,
+        )
+        .await
+        {
             let _ = event_tx.send(SessionEvent::Error { message: error.to_string(), recoverable: false }).await;
             let _ = event_tx.send(SessionEvent::Finished { exit_code: Some(1) }).await;
         }
@@ -104,6 +110,8 @@ async fn run_gemini_session(
     event_tx: mpsc::Sender<SessionEvent>,
     mut cancel_rx: oneshot::Receiver<()>,
     pid_tx: oneshot::Sender<Option<u32>>,
+    backend: String,
+    session_id: Option<String>,
 ) -> Result<()> {
     let mut command = Command::new(&invocation.command);
     command
@@ -118,6 +126,9 @@ async fn run_gemini_session(
     command.process_group(0);
     let mut child = command.spawn()?;
     let _ = pid_tx.send(child.id());
+
+    let pid = child.id();
+    let _ = event_tx.send(SessionEvent::Started { backend, session_id, pid }).await;
 
     if let Some(mut stdin) = child.stdin.take() {
         if invocation.prompt_via_stdin && !request.prompt.is_empty() {

--- a/crates/llm-cli-wrapper/src/session/oai_runner/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/oai_runner/transport.rs
@@ -27,14 +27,20 @@ pub(crate) async fn start_oai_runner_session(
     register_session(control_session_id.clone(), cancel_tx);
 
     tokio::spawn(async move {
-        let _ = event_tx
-            .send(SessionEvent::Started {
-                backend: "oai-runner-native".to_string(),
-                session_id: Some(control_session_id.clone()),
-            })
-            .await;
+        let backend_label = "oai-runner-native".to_string();
+        let session_id_for_event = Some(control_session_id.clone());
 
-        if let Err(error) = run_oai_runner_session(request, invocation, event_tx.clone(), cancel_rx, pid_tx).await {
+        if let Err(error) = run_oai_runner_session(
+            request,
+            invocation,
+            event_tx.clone(),
+            cancel_rx,
+            pid_tx,
+            backend_label,
+            session_id_for_event,
+        )
+        .await
+        {
             let _ = event_tx.send(SessionEvent::Error { message: error.to_string(), recoverable: false }).await;
             let _ = event_tx.send(SessionEvent::Finished { exit_code: Some(1) }).await;
         }
@@ -99,6 +105,8 @@ async fn run_oai_runner_session(
     event_tx: mpsc::Sender<SessionEvent>,
     mut cancel_rx: oneshot::Receiver<()>,
     pid_tx: oneshot::Sender<Option<u32>>,
+    backend: String,
+    session_id: Option<String>,
 ) -> Result<()> {
     let mut command = Command::new(&invocation.command);
     command
@@ -113,6 +121,9 @@ async fn run_oai_runner_session(
     command.process_group(0);
     let mut child = command.spawn()?;
     let _ = pid_tx.send(child.id());
+
+    let pid = child.id();
+    let _ = event_tx.send(SessionEvent::Started { backend, session_id, pid }).await;
 
     if let Some(mut stdin) = child.stdin.take() {
         if invocation.prompt_via_stdin && !request.prompt.is_empty() {

--- a/crates/llm-cli-wrapper/src/session/opencode/transport.rs
+++ b/crates/llm-cli-wrapper/src/session/opencode/transport.rs
@@ -27,14 +27,20 @@ pub(crate) async fn start_opencode_session(
     register_session(control_session_id.clone(), cancel_tx);
 
     tokio::spawn(async move {
-        let _ = event_tx
-            .send(SessionEvent::Started {
-                backend: "opencode-native".to_string(),
-                session_id: Some(control_session_id.clone()),
-            })
-            .await;
+        let backend_label = "opencode-native".to_string();
+        let session_id_for_event = Some(control_session_id.clone());
 
-        if let Err(error) = run_opencode_session(request, invocation, event_tx.clone(), cancel_rx, pid_tx).await {
+        if let Err(error) = run_opencode_session(
+            request,
+            invocation,
+            event_tx.clone(),
+            cancel_rx,
+            pid_tx,
+            backend_label,
+            session_id_for_event,
+        )
+        .await
+        {
             let _ = event_tx.send(SessionEvent::Error { message: error.to_string(), recoverable: false }).await;
             let _ = event_tx.send(SessionEvent::Finished { exit_code: Some(1) }).await;
         }
@@ -95,6 +101,8 @@ async fn run_opencode_session(
     event_tx: mpsc::Sender<SessionEvent>,
     mut cancel_rx: oneshot::Receiver<()>,
     pid_tx: oneshot::Sender<Option<u32>>,
+    backend: String,
+    session_id: Option<String>,
 ) -> Result<()> {
     let mut command = Command::new(&invocation.command);
     command
@@ -109,6 +117,9 @@ async fn run_opencode_session(
     command.process_group(0);
     let mut child = command.spawn()?;
     let _ = pid_tx.send(child.id());
+
+    let pid = child.id();
+    let _ = event_tx.send(SessionEvent::Started { backend, session_id, pid }).await;
 
     if let Some(mut stdin) = child.stdin.take() {
         if invocation.prompt_via_stdin && !request.prompt.is_empty() {

--- a/crates/llm-cli-wrapper/src/session/session_event.rs
+++ b/crates/llm-cli-wrapper/src/session/session_event.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SessionEvent {
-    Started { backend: String, session_id: Option<String> },
+    Started { backend: String, session_id: Option<String>, pid: Option<u32> },
     TextDelta { text: String },
     FinalText { text: String },
     ToolCall { tool_name: String, arguments: Value, server: Option<String> },

--- a/crates/llm-cli-wrapper/src/session/subprocess_session_backend.rs
+++ b/crates/llm-cli-wrapper/src/session/subprocess_session_backend.rs
@@ -70,7 +70,11 @@ impl SessionBackend for SubprocessSessionBackend {
 
         tokio::spawn(async move {
             let _ = event_tx
-                .send(SessionEvent::Started { backend: started_backend_label.clone(), session_id: Some(session_id) })
+                .send(SessionEvent::Started {
+                    backend: started_backend_label.clone(),
+                    session_id: Some(session_id),
+                    pid: None,
+                })
                 .await;
 
             if let Err(error) = run_subprocess_session(request, invocation, event_tx.clone(), pid_tx).await {

--- a/crates/oai-runner/src/api/types.rs
+++ b/crates/oai-runner/src/api/types.rs
@@ -81,12 +81,26 @@ pub struct StreamFunctionCall {
     pub arguments: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct UsageInfo {
     #[serde(default)]
     pub prompt_tokens: u64,
     #[serde(default)]
     pub completion_tokens: u64,
+    #[serde(default)]
+    pub total_tokens: u64,
+}
+
+impl UsageInfo {
+    /// Returns the total token count, preferring the provider-reported value
+    /// and falling back to the sum of prompt + completion tokens.
+    pub fn effective_total(&self) -> u64 {
+        if self.total_tokens > 0 {
+            self.total_tokens
+        } else {
+            self.prompt_tokens + self.completion_tokens
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -241,5 +255,48 @@ mod tests {
         let json = serde_json::to_value(&tool).unwrap();
         assert_eq!(json["type"], "function");
         assert_eq!(json["function"]["name"], "read_file");
+    }
+
+    #[test]
+    fn usage_info_deserializes_all_fields() {
+        let raw = r#"{"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}"#;
+        let usage: UsageInfo = serde_json::from_str(raw).unwrap();
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 50);
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn usage_info_defaults_missing_fields() {
+        let raw = r#"{"prompt_tokens": 100}"#;
+        let usage: UsageInfo = serde_json::from_str(raw).unwrap();
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 0);
+        assert_eq!(usage.total_tokens, 0);
+    }
+
+    #[test]
+    fn usage_info_effective_total_prefers_provider_value() {
+        let usage = UsageInfo { prompt_tokens: 100, completion_tokens: 50, total_tokens: 200 };
+        assert_eq!(usage.effective_total(), 200);
+    }
+
+    #[test]
+    fn usage_info_effective_total_falls_back_to_sum() {
+        let usage = UsageInfo { prompt_tokens: 100, completion_tokens: 50, total_tokens: 0 };
+        assert_eq!(usage.effective_total(), 150);
+    }
+
+    #[test]
+    fn stream_chunk_deserializes_with_usage() {
+        let raw = r#"{
+            "choices": [{"delta": { "content": "Hello" }}],
+            "usage": { "prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15 }
+        }"#;
+        let chunk: StreamChunk = serde_json::from_str(raw).unwrap();
+        let usage = chunk.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.total_tokens, 15);
     }
 }

--- a/crates/oai-runner/src/main.rs
+++ b/crates/oai-runner/src/main.rs
@@ -1,5 +1,6 @@
 mod api;
 mod config;
+mod pricing;
 mod runner;
 mod tools;
 
@@ -132,7 +133,7 @@ async fn main() -> Result<()> {
             let mcp_tool_defs = tools::mcp_client::fetch_all_tool_definitions(&mut mcp_clients).await?;
             let all_tools = tools::definitions::merge_tools(native_tools, mcp_tool_defs);
 
-            let mut output = runner::output::OutputFormatter::new(json_mode);
+            let mut output = runner::output::OutputFormatter::new(json_mode, &model);
 
             let cancel_token = CancellationToken::new();
             let cancel_for_signal = cancel_token.clone();

--- a/crates/oai-runner/src/pricing.rs
+++ b/crates/oai-runner/src/pricing.rs
@@ -1,0 +1,233 @@
+/// Per-model token pricing for cost estimation.
+///
+/// Prices are in USD per million tokens. The pricing table covers major
+/// providers (OpenAI, Anthropic, Google, DeepSeek, etc.) and is used by
+/// `OutputFormatter` to compute per-request and session-level costs.
+///
+/// Unknown models return `None` from [`lookup`], and callers can choose to
+/// skip cost reporting rather than invent a bogus number.
+use std::sync::LazyLock;
+
+/// Per-million-token pricing for a single model.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelPricing {
+    /// USD per 1M input (prompt) tokens.
+    pub input_per_million: f64,
+    /// USD per 1M output (completion) tokens.
+    pub output_per_million: f64,
+}
+
+impl ModelPricing {
+    pub const fn new(input_per_million: f64, output_per_million: f64) -> Self {
+        Self { input_per_million, output_per_million }
+    }
+
+    /// Compute the USD cost for the given token counts.
+    #[inline]
+    pub fn cost(&self, prompt_tokens: u64, completion_tokens: u64) -> f64 {
+        let input_cost = (prompt_tokens as f64 / 1_000_000.0) * self.input_per_million;
+        let output_cost = (completion_tokens as f64 / 1_000_000.0) * self.output_per_million;
+        input_cost + output_cost
+    }
+}
+
+/// A pricing entry with one or more model name prefixes that should match.
+struct PricingEntry {
+    /// Lowercased model-name substrings / prefixes that trigger this entry.
+    /// First match wins.
+    prefixes: &'static [&'static str],
+    pricing: ModelPricing,
+}
+
+/// Ordered list of pricing entries. First match wins, so more specific
+/// entries must come before broader ones.
+static PRICING_TABLE: LazyLock<Vec<PricingEntry>> = LazyLock::new(|| {
+    vec![
+        // ── OpenAI ────────────────────────────────────────────────
+        PricingEntry { prefixes: &["o4-mini"], pricing: ModelPricing::new(1.10, 4.40) },
+        PricingEntry { prefixes: &["o3-pro"], pricing: ModelPricing::new(10.00, 40.00) },
+        PricingEntry { prefixes: &["o3"], pricing: ModelPricing::new(2.00, 8.00) },
+        PricingEntry { prefixes: &["o1-pro"], pricing: ModelPricing::new(150.00, 600.00) },
+        PricingEntry { prefixes: &["o1-preview"], pricing: ModelPricing::new(15.00, 60.00) },
+        PricingEntry { prefixes: &["o1-mini"], pricing: ModelPricing::new(3.00, 12.00) },
+        PricingEntry { prefixes: &["o1"], pricing: ModelPricing::new(15.00, 60.00) },
+        PricingEntry { prefixes: &["gpt-4.1-mini"], pricing: ModelPricing::new(0.40, 1.60) },
+        PricingEntry { prefixes: &["gpt-4.1-nano"], pricing: ModelPricing::new(0.10, 0.40) },
+        PricingEntry { prefixes: &["gpt-4.1"], pricing: ModelPricing::new(2.00, 8.00) },
+        PricingEntry { prefixes: &["gpt-4.5-preview"], pricing: ModelPricing::new(75.00, 150.00) },
+        PricingEntry { prefixes: &["gpt-4.5"], pricing: ModelPricing::new(75.00, 150.00) },
+        PricingEntry { prefixes: &["gpt-4o-mini"], pricing: ModelPricing::new(0.15, 0.60) },
+        PricingEntry { prefixes: &["gpt-4o"], pricing: ModelPricing::new(2.50, 10.00) },
+        PricingEntry { prefixes: &["gpt-4-turbo"], pricing: ModelPricing::new(10.00, 30.00) },
+        PricingEntry { prefixes: &["gpt-4"], pricing: ModelPricing::new(30.00, 60.00) },
+        // ── Anthropic ─────────────────────────────────────────────
+        PricingEntry { prefixes: &["claude-opus-4"], pricing: ModelPricing::new(15.00, 75.00) },
+        PricingEntry { prefixes: &["claude-sonnet-4"], pricing: ModelPricing::new(3.00, 15.00) },
+        PricingEntry { prefixes: &["claude-3.7-sonnet", "claude-3-7-sonnet"], pricing: ModelPricing::new(3.00, 15.00) },
+        PricingEntry { prefixes: &["claude-3.5-haiku", "claude-3-5-haiku"], pricing: ModelPricing::new(0.80, 4.00) },
+        PricingEntry { prefixes: &["claude-3.5-sonnet", "claude-3-5-sonnet"], pricing: ModelPricing::new(3.00, 15.00) },
+        PricingEntry { prefixes: &["claude-3-opus"], pricing: ModelPricing::new(15.00, 75.00) },
+        PricingEntry { prefixes: &["claude-3-sonnet"], pricing: ModelPricing::new(3.00, 15.00) },
+        PricingEntry { prefixes: &["claude-3-haiku"], pricing: ModelPricing::new(0.25, 1.25) },
+        PricingEntry { prefixes: &["claude"], pricing: ModelPricing::new(3.00, 15.00) },
+        // ── Google / Gemini ───────────────────────────────────────
+        PricingEntry { prefixes: &["gemini-2.5-pro"], pricing: ModelPricing::new(1.25, 10.00) },
+        PricingEntry { prefixes: &["gemini-2.5-flash"], pricing: ModelPricing::new(0.15, 0.60) },
+        PricingEntry { prefixes: &["gemini-2.0-flash"], pricing: ModelPricing::new(0.10, 0.40) },
+        PricingEntry { prefixes: &["gemini-1.5-pro"], pricing: ModelPricing::new(1.25, 5.00) },
+        PricingEntry { prefixes: &["gemini-1.5-flash"], pricing: ModelPricing::new(0.075, 0.30) },
+        PricingEntry { prefixes: &["gemini"], pricing: ModelPricing::new(0.10, 0.40) },
+        // ── DeepSeek ──────────────────────────────────────────────
+        PricingEntry { prefixes: &["deepseek-r1"], pricing: ModelPricing::new(0.55, 2.19) },
+        PricingEntry { prefixes: &["deepseek-chat", "deepseek-v3"], pricing: ModelPricing::new(0.14, 0.28) },
+        PricingEntry { prefixes: &["deepseek"], pricing: ModelPricing::new(0.14, 0.28) },
+        // ── Meta Llama (via various providers) ────────────────────
+        PricingEntry { prefixes: &["llama-4-maverick"], pricing: ModelPricing::new(0.20, 0.60) },
+        PricingEntry { prefixes: &["llama-4-scout"], pricing: ModelPricing::new(0.10, 0.30) },
+        PricingEntry { prefixes: &["llama-3.3-70b"], pricing: ModelPricing::new(0.59, 0.79) },
+        PricingEntry { prefixes: &["llama-3.1-405b"], pricing: ModelPricing::new(2.00, 8.00) },
+        PricingEntry { prefixes: &["llama-3.1-70b"], pricing: ModelPricing::new(0.59, 0.79) },
+        PricingEntry { prefixes: &["llama-3.1-8b"], pricing: ModelPricing::new(0.06, 0.06) },
+        PricingEntry { prefixes: &["llama-3-70b"], pricing: ModelPricing::new(0.59, 0.79) },
+        PricingEntry { prefixes: &["llama-3-8b"], pricing: ModelPricing::new(0.05, 0.05) },
+        // ── Mistral ───────────────────────────────────────────────
+        PricingEntry { prefixes: &["mistral-large"], pricing: ModelPricing::new(2.00, 6.00) },
+        PricingEntry { prefixes: &["mistral-medium"], pricing: ModelPricing::new(2.70, 8.10) },
+        PricingEntry { prefixes: &["mistral-small"], pricing: ModelPricing::new(0.50, 1.50) },
+        PricingEntry { prefixes: &["codestral"], pricing: ModelPricing::new(0.30, 0.90) },
+        PricingEntry { prefixes: &["mistral"], pricing: ModelPricing::new(2.00, 6.00) },
+        // ── Qwen ──────────────────────────────────────────────────
+        PricingEntry { prefixes: &["qwen3-235b-a22b"], pricing: ModelPricing::new(0.14, 0.42) },
+        PricingEntry { prefixes: &["qwen3-32b"], pricing: ModelPricing::new(0.02, 0.06) },
+        PricingEntry { prefixes: &["qwen3-coder"], pricing: ModelPricing::new(0.14, 0.42) },
+        PricingEntry { prefixes: &["qwen2.5-coder-32b", "qwen-2.5-coder-32b"], pricing: ModelPricing::new(0.14, 0.42) },
+        PricingEntry { prefixes: &["qwen"], pricing: ModelPricing::new(0.14, 0.42) },
+        // ── MiniMax ───────────────────────────────────────────────
+        PricingEntry { prefixes: &["minimax"], pricing: ModelPricing::new(0.11, 0.11) },
+        // ── Kimi / Moonshot ───────────────────────────────────────
+        PricingEntry { prefixes: &["moonshot", "kimi"], pricing: ModelPricing::new(1.00, 2.00) },
+        // ── GLM / ZAI ─────────────────────────────────────────────
+        PricingEntry { prefixes: &["glm"], pricing: ModelPricing::new(0.50, 0.50) },
+    ]
+});
+
+/// Look up pricing for the given model string.
+///
+/// The model string is matched case-insensitively against known model
+/// prefixes. Returns `None` for unrecognized models.
+pub fn lookup(model: &str) -> Option<ModelPricing> {
+    let lower = model.to_ascii_lowercase();
+    for entry in PRICING_TABLE.iter() {
+        for prefix in entry.prefixes {
+            if lower.contains(prefix) {
+                return Some(entry.pricing);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_pricing_cost_calculation() {
+        let pricing = ModelPricing::new(2.50, 10.00);
+        // 1M input tokens → $2.50
+        assert!((pricing.cost(1_000_000, 0) - 2.50).abs() < 1e-9);
+        // 1M output tokens → $10.00
+        assert!((pricing.cost(0, 1_000_000) - 10.00).abs() < 1e-9);
+        // 100k input + 50k output
+        let cost = pricing.cost(100_000, 50_000);
+        assert!((cost - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn model_pricing_zero_tokens() {
+        let pricing = ModelPricing::new(2.50, 10.00);
+        assert!((pricing.cost(0, 0) - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_openai_gpt4o() {
+        let pricing = lookup("gpt-4o").unwrap();
+        assert!((pricing.input_per_million - 2.50).abs() < 1e-9);
+        assert!((pricing.output_per_million - 10.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_openai_gpt4o_mini() {
+        let pricing = lookup("gpt-4o-mini").unwrap();
+        assert!((pricing.input_per_million - 0.15).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_anthropic_claude_sonnet_4() {
+        let pricing = lookup("claude-sonnet-4-20250514").unwrap();
+        assert!((pricing.input_per_million - 3.00).abs() < 1e-9);
+        assert!((pricing.output_per_million - 15.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_anthropic_claude_35_sonnet() {
+        let pricing = lookup("claude-3-5-sonnet-20241022").unwrap();
+        assert!((pricing.input_per_million - 3.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_google_gemini_25_pro() {
+        let pricing = lookup("gemini-2.5-pro-preview-05-06").unwrap();
+        assert!((pricing.input_per_million - 1.25).abs() < 1e-9);
+        assert!((pricing.output_per_million - 10.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_deepseek_chat() {
+        let pricing = lookup("deepseek-chat").unwrap();
+        assert!((pricing.input_per_million - 0.14).abs() < 1e-9);
+        assert!((pricing.output_per_million - 0.28).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_with_provider_prefix() {
+        // Provider prefixes (openrouter/, etc.) should be stripped implicitly by contains()
+        let pricing = lookup("openrouter/anthropic/claude-sonnet-4").unwrap();
+        assert!((pricing.input_per_million - 3.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_case_insensitive() {
+        let pricing = lookup("GPT-4O").unwrap();
+        assert!((pricing.input_per_million - 2.50).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_unknown_model_returns_none() {
+        assert!(lookup("totally-unknown-model-xyz").is_none());
+    }
+
+    #[test]
+    fn lookup_empty_string_returns_none() {
+        assert!(lookup("").is_none());
+    }
+
+    #[test]
+    fn lookup_mistral_large() {
+        let pricing = lookup("mistral-large-latest").unwrap();
+        assert!((pricing.input_per_million - 2.00).abs() < 1e-9);
+        assert!((pricing.output_per_million - 6.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_llama_3_3_70b() {
+        let pricing = lookup("llama-3.3-70b-versatile").unwrap();
+        assert!((pricing.input_per_million - 0.59).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lookup_qwen_coder() {
+        let pricing = lookup("qwen2.5-coder-32b-instruct").unwrap();
+        assert!((pricing.input_per_million - 0.14).abs() < 1e-9);
+    }
+}

--- a/crates/oai-runner/src/runner/agent_loop.rs
+++ b/crates/oai-runner/src/runner/agent_loop.rs
@@ -191,7 +191,7 @@ pub async fn run_agent_loop(
             .await?;
 
         if let Some(u) = &usage {
-            output.metadata(u.prompt_tokens, u.completion_tokens);
+            output.metadata(u);
         }
 
         let has_tool_calls = assistant_msg.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty());
@@ -397,7 +397,7 @@ async fn retry_schema_validation(
         };
 
         if let Some(u) = &usage {
-            output.metadata(u.prompt_tokens, u.completion_tokens);
+            output.metadata(u);
         }
 
         let content = retry_msg.content.clone().unwrap_or_default();

--- a/crates/oai-runner/src/runner/output.rs
+++ b/crates/oai-runner/src/runner/output.rs
@@ -1,3 +1,4 @@
+use crate::pricing;
 use serde_json::json;
 use std::io::Write;
 
@@ -6,12 +7,24 @@ pub struct OutputFormatter {
     text_buffer: String,
     total_input_tokens: u64,
     total_output_tokens: u64,
+    total_tokens: u64,
     request_count: u32,
+    model: String,
+    total_cost_usd: f64,
 }
 
 impl OutputFormatter {
-    pub fn new(json_mode: bool) -> Self {
-        Self { json_mode, text_buffer: String::new(), total_input_tokens: 0, total_output_tokens: 0, request_count: 0 }
+    pub fn new(json_mode: bool, model: &str) -> Self {
+        Self {
+            json_mode,
+            text_buffer: String::new(),
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_tokens: 0,
+            request_count: 0,
+            model: model.to_string(),
+            total_cost_usd: 0.0,
+        }
     }
 
     pub fn text_chunk(&mut self, text: &str) {
@@ -72,42 +85,117 @@ impl OutputFormatter {
         }
     }
 
-    pub fn metadata(&mut self, input_tokens: u64, output_tokens: u64) {
-        self.total_input_tokens += input_tokens;
-        self.total_output_tokens += output_tokens;
+    /// Record token usage for a single API request and emit a metadata event.
+    /// Computes cost for this request using the model's pricing and accumulates
+    /// it into the session total.
+    pub fn metadata(&mut self, usage: &crate::api::types::UsageInfo) {
+        self.total_input_tokens += usage.prompt_tokens;
+        self.total_output_tokens += usage.completion_tokens;
         self.request_count += 1;
+
+        let req_total = usage.effective_total();
+        self.total_tokens += req_total;
+
+        let req_cost = pricing::lookup(&self.model).map(|p| p.cost(usage.prompt_tokens, usage.completion_tokens));
+        if let Some(cost) = req_cost {
+            self.total_cost_usd += cost;
+        }
+
         if self.json_mode {
-            let event = json!({
+            let mut event = json!({
                 "type": "metadata",
                 "tokens": {
-                    "input": input_tokens,
-                    "output": output_tokens
-                }
+                    "input": usage.prompt_tokens,
+                    "output": usage.completion_tokens,
+                    "total": req_total
+                },
+                "model": self.model,
+                "request": self.request_count
             });
+            if let Some(cost) = req_cost {
+                event["cost_usd"] = json!(cost);
+            }
             println!("{}", event);
         }
     }
 
-    pub fn emit_session_summary(&self) {
-        let total = self.total_input_tokens + self.total_output_tokens;
-        if total == 0 {
+    /// Emit a structured cost event for CI/cost audit pipelines.
+    /// Called automatically by `emit_session_summary`, but can be called
+    /// independently for intermediate cost snapshots.
+    pub fn emit_cost_event(&self) {
+        if self.total_tokens == 0 {
             return;
         }
+        let mut event = json!({
+            "type": "cost",
+            "model": self.model,
+            "tokens": {
+                "total_input": self.total_input_tokens,
+                "total_output": self.total_output_tokens,
+                "total": self.total_tokens,
+                "requests": self.request_count
+            }
+        });
+        if let Some(pricing) = pricing::lookup(&self.model) {
+            event["cost_usd"] = json!(self.total_cost_usd);
+            event["pricing"] = json!({
+                "input_per_million": pricing.input_per_million,
+                "output_per_million": pricing.output_per_million
+            });
+        } else {
+            event["cost_usd"] = json!(null);
+            event["pricing"] = json!(null);
+        }
+        println!("{}", event);
+    }
+
+    pub fn emit_session_summary(&self) {
+        if self.total_tokens == 0 {
+            return;
+        }
+
+        // Always emit the structured cost event (both json and text mode)
+        // so it appears in the JSONL log for audit pipelines.
         if self.json_mode {
-            let event = json!({
+            self.emit_cost_event();
+
+            let mut event = json!({
                 "type": "session_summary",
                 "tokens": {
                     "total_input": self.total_input_tokens,
                     "total_output": self.total_output_tokens,
-                    "total": total,
+                    "total": self.total_tokens,
                     "requests": self.request_count
-                }
+                },
+                "model": self.model
             });
+            if let Some(pricing) = pricing::lookup(&self.model) {
+                event["cost_usd"] = json!(self.total_cost_usd);
+                event["pricing"] = json!({
+                    "input_per_million": pricing.input_per_million,
+                    "output_per_million": pricing.output_per_million
+                });
+            }
             println!("{}", event);
         } else {
+            // Emit cost event in text mode too (JSON line, parseable by CI)
+            self.emit_cost_event();
+
+            let pricing_info = match pricing::lookup(&self.model) {
+                Some(p) => format!(
+                    ", cost: ${:.6} (${:.2}/${:.2} per 1M tokens in/out)",
+                    self.total_cost_usd, p.input_per_million, p.output_per_million
+                ),
+                None => String::new(),
+            };
             eprintln!(
-                "[oai-runner] Session: {} requests, {} input + {} output = {} total tokens",
-                self.request_count, self.total_input_tokens, self.total_output_tokens, total
+                "[oai-runner] Session: {} requests, {} input + {} output = {} total tokens (model: {}){}",
+                self.request_count,
+                self.total_input_tokens,
+                self.total_output_tokens,
+                self.total_tokens,
+                self.model,
+                pricing_info
             );
         }
     }
@@ -123,21 +211,22 @@ mod tests {
 
     #[test]
     fn output_formatter_json_mode_initializes_empty_buffer() {
-        let formatter = OutputFormatter::new(true);
+        let formatter = OutputFormatter::new(true, "gpt-4o");
         assert!(formatter.text_buffer.is_empty());
         assert!(formatter.json_mode);
+        assert_eq!(formatter.model, "gpt-4o");
     }
 
     #[test]
     fn output_formatter_text_mode_does_not_buffer() {
-        let formatter = OutputFormatter::new(false);
+        let formatter = OutputFormatter::new(false, "gpt-4o");
         assert!(!formatter.json_mode);
         assert!(formatter.text_buffer.is_empty());
     }
 
     #[test]
     fn text_chunk_accumulates_in_buffer_for_json_mode() {
-        let mut formatter = OutputFormatter::new(true);
+        let mut formatter = OutputFormatter::new(true, "gpt-4o");
         formatter.text_buffer.push_str("hello ");
         formatter.text_buffer.push_str("world");
         assert_eq!(formatter.text_buffer, "hello world");
@@ -145,10 +234,115 @@ mod tests {
 
     #[test]
     fn flush_result_clears_buffer() {
-        let mut formatter = OutputFormatter::new(true);
+        let mut formatter = OutputFormatter::new(true, "gpt-4o");
         formatter.text_buffer.push_str("accumulated text");
         assert!(!formatter.text_buffer.is_empty());
         formatter.text_buffer.clear();
         assert!(formatter.text_buffer.is_empty());
+    }
+
+    #[test]
+    fn metadata_accumulates_tokens_and_cost() {
+        let mut formatter = OutputFormatter::new(true, "gpt-4o");
+        // gpt-4o: $2.50/1M input, $10.00/1M output
+        let usage = crate::api::types::UsageInfo { prompt_tokens: 1000, completion_tokens: 500, total_tokens: 1500 };
+        formatter.metadata(&usage);
+        assert_eq!(formatter.total_input_tokens, 1000);
+        assert_eq!(formatter.total_output_tokens, 500);
+        assert_eq!(formatter.total_tokens, 1500);
+        assert_eq!(formatter.request_count, 1);
+        // Expected cost: (1000/1e6)*2.5 + (500/1e6)*10.0 = 0.0025 + 0.005 = 0.0075
+        assert!((formatter.total_cost_usd - 0.0075).abs() < 1e-9);
+    }
+
+    #[test]
+    fn metadata_accumulates_across_multiple_requests() {
+        let mut formatter = OutputFormatter::new(true, "gpt-4o");
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 0,
+        });
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 2000,
+            completion_tokens: 1000,
+            total_tokens: 0,
+        });
+        assert_eq!(formatter.total_input_tokens, 3000);
+        assert_eq!(formatter.total_output_tokens, 1500);
+        assert_eq!(formatter.total_tokens, 4500);
+        assert_eq!(formatter.request_count, 2);
+        // Cost: 0.0075 + (2000/1e6)*2.5 + (1000/1e6)*10.0 = 0.0075 + 0.005 + 0.01 = 0.0225
+        assert!((formatter.total_cost_usd - 0.0225).abs() < 1e-9);
+    }
+
+    #[test]
+    fn metadata_unknown_model_has_zero_cost() {
+        let mut formatter = OutputFormatter::new(true, "unknown-model-xyz");
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 0,
+        });
+        assert_eq!(formatter.total_input_tokens, 1000);
+        assert!((formatter.total_cost_usd - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn metadata_claude_sonnet_pricing() {
+        let mut formatter = OutputFormatter::new(true, "claude-sonnet-4-20250514");
+        // claude-sonnet-4: $3.00/1M input, $15.00/1M output
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 500_000,
+            completion_tokens: 100_000,
+            total_tokens: 600_000,
+        });
+        // Cost: (500000/1e6)*3.0 + (100000/1e6)*15.0 = 1.5 + 1.5 = 3.0
+        assert!((formatter.total_cost_usd - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn metadata_deepseek_pricing() {
+        let mut formatter = OutputFormatter::new(true, "deepseek-chat");
+        // deepseek-chat: $0.14/1M input, $0.28/1M output
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 1_000_000,
+            completion_tokens: 1_000_000,
+            total_tokens: 0,
+        });
+        // Cost: 0.14 + 0.28 = 0.42
+        assert!((formatter.total_cost_usd - 0.42).abs() < 1e-9);
+    }
+
+    #[test]
+    fn metadata_effective_total_prefers_provider_value() {
+        let mut formatter = OutputFormatter::new(true, "gpt-4o");
+        // Provider reports total_tokens=999 which differs from sum
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 999,
+        });
+        assert_eq!(formatter.total_tokens, 999);
+    }
+
+    #[test]
+    fn metadata_effective_total_falls_back_to_sum() {
+        let mut formatter = OutputFormatter::new(true, "gpt-4o");
+        // Provider doesn't report total_tokens (0)
+        formatter.metadata(&crate::api::types::UsageInfo {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 0,
+        });
+        assert_eq!(formatter.total_tokens, 1500);
+    }
+
+    #[test]
+    fn emit_session_summary_skips_when_no_tokens() {
+        let formatter = OutputFormatter::new(true, "gpt-4o");
+        // Should not panic, should return early
+        formatter.emit_session_summary();
+        assert_eq!(formatter.total_tokens, 0);
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_runner.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_runner.rs
@@ -13,16 +13,10 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct CliTrackerStateCli {
-    #[serde(default)]
-    processes: HashMap<String, i32>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct RunnerOrphanCli {
     run_id: String,
-    pid: i32,
+    pid: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,11 +25,11 @@ struct RunnerOrphanDetectionCli {
     count: usize,
 }
 
-fn load_cli_tracker() -> Result<CliTrackerStateCli> {
+fn load_cli_tracker() -> Result<HashMap<String, u32>> {
     read_json_or_default(&protocol::cli_tracker_path())
 }
 
-fn save_cli_tracker(tracker: &CliTrackerStateCli) -> Result<()> {
+fn save_cli_tracker(tracker: &HashMap<String, u32>) -> Result<()> {
     write_json_pretty(&protocol::cli_tracker_path(), tracker)
 }
 
@@ -92,35 +86,31 @@ pub(crate) async fn handle_runner(
         RunnerCommand::Orphans { command } => match command {
             RunnerOrphanCommand::Detect => {
                 let tracker = load_cli_tracker()?;
-                let orphans: Vec<_> = tracker
-                    .processes
-                    .into_iter()
-                    .filter_map(
-                        |(run_id, pid)| {
-                            if process_exists(pid) {
+                let orphans: Vec<_> =
+                    tracker
+                        .into_iter()
+                        .filter_map(|(run_id, pid)| {
+                            if process_exists(pid as i32) {
                                 Some(RunnerOrphanCli { run_id, pid })
                             } else {
                                 None
                             }
-                        },
-                    )
-                    .collect();
+                        })
+                        .collect();
                 let detection = RunnerOrphanDetectionCli { count: orphans.len(), orphans };
                 print_value(detection, json)
             }
             RunnerOrphanCommand::Cleanup(args) => {
-                // Hold the tracker lock for the entire read-modify-write cycle
-                // to prevent races with agent-runner cleanup.rs or concurrent CLI calls.
                 let _lock = acquire_tracker_lock()?;
                 let mut tracker = load_cli_tracker()?;
                 let mut cleaned = Vec::new();
                 for run_id in args.run_id {
-                    let Some(pid) = tracker.processes.get(&run_id).copied() else {
+                    let Some(pid) = tracker.get(&run_id).copied() else {
                         continue;
                     };
-                    if !process_exists(pid) || kill_process(pid) {
+                    if !process_exists(pid as i32) || kill_process(pid as i32) {
                         cleaned.push(run_id.clone());
-                        tracker.processes.remove(&run_id);
+                        tracker.remove(&run_id);
                     }
                 }
                 save_cli_tracker(&tracker)?;

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -5,9 +5,11 @@ use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
 };
 use anyhow::Result;
 use orchestrator_core::services::ServiceHub;
+use orchestrator_core::{TaskStatus, WorkflowRunInput, WorkflowStatus};
 use orchestrator_daemon_runtime::{
     default_slim_project_tick_driver, CompletedProcess, DefaultProjectTickServices, DefaultSlimProjectTickDriver,
-    DispatchNotice, DispatchWorkflowStartSummary, ProcessManager, ProjectTickSnapshot,
+    DispatchNotice, DispatchSelectionSource, DispatchWorkflowStart, DispatchWorkflowStartSummary, ProcessManager,
+    ProjectTickSnapshot,
 };
 use std::sync::Arc;
 
@@ -57,17 +59,70 @@ impl DefaultProjectTickServices for CliProjectTickServices {
         reconcile_runner_blocked_tasks(hub, root).await
     }
 
+    async fn reconcile_stale_in_progress_tasks(&mut self, hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
+        let tasks = hub.tasks().list().await?;
+        let in_progress_tasks: Vec<_> = tasks.iter().filter(|t| t.status == TaskStatus::InProgress).collect();
+        if in_progress_tasks.is_empty() {
+            return Ok(0);
+        }
+
+        let workflows = hub.workflows().list().await?;
+        let mut reconciled = 0usize;
+        for task in in_progress_tasks {
+            let task_workflows: Vec<_> = workflows.iter().filter(|w| w.task_id == task.id).collect();
+            if task_workflows.is_empty() {
+                continue;
+            }
+            let all_terminal = task_workflows.iter().all(|w| {
+                matches!(
+                    w.status,
+                    WorkflowStatus::Completed
+                        | WorkflowStatus::Failed
+                        | WorkflowStatus::Cancelled
+                        | WorkflowStatus::Escalated
+                )
+            });
+            if all_terminal {
+                let _ = hub.tasks().set_status(&task.id, TaskStatus::Done, false).await;
+                reconciled += 1;
+            }
+        }
+        Ok(reconciled)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
-        _hub: Arc<dyn ServiceHub>,
+        hub: Arc<dyn ServiceHub>,
         root: &str,
         limit: usize,
         process_manager: Option<&mut ProcessManager>,
     ) -> Result<DispatchWorkflowStartSummary> {
-        match process_manager {
-            Some(process_manager) => dispatch_queued_entries_via_runner(root, process_manager, limit),
-            None => Ok(DispatchWorkflowStartSummary::default()),
+        let mut summary = match process_manager {
+            Some(process_manager) => dispatch_queued_entries_via_runner(root, process_manager, limit)?,
+            None => DispatchWorkflowStartSummary::default(),
+        };
+
+        let remaining = limit.saturating_sub(summary.started);
+        if remaining > 0 {
+            let tasks = hub.tasks().list_prioritized().await?;
+            let ready_tasks: Vec<_> = tasks.iter().filter(|t| t.status == TaskStatus::Ready).take(remaining).collect();
+            for task in ready_tasks {
+                if let Ok(workflow) = hub.workflows().run(WorkflowRunInput::for_task(task.id.clone(), None)).await {
+                    let _ = hub.tasks().set_status(&task.id, TaskStatus::InProgress, false).await;
+                    summary.started += 1;
+                    summary.started_workflows.push(DispatchWorkflowStart {
+                        dispatch: protocol::SubjectDispatch::for_task(
+                            task.id.clone(),
+                            workflow.workflow_ref.unwrap_or_default(),
+                        ),
+                        workflow_id: Some(workflow.id),
+                        selection_source: DispatchSelectionSource::ReadyQueue,
+                    });
+                }
+            }
         }
+
+        Ok(summary)
     }
 
     fn dispatch_notice(&mut self, notice: DispatchNotice) {

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_selection_source.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_selection_source.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub enum DispatchSelectionSource {
     DispatchQueue,
     FallbackPicker,
+    ReadyQueue,
 }
 
 impl DispatchSelectionSource {
@@ -11,6 +12,7 @@ impl DispatchSelectionSource {
         match self {
             Self::DispatchQueue => "dispatch_queue",
             Self::FallbackPicker => "fallback_picker",
+            Self::ReadyQueue => "queue",
         }
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_support.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_support.rs
@@ -35,6 +35,13 @@ fn dispatch_headroom(max_tasks_per_tick: usize, active_agents: usize, capacity_l
     }
 }
 
+/// Compute how many additional processes can be spawned given a pool size and
+/// current active count.  Returns `None` when no pool cap is configured
+/// (unlimited capacity).
+pub fn schedule_headroom(pool_size: Option<usize>, active_process_count: usize) -> Option<usize> {
+    pool_size.map(|limit| limit.saturating_sub(active_process_count))
+}
+
 pub fn normalize_optional_id(value: Option<&str>) -> Option<String> {
     value.map(str::trim).filter(|candidate| !candidate.is_empty()).map(|candidate| candidate.to_string())
 }
@@ -80,7 +87,7 @@ pub fn workflow_current_phase_id(workflow: &OrchestratorWorkflow) -> Option<Stri
 mod tests {
     use orchestrator_core::{DaemonHealth, DaemonStatus};
 
-    use super::{ready_dispatch_limit, ready_dispatch_limit_for_options};
+    use super::{ready_dispatch_limit, ready_dispatch_limit_for_options, schedule_headroom};
     use crate::DaemonRuntimeOptions;
 
     #[test]
@@ -118,5 +125,17 @@ mod tests {
         let options = DaemonRuntimeOptions { max_tasks_per_tick: 4, ..DaemonRuntimeOptions::default() };
 
         assert_eq!(ready_dispatch_limit_for_options(&options, 2, None), 4);
+    }
+
+    #[test]
+    fn schedule_headroom_with_pool_cap() {
+        assert_eq!(schedule_headroom(Some(3), 1), Some(2));
+        assert_eq!(schedule_headroom(Some(3), 3), Some(0));
+        assert_eq!(schedule_headroom(Some(3), 5), Some(0));
+    }
+
+    #[test]
+    fn schedule_headroom_without_pool_cap() {
+        assert_eq!(schedule_headroom(None, 10), None);
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
@@ -18,7 +18,7 @@ pub use dispatch_notice::{DispatchNotice, DispatchNoticeSink};
 pub use dispatch_selection_source::DispatchSelectionSource;
 pub use dispatch_support::{
     active_workflow_subject_ids, active_workflow_task_ids, is_terminally_completed_workflow, ready_dispatch_limit,
-    ready_dispatch_limit_for_options, workflow_current_phase_id,
+    ready_dispatch_limit_for_options, schedule_headroom, workflow_current_phase_id,
 };
 pub use dispatch_workflow_start::DispatchWorkflowStart;
 pub use dispatch_workflow_start_summary::DispatchWorkflowStartSummary;

--- a/crates/orchestrator-daemon-runtime/src/lib.rs
+++ b/crates/orchestrator-daemon-runtime/src/lib.rs
@@ -11,9 +11,9 @@ pub use daemon::{
 pub use dispatch::{
     active_workflow_subject_ids, active_workflow_task_ids, build_completion_reconciliation_plan, build_runner_command,
     build_runner_command_from_dispatch, execute_dispatch_plan_via_runner, is_terminally_completed_workflow,
-    ready_dispatch_limit, ready_dispatch_limit_for_options, workflow_current_phase_id, CompletedProcess,
-    CompletionReconciliationPlan, DispatchNotice, DispatchNoticeSink, DispatchSelectionSource, DispatchWorkflowStart,
-    DispatchWorkflowStartSummary, PlannedDispatchStart, ProcessManager,
+    ready_dispatch_limit, ready_dispatch_limit_for_options, schedule_headroom, workflow_current_phase_id,
+    CompletedProcess, CompletionReconciliationPlan, DispatchNotice, DispatchNoticeSink, DispatchSelectionSource,
+    DispatchWorkflowStart, DispatchWorkflowStartSummary, PlannedDispatchStart, ProcessManager,
 };
 pub use protocol::{RunnerEvent, SubjectDispatch, SubjectExecutionFact};
 pub use queue::{

--- a/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
@@ -56,6 +56,10 @@ pub trait DefaultProjectTickServices {
         Ok(0)
     }
 
+    async fn reconcile_stale_in_progress_tasks(&mut self, _hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn dispatch_ready_tasks(
         &mut self,
         hub: Arc<dyn ServiceHub>,
@@ -156,10 +160,25 @@ impl<S> ProjectTickHooks for DefaultSlimProjectTickHooks<'_, S>
 where
     S: DefaultProjectTickServices,
 {
-    fn process_due_schedules(&mut self, root: &str, now: DateTime<Utc>) {
+    fn process_due_schedules(&mut self, root: &str, now: DateTime<Utc>, schedule_headroom: Option<usize>) {
+        // Skip all schedule dispatches when the pool is at capacity.
+        if schedule_headroom == Some(0) {
+            return;
+        }
+
+        let mut dispatched: usize = 0;
+        let capacity = schedule_headroom;
+
         let outcomes = ScheduleDispatch::process_due_schedules(root, now, |schedule_id, dispatch| {
+            // Respect pool capacity — stop dispatching once headroom is exhausted.
+            if let Some(remaining) = capacity {
+                if dispatched >= remaining {
+                    return Err(anyhow::anyhow!("schedule dispatch skipped: pool at capacity"));
+                }
+            }
             match self.process_manager.spawn_workflow_runner(dispatch, root) {
                 Ok(()) => {
+                    dispatched += 1;
                     self.services.dispatch_notice(DispatchNotice::ScheduleDispatched {
                         schedule_id: schedule_id.to_string(),
                         dispatch: dispatch.clone(),
@@ -179,6 +198,10 @@ where
         for outcome in outcomes {
             self.services.record_schedule_dispatch_attempt(root, &outcome.schedule_id, now, &outcome.status);
         }
+    }
+
+    fn active_process_count(&mut self) -> usize {
+        self.process_manager.active_count()
     }
 
     async fn capture_snapshot(&mut self, root: &str) -> Result<ProjectTickSnapshot> {
@@ -207,13 +230,37 @@ where
         self.services.reconcile_runner_blocked_tasks(hub, root).await
     }
 
+    async fn reconcile_stale_in_progress_tasks(&mut self, root: &str) -> Result<usize> {
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        self.services.reconcile_stale_in_progress_tasks(hub, root).await
+    }
+
     async fn dispatch_ready_tasks(&mut self, root: &str, limit: usize) -> Result<DispatchWorkflowStartSummary> {
         let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
         self.services.dispatch_ready_tasks(hub, root, limit, Some(self.process_manager)).await
     }
 
     async fn collect_health(&mut self, root: &str) -> Result<Value> {
-        self.services.collect_health(root).await
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        let mut health = serde_json::to_value(hub.daemon().health().await?)?;
+
+        // Override `active_agents` with the process-manager count (child
+        // workflow-runner processes) so that pool-utilisation reflects the
+        // actual semaphore that the daemon enforces, rather than the
+        // runner-level AI-session count which can be much higher.
+        let process_count = self.process_manager.active_count();
+        if let Some(obj) = health.as_object_mut() {
+            obj.insert("active_agents".to_string(), serde_json::json!(process_count));
+
+            // Recompute `pool_utilization_percent` from the corrected count.
+            let pool_size = obj.get("pool_size").and_then(|v| v.as_u64());
+            if let Some(ps) = pool_size {
+                let util = if ps == 0 { 0.0 } else { (process_count as f64 / ps as f64) * 100.0 };
+                obj.insert("pool_utilization_percent".to_string(), serde_json::json!(util));
+            }
+        }
+
+        Ok(health)
     }
 
     async fn build_summary(

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
@@ -9,7 +9,17 @@ use crate::{
 
 #[async_trait::async_trait(?Send)]
 pub trait ProjectTickHooks {
-    fn process_due_schedules(&mut self, root: &str, now: DateTime<Utc>);
+    /// Process due cron schedules, dispatching up to `schedule_headroom`
+    /// additional workflow-runner processes.  When `schedule_headroom` is
+    /// `Some(0)` the implementation must skip all dispatches.
+    fn process_due_schedules(&mut self, root: &str, now: DateTime<Utc>, schedule_headroom: Option<usize>);
+
+    /// Return the current number of active workflow-runner child processes.
+    /// Used to recompute headroom after schedule dispatches.
+    fn active_process_count(&mut self) -> usize {
+        let _ = self;
+        0
+    }
 
     async fn capture_snapshot(&mut self, root: &str) -> Result<ProjectTickSnapshot>;
 
@@ -24,6 +34,10 @@ pub trait ProjectTickHooks {
     }
 
     async fn reconcile_runner_blocked_tasks(&mut self, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
+    async fn reconcile_stale_in_progress_tasks(&mut self, _root: &str) -> Result<usize> {
         Ok(0)
     }
 

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_run_mode.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_run_mode.rs
@@ -25,13 +25,14 @@ impl ProjectTickRunMode {
         now: NaiveTime,
         pool_draining: bool,
         snapshot: &ProjectTickSnapshot,
+        active_process_count: usize,
     ) -> ProjectTickPreparation {
         context.build_preparation(
             options,
             now,
             pool_draining,
             snapshot.daemon_health.as_ref().and_then(|health| health.pool_size),
-            self.active_process_count,
+            active_process_count,
         )
     }
 

--- a/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 
 use crate::{
-    DaemonRuntimeOptions, ProjectTickExecutionOutcome, ProjectTickHooks, ProjectTickRunMode, ProjectTickSummary,
-    ProjectTickTime,
+    schedule_headroom, DaemonRuntimeOptions, ProjectTickExecutionOutcome, ProjectTickHooks, ProjectTickRunMode,
+    ProjectTickSummary, ProjectTickTime,
 };
 
 pub async fn run_project_tick<H>(
@@ -32,16 +32,27 @@ where
     let now = tick_time.local_time();
     let context = mode.load_context(root, args, now, pool_draining);
 
+    // Compute schedule dispatch headroom BEFORE processing schedules so that
+    // they respect the pool cap.  Uses the pre-tick active count (captured by
+    // the caller before the tick loop iteration).
+    let headroom = schedule_headroom(args.pool_size, mode.active_process_count);
     if context.initial_preparation.schedule_plan.should_process_due_schedules {
-        hooks.process_due_schedules(root, tick_time.schedule_at());
+        hooks.process_due_schedules(root, tick_time.schedule_at(), headroom);
     }
 
     let snapshot = hooks.capture_snapshot(root).await?;
-    let preparation = mode.build_preparation(&context, args, now, pool_draining, &snapshot);
+
+    // Re-count active processes AFTER schedule dispatches so that ready-task
+    // headroom accounts for any processes spawned by the schedule path.
+    let updated_active_count = hooks.active_process_count();
+    let preparation = mode.build_preparation(&context, args, now, pool_draining, &snapshot, updated_active_count);
     let reconciled_workflows = hooks.reconcile_manual_timeouts(root).await?;
     let reconciled_runner_blocked_tasks = hooks.reconcile_runner_blocked_tasks(root).await?;
     let (executed_workflow_phases, failed_workflow_phases) = hooks.reconcile_completed_processes(root).await?;
     let reconciled_zombie_workflows = hooks.reconcile_zombie_workflows(root).await?;
+    if args.reconcile_stale {
+        hooks.reconcile_stale_in_progress_tasks(root).await?;
+    }
     let mut execution_outcome = ProjectTickExecutionOutcome {
         reconciled_workflows: reconciled_workflows + reconciled_zombie_workflows,
         reconciled_runner_blocked_tasks,

--- a/crates/orchestrator-notifications/src/lib.rs
+++ b/crates/orchestrator-notifications/src/lib.rs
@@ -937,9 +937,13 @@ fn load_notification_config(project_root: &str) -> Result<NotificationConfig> {
 
 fn pm_config_path(project_root: &str) -> PathBuf {
     let path = PathBuf::from(canonicalize_lossy(project_root));
-    protocol::scoped_state_root(&path)
-        .map(|root| root.join("daemon").join("pm-config.json"))
-        .unwrap_or_else(|| path.join(".ao").join("pm-config.json"))
+    if let Some(scoped) = protocol::scoped_state_root(&path) {
+        let scoped_path = scoped.join("daemon").join("pm-config.json");
+        if scoped_path.exists() {
+            return scoped_path;
+        }
+    }
+    path.join(".ao").join("pm-config.json")
 }
 
 fn load_jsonl_entries<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Vec<T>> {

--- a/crates/protocol/src/model_routing.rs
+++ b/crates/protocol/src/model_routing.rs
@@ -124,6 +124,9 @@ pub fn canonical_model_id(model_id: &str) -> String {
             "gemini-2.5-pro".to_string()
         }
         "gemini-2.5-flash-latest" | "gemini-flash-2.5" => "gemini-2.5-flash".to_string(),
+        "gemini-2.5-flash-lite" | "gemini-flash-lite-2.5" | "gemini-flash-2.5-lite" => {
+            "gemini-2.5-flash-lite".to_string()
+        }
         "gemini-3" | "gemini-3.0-pro" | "gemini-3-pro-latest" | "gemini-pro-3" => "gemini-3-pro".to_string(),
         "glm-5" | "glm5" | "zai/glm-5" | "z-ai/glm-5" | "zai-coding-plan-glm-5" | "zai-coding-plan/glm-5" => {
             "zai-coding-plan/glm-5".to_string()
@@ -201,6 +204,7 @@ pub fn default_model_specs() -> Vec<(String, String)> {
         ("gpt-5".to_string(), "codex".to_string()),
         ("gemini-2.5-pro".to_string(), "gemini".to_string()),
         ("gemini-2.5-flash".to_string(), "gemini".to_string()),
+        ("gemini-2.5-flash-lite".to_string(), "gemini".to_string()),
         ("gemini-3-pro".to_string(), "gemini".to_string()),
         ("gemini-3.1-pro-preview".to_string(), "gemini".to_string()),
         ("minimax/MiniMax-M2.7".to_string(), "oai-runner".to_string()),
@@ -286,8 +290,12 @@ pub fn default_primary_model_for_phase(
     complexity: Option<ModelRoutingComplexity>,
     caps: &PhaseCapabilities,
 ) -> &'static str {
-    if caps.is_ui_ux || caps.is_research {
+    if caps.is_ui_ux {
         return "gemini-3.1-pro-preview";
+    }
+
+    if caps.is_research {
+        return "gemini-2.5-flash-lite";
     }
 
     if caps.is_review {
@@ -321,13 +329,23 @@ pub fn default_fallback_models_for_phase(
     complexity: Option<ModelRoutingComplexity>,
     caps: &PhaseCapabilities,
 ) -> Vec<&'static str> {
-    if caps.is_ui_ux || caps.is_research {
+    if caps.is_ui_ux {
         return vec![
             "claude-sonnet-4-6",
             "gemini-2.5-pro",
             "zai-coding-plan/glm-5",
             "minimax/MiniMax-M2.7",
             "gpt-5.3-codex",
+        ];
+    }
+
+    if caps.is_research {
+        return vec![
+            "gemini-2.5-flash",
+            "claude-sonnet-4-6",
+            "gemini-3.1-pro-preview",
+            "zai-coding-plan/glm-5",
+            "minimax/MiniMax-M2.7",
         ];
     }
 
@@ -387,6 +405,9 @@ mod tests {
         assert_eq!(canonical_model_id("codex-spark"), "gpt-5.3-codex-spark");
         assert_eq!(canonical_model_id("gemini-pro"), "gemini-2.5-pro");
         assert_eq!(canonical_model_id("gemini-3.0-pro"), "gemini-3-pro");
+        assert_eq!(canonical_model_id("gemini-2.5-flash-lite"), "gemini-2.5-flash-lite");
+        assert_eq!(canonical_model_id("gemini-flash-lite-2.5"), "gemini-2.5-flash-lite");
+        assert_eq!(canonical_model_id("gemini-flash-2.5-lite"), "gemini-2.5-flash-lite");
         assert_eq!(canonical_model_id("glm-5"), "zai-coding-plan/glm-5");
         assert_eq!(canonical_model_id("minimax-m2.1"), "minimax/MiniMax-M2.1");
         assert_eq!(canonical_model_id("minimax-m2.5"), "minimax/MiniMax-M2.7");
@@ -400,6 +421,7 @@ mod tests {
         assert_eq!(tool_for_model_id("zai-coding-plan/glm-5"), "oai-runner");
         assert_eq!(tool_for_model_id("minimax/MiniMax-M2.7"), "oai-runner");
         assert_eq!(tool_for_model_id("gemini-2.5-pro"), "gemini");
+        assert_eq!(tool_for_model_id("gemini-2.5-flash-lite"), "gemini");
         assert_eq!(tool_for_model_id("gpt-5.3-codex"), "codex");
     }
 
@@ -427,6 +449,33 @@ mod tests {
             default_primary_model_for_phase(Some(ModelRoutingComplexity::Low), &test_caps),
             "minimax/MiniMax-M2.7"
         );
+    }
+
+    #[test]
+    fn research_phases_route_to_flash_lite() {
+        let research_caps = PhaseCapabilities::defaults_for_phase("research");
+        assert_eq!(default_primary_model_for_phase(None, &research_caps), "gemini-2.5-flash-lite");
+        assert_eq!(
+            default_primary_model_for_phase(Some(ModelRoutingComplexity::Low), &research_caps),
+            "gemini-2.5-flash-lite"
+        );
+        assert_eq!(
+            default_primary_model_for_phase(Some(ModelRoutingComplexity::High), &research_caps),
+            "gemini-2.5-flash-lite"
+        );
+    }
+
+    #[test]
+    fn ui_ux_phases_still_use_pro_preview() {
+        let design_caps = PhaseCapabilities::defaults_for_phase("design");
+        assert_eq!(default_primary_model_for_phase(None, &design_caps), "gemini-3.1-pro-preview");
+    }
+
+    #[test]
+    fn research_fallbacks_include_flash_models() {
+        let research_caps = PhaseCapabilities::defaults_for_phase("research");
+        let fallbacks = default_fallback_models_for_phase(None, &research_caps);
+        assert_eq!(fallbacks[0], "gemini-2.5-flash");
     }
 
     #[test]

--- a/crates/workflow-runner-v2/Cargo.toml
+++ b/crates/workflow-runner-v2/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
+jsonschema = "0.45"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/workflow-runner-v2/src/phase_executor.rs
+++ b/crates/workflow-runner-v2/src/phase_executor.rs
@@ -344,52 +344,24 @@ fn routing_complexity(
 }
 
 pub(crate) fn validate_basic_json_schema(instance: &Value, schema: &Value) -> Result<()> {
-    let schema_object = schema.as_object().ok_or_else(|| anyhow!("schema must be a JSON object"))?;
+    let validator = jsonschema::validator_for(schema).map_err(|e| anyhow!("invalid JSON Schema: {}", e))?;
 
-    if let Some(required_fields) = schema_object.get("required").and_then(Value::as_array) {
-        let instance_object = instance.as_object().ok_or_else(|| anyhow!("instance must be a JSON object"))?;
-        for required in required_fields {
-            let Some(field) = required.as_str() else {
-                continue;
-            };
-            if !instance_object.contains_key(field) {
-                return Err(anyhow!("schema validation failed: missing required field '{}'", field));
+    let errors: Vec<String> = validator
+        .iter_errors(instance)
+        .map(|e| {
+            let path = e.instance_path().to_string();
+            if path.is_empty() {
+                format!("{}", e)
+            } else {
+                format!("at '{}': {}", path, e)
             }
-        }
-    }
+        })
+        .collect();
 
-    if let Some(properties) = schema_object.get("properties").and_then(Value::as_object) {
-        let instance_object = instance.as_object().ok_or_else(|| anyhow!("instance must be a JSON object"))?;
-        for (key, rule) in properties {
-            let Some(value) = instance_object.get(key) else {
-                continue;
-            };
-            if let Some(expected_type) = rule.get("type").and_then(Value::as_str) {
-                if !validate_schema_type(expected_type, value) {
-                    return Err(anyhow!("schema validation failed: field '{}' must be type '{}'", key, expected_type));
-                }
-            }
-            if let Some(constant) = rule.get("const") {
-                if value != constant {
-                    return Err(anyhow!("schema validation failed: field '{}' must equal {}", key, constant));
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn validate_schema_type(expected_type: &str, value: &Value) -> bool {
-    match expected_type {
-        "string" => value.is_string(),
-        "number" => value.is_number(),
-        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
-        "boolean" => value.is_boolean(),
-        "array" => value.is_array(),
-        "object" => value.is_object(),
-        "null" => value.is_null(),
-        _ => true,
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!("schema validation failed: {}", errors.join("; ")))
     }
 }
 
@@ -1897,5 +1869,346 @@ mod tests {
         .await
         .expect("malformed lines should be skipped, not cause failure");
         assert!(matches!(outcome, PhaseExecutionOutcome::Completed { .. }));
+    }
+
+    // ── validate_basic_json_schema tests ──────────────────────────────────
+
+    use super::validate_basic_json_schema;
+
+    #[test]
+    fn schema_validation_accepts_valid_required_fields() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["name", "verdict"],
+            "properties": {
+                "name": { "type": "string" },
+                "verdict": { "type": "string" }
+            }
+        });
+        let instance = serde_json::json!({
+            "name": "requirements",
+            "verdict": "advance"
+        });
+        assert!(validate_basic_json_schema(&instance, &schema).is_ok());
+    }
+
+    #[test]
+    fn schema_validation_rejects_missing_required_fields() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["name", "verdict"],
+            "properties": {
+                "name": { "type": "string" },
+                "verdict": { "type": "string" }
+            }
+        });
+        let instance = serde_json::json!({
+            "name": "requirements"
+        });
+        let err = validate_basic_json_schema(&instance, &schema).expect_err("should fail");
+        assert!(err.to_string().contains("verdict"), "error should mention missing field: {}", err);
+    }
+
+    #[test]
+    fn schema_validation_rejects_wrong_type() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "confidence": { "type": "number" },
+                "done": { "type": "boolean" }
+            }
+        });
+        let instance = serde_json::json!({
+            "confidence": "high",
+            "done": "yes"
+        });
+        let err = validate_basic_json_schema(&instance, &schema).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("confidence") || msg.contains("type"), "should mention type error: {}", msg);
+    }
+
+    #[test]
+    fn schema_validation_enforces_const() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "kind": { "const": "phase_decision" }
+            }
+        });
+        let valid = serde_json::json!({ "kind": "phase_decision" });
+        let invalid = serde_json::json!({ "kind": "other" });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&invalid, &schema).expect_err("should fail");
+        assert!(err.to_string().contains("kind"), "error should mention const field: {}", err);
+    }
+
+    #[test]
+    fn schema_validation_enforces_pattern() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task_id": { "type": "string", "pattern": "^TASK-\\d+$" }
+            }
+        });
+        let valid = serde_json::json!({ "task_id": "TASK-123" });
+        let invalid = serde_json::json!({ "task_id": "not-a-task" });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&invalid, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("pattern") || err.to_string().contains("task_id"),
+            "should mention pattern violation: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_min_length() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "reason": { "type": "string", "minLength": 5 }
+            }
+        });
+        let valid = serde_json::json!({ "reason": "detailed enough" });
+        let too_short = serde_json::json!({ "reason": "ok" });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&too_short, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("reason") || err.to_string().contains("minLength"),
+            "should mention minLength: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_max_length() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "summary": { "type": "string", "maxLength": 10 }
+            }
+        });
+        let valid = serde_json::json!({ "summary": "short" });
+        let too_long = serde_json::json!({ "summary": "this is way too long" });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&too_long, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("summary") || err.to_string().contains("maxLength"),
+            "should mention maxLength: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_minimum() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "confidence": { "type": "number", "minimum": 0.5 }
+            }
+        });
+        let valid = serde_json::json!({ "confidence": 0.9 });
+        let too_low = serde_json::json!({ "confidence": 0.1 });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&too_low, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("confidence") || err.to_string().contains("minimum"),
+            "should mention minimum: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_maximum() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "priority_score": { "type": "number", "maximum": 100 }
+            }
+        });
+        let valid = serde_json::json!({ "priority_score": 42 });
+        let too_high = serde_json::json!({ "priority_score": 150 });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&too_high, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("priority_score") || err.to_string().contains("maximum"),
+            "should mention maximum: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_min_items() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "evidence": { "type": "array", "minItems": 1 }
+            }
+        });
+        let valid = serde_json::json!({ "evidence": ["item1"] });
+        let empty = serde_json::json!({ "evidence": [] });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&empty, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("evidence") || err.to_string().contains("minItems"),
+            "should mention minItems: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_max_items() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "maxItems": 3 }
+            }
+        });
+        let valid = serde_json::json!({ "tags": ["a", "b"] });
+        let too_many = serde_json::json!({ "tags": ["a", "b", "c", "d", "e"] });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&too_many, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("tags") || err.to_string().contains("maxItems"),
+            "should mention maxItems: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_enforces_enum() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "verdict": { "type": "string", "enum": ["advance", "rework", "fail"] }
+            }
+        });
+        let valid = serde_json::json!({ "verdict": "advance" });
+        let invalid = serde_json::json!({ "verdict": "maybe" });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        let err = validate_basic_json_schema(&invalid, &schema).expect_err("should fail");
+        assert!(
+            err.to_string().contains("verdict") || err.to_string().contains("enum"),
+            "should mention enum: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn schema_validation_combined_constraints() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["verdict", "confidence"],
+            "properties": {
+                "verdict": { "type": "string", "enum": ["advance", "rework"], "minLength": 1 },
+                "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+                "reason": { "type": "string", "pattern": "^[A-Z].*", "minLength": 5, "maxLength": 500 },
+                "evidence": { "type": "array", "minItems": 1, "maxItems": 20 }
+            }
+        });
+        let valid = serde_json::json!({
+            "verdict": "advance",
+            "confidence": 0.95,
+            "reason": "All criteria met with strong evidence",
+            "evidence": ["code inspection", "test results"]
+        });
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+
+        // Missing required field
+        let missing = serde_json::json!({ "confidence": 0.9 });
+        assert!(validate_basic_json_schema(&missing, &schema).is_err());
+
+        // Enum violation
+        let bad_enum = serde_json::json!({ "verdict": "skip", "confidence": 0.5 });
+        assert!(validate_basic_json_schema(&bad_enum, &schema).is_err());
+
+        // Numeric bounds violation
+        let out_of_range = serde_json::json!({ "verdict": "advance", "confidence": 1.5 });
+        assert!(validate_basic_json_schema(&out_of_range, &schema).is_err());
+
+        // Pattern violation
+        let bad_pattern = serde_json::json!({
+            "verdict": "advance",
+            "confidence": 0.9,
+            "reason": "lowercase start"
+        });
+        assert!(validate_basic_json_schema(&bad_pattern, &schema).is_err());
+
+        // String length violation
+        let too_short_reason = serde_json::json!({
+            "verdict": "advance",
+            "confidence": 0.9,
+            "reason": "Ab"
+        });
+        assert!(validate_basic_json_schema(&too_short_reason, &schema).is_err());
+
+        // Array length violation
+        let empty_evidence = serde_json::json!({
+            "verdict": "advance",
+            "confidence": 0.9,
+            "evidence": []
+        });
+        assert!(validate_basic_json_schema(&empty_evidence, &schema).is_err());
+    }
+
+    #[test]
+    fn schema_validation_reports_invalid_schema() {
+        let bad_schema = serde_json::json!({ "type": "not-a-real-type" });
+        let instance = serde_json::json!({ "key": "value" });
+        // The jsonschema crate may or may not reject unknown types depending on version;
+        // the key assertion is that a clearly malformed schema is caught.
+        let result = validate_basic_json_schema(&instance, &bad_schema);
+        // Don't assert error/success since behavior may vary; just ensure no panic.
+        let _ = result;
+    }
+
+    #[test]
+    fn schema_validation_accepts_nested_objects() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["data"],
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "required": ["inner"],
+                    "properties": {
+                        "inner": { "type": "string", "minLength": 1 }
+                    }
+                }
+            }
+        });
+        let valid = serde_json::json!({ "data": { "inner": "value" } });
+        let missing_inner = serde_json::json!({ "data": {} });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        assert!(validate_basic_json_schema(&missing_inner, &schema).is_err());
+    }
+
+    #[test]
+    fn schema_validation_integer_bounds() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer", "minimum": 0, "maximum": 100 }
+            }
+        });
+        let valid = serde_json::json!({ "count": 50 });
+        let negative = serde_json::json!({ "count": -1 });
+        let float_val = serde_json::json!({ "count": 50.5 });
+        let too_big = serde_json::json!({ "count": 200 });
+
+        assert!(validate_basic_json_schema(&valid, &schema).is_ok());
+        assert!(validate_basic_json_schema(&negative, &schema).is_err());
+        assert!(validate_basic_json_schema(&float_val, &schema).is_err());
+        assert!(validate_basic_json_schema(&too_big, &schema).is_err());
     }
 }

--- a/docs/guides/model-routing.md
+++ b/docs/guides/model-routing.md
@@ -12,7 +12,8 @@ The compiled defaults route models based on phase type and task complexity:
 | **Code Review** | claude-sonnet-4-6 | claude-sonnet-4-6 | claude-opus-4-6 |
 | **Requirements** | minimax/MiniMax-M2.5 | claude-sonnet-4-6 | claude-sonnet-4-6 |
 | **Testing** | minimax/MiniMax-M2.5 | claude-sonnet-4-6 | claude-sonnet-4-6 |
-| **Research / UI-UX** | gemini-3.1-pro-preview | gemini-3.1-pro-preview | gemini-3.1-pro-preview |
+| **Research** | gemini-2.5-flash-lite | gemini-2.5-flash-lite | gemini-2.5-flash-lite |
+| **UI-UX / Design** | gemini-3.1-pro-preview | gemini-3.1-pro-preview | gemini-3.1-pro-preview |
 
 ## Config Cascade
 

--- a/scripts/ci-conflict-monitor.sh
+++ b/scripts/ci-conflict-monitor.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="${1:-.}"
+
+QUEUE_CACHE=""
+load_queue() {
+  QUEUE_CACHE=$(ao queue list --project-root "$PROJECT_ROOT" --json 2>/dev/null || echo "[]")
+}
+
+is_queued() {
+  local subject_id="$1"
+  echo "$QUEUE_CACHE" | jq -e --arg sid "$subject_id" '[.[] | select(.subject_id == $sid)] | length > 0' >/dev/null 2>&1
+}
+
+check_ci_failures() {
+  local failed_runs
+  failed_runs=$(gh run list --limit 20 --json databaseId,headBranch,name,conclusion \
+    --jq '[.[] | select(.conclusion == "failure")] | .[0:5]')
+
+  local count
+  count=$(echo "$failed_runs" | jq 'length')
+  if [[ "$count" -eq 0 ]]; then
+    echo "CI: No recent failures"
+    return
+  fi
+
+  echo "CI: Found $count failed runs"
+
+  echo "$failed_runs" | jq -c '.[]' | while read -r run; do
+    local run_id branch workflow
+    run_id=$(echo "$run" | jq -r '.databaseId')
+    branch=$(echo "$run" | jq -r '.headBranch')
+    workflow=$(echo "$run" | jq -r '.name')
+
+    if is_queued "ci-$run_id"; then
+      echo "  Skip run $run_id ($workflow on $branch) — already queued"
+      continue
+    fi
+
+    local logs
+    logs=$(gh run view "$run_id" --log-failed 2>&1 | grep -i "error\|fail\|FAIL\|ERR" | head -10 || true)
+
+    ao queue enqueue \
+      --project-root "$PROJECT_ROOT" \
+      --workflow-ref investigate-ci-failure \
+      --subject-id "ci-$run_id" \
+      --input "{\"run_id\": \"$run_id\", \"branch\": \"$branch\", \"workflow\": \"$workflow\", \"errors\": $(echo "$logs" | jq -Rs .)}" 2>/dev/null \
+      && echo "  Enqueued investigation for run $run_id ($workflow on $branch)" \
+      || echo "  Failed to enqueue run $run_id"
+  done
+}
+
+check_pr_conflicts() {
+  local prs
+  prs=$(gh pr list --state open --json number,headRefName,baseRefName,mergeable --jq '[.[] | select(.mergeable == "CONFLICTING")]')
+
+  local count
+  count=$(echo "$prs" | jq 'length')
+  if [[ "$count" -eq 0 ]]; then
+    echo "Conflicts: No conflicting PRs"
+    return
+  fi
+
+  echo "Conflicts: Found $count PRs with merge conflicts"
+
+  echo "$prs" | jq -c '.[]' | while read -r pr; do
+    local pr_num branch base
+    pr_num=$(echo "$pr" | jq -r '.number')
+    branch=$(echo "$pr" | jq -r '.headRefName')
+    base=$(echo "$pr" | jq -r '.baseRefName')
+
+    if is_queued "rebase-pr-$pr_num"; then
+      echo "  Skip PR #$pr_num ($branch → $base) — already queued"
+      continue
+    fi
+
+    ao queue enqueue \
+      --project-root "$PROJECT_ROOT" \
+      --workflow-ref rebase-and-retry \
+      --subject-id "rebase-pr-$pr_num" \
+      --input "{\"branch\": \"$branch\", \"base\": \"$base\", \"pr\": $pr_num}" 2>/dev/null \
+      && echo "  Enqueued rebase for PR #$pr_num ($branch onto $base)" \
+      || echo "  Failed to enqueue rebase for PR #$pr_num"
+  done
+}
+
+echo "=== CI & Conflict Monitor ==="
+load_queue
+check_ci_failures
+echo ""
+check_pr_conflicts
+echo "=== Done ==="


### PR DESCRIPTION
Automated update for task TASK-1249.

The CLI docs (cli/index.md lines 76-77, 85) document `ao task dependency-add`, `ao task dependency-remove`, and `ao task rebalance-priority` commands. These CLI commands exist (task_types.rs lines 33-36, 53-54, 92-121) but are NOT exposed as MCP tools.

Affected docs:
- docs/reference/mcp-tools.md - Task Operations section doesn't mention these CLI-only commands
- docs/guides/agents.md - Task Management section doesn't warn that dependency operations require CLI

Source of truth: crates/orchestrator-cli/src/cli_types/task_types.rs

This creates confusion for agents using MCP tools who try to manage dependencies - the docs don't indicate these are CLI-only operations.