### PR TITLE
feat: configurable timeout enforcement and context-thrashing detection

### DIFF
--- a/crates/oai-runner/src/runner/agent_loop.rs
+++ b/crates/oai-runner/src/runner/agent_loop.rs
@@ -152,6 +152,9 @@ pub async fn run_agent_loop(
     };
     let api_tools = if needs_tool_name_sanitization { &sanitized_tools } else { tools };
 
+    let max_consecutive_truncations = context::DEFAULT_MAX_CONSECUTIVE_TRUNCATIONS;
+    let mut consecutive_truncations: usize = 0;
+
     for turn in 0..max_turns {
         if cancel_token.is_cancelled() {
             eprintln!("[oai-runner] Cancelled by signal");
@@ -164,7 +167,48 @@ pub async fn run_agent_loop(
             anyhow::bail!("Cancelled by shutdown signal");
         }
 
-        context::truncate_to_fit(&mut messages, context_limit, max_tokens);
+        let truncation = context::truncate_to_fit(&mut messages, context_limit, max_tokens);
+        match truncation {
+            context::TruncationResult::MessagesDropped => {
+                consecutive_truncations += 1;
+                eprintln!(
+                    "[oai-runner] Context thrashing: {} consecutive message drops (limit: {})",
+                    consecutive_truncations, max_consecutive_truncations
+                );
+                if consecutive_truncations >= max_consecutive_truncations {
+                    eprintln!(
+                        "[oai-runner] Aborting: context thrashing detected — {} consecutive turns required message drops",
+                        consecutive_truncations
+                    );
+                    if let Some(sid) = session_id {
+                        let _ = save_session_messages_to(&config_dir(), sid, &messages);
+                    }
+                    output.flush_result();
+                    if response_schema.is_some() {
+                        let fallback = synthesize_fallback(
+                            model,
+                            &format!(
+                                "Context thrashing: {} consecutive context overflows. Agent cannot make progress.",
+                                consecutive_truncations
+                            ),
+                            0.2,
+                        );
+                        let fallback_str = serde_json::to_string(&fallback).unwrap_or_default();
+                        output.text_chunk(&fallback_str);
+                        output.flush_result();
+                    }
+                    output.emit_session_summary();
+                    output.newline();
+                    anyhow::bail!(
+                        "context thrashing: {} consecutive message drops exceeded limit",
+                        consecutive_truncations
+                    );
+                }
+            }
+            context::TruncationResult::NoChange | context::TruncationResult::ContentTruncated => {
+                consecutive_truncations = 0;
+            }
+        }
 
         let format = match structured_output {
             Some(StructuredOutputSupport::JsonSchema) => response_schema.map(build_json_schema_format),

--- a/crates/oai-runner/src/runner/context.rs
+++ b/crates/oai-runner/src/runner/context.rs
@@ -31,12 +31,25 @@ pub fn estimate_total_tokens(messages: &[ChatMessage]) -> usize {
     total
 }
 
-pub fn truncate_to_fit(messages: &mut Vec<ChatMessage>, context_limit: usize, reserve_for_output: usize) {
+pub const DEFAULT_MAX_CONSECUTIVE_TRUNCATIONS: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TruncationResult {
+    NoChange,
+    ContentTruncated,
+    MessagesDropped,
+}
+
+pub fn truncate_to_fit(
+    messages: &mut Vec<ChatMessage>,
+    context_limit: usize,
+    reserve_for_output: usize,
+) -> TruncationResult {
     let target = context_limit.saturating_sub(reserve_for_output);
     let total = estimate_total_tokens(messages);
 
     if total <= target {
-        return;
+        return TruncationResult::NoChange;
     }
 
     let system_idx = messages.iter().position(|m| m.role == "system");
@@ -124,7 +137,14 @@ pub fn truncate_to_fit(messages: &mut Vec<ChatMessage>, context_limit: usize, re
                 "[oai-runner] Context management: dropped {} old messages ({} estimated tokens, limit {})",
                 count, new_total, target
             );
+            return TruncationResult::MessagesDropped;
         }
+    }
+
+    if removed > 0 {
+        TruncationResult::ContentTruncated
+    } else {
+        TruncationResult::NoChange
     }
 }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -510,6 +510,7 @@ pub(crate) async fn handle_workflow(
                     phases: args.phases.into_iter().map(orchestrator_core::WorkflowPhaseEntry::Simple).collect(),
                     post_success: None,
                     variables: Vec::new(),
+                    timeout_secs: None,
                 })
             })?;
             print_value(phases::upsert_pipeline(project_root, workflow)?, json)

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::services::runtime::execution_fact_projection::project_terminal_workflow_result;
 use crate::services::runtime::workflow_mutation_surface::cancel_orphaned_running_workflow;
 use anyhow::Result;
+use orchestrator_config::agent_runtime_config::DEFAULT_WORKFLOW_TIMEOUT_SECS;
 use orchestrator_core::{
     active_workflow_runner_ids, dispatch_workflow_event, load_agent_runtime_config_or_default, services::ServiceHub,
     WorkflowEvent, WorkflowMachineState, WorkflowStatus,
@@ -171,6 +172,90 @@ fn workflow_is_waiting_on_manual_phase(project_root: &str, workflow: &orchestrat
         .and_then(|config| config.phase_execution(&phase_id).cloned())
         .map(|definition| matches!(definition.mode, orchestrator_core::PhaseExecutionMode::Manual))
         .unwrap_or(false)
+}
+
+pub async fn reconcile_workflow_timeouts(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    cli_timeout_override: Option<u64>,
+) -> Result<usize> {
+    let workflow_config = orchestrator_core::load_workflow_config(Path::new(project_root)).unwrap_or_default();
+    let workflows = match hub.workflows().list().await {
+        Ok(workflows) => workflows,
+        Err(error) => {
+            eprintln!("{}: failed to list workflows for timeout reconciliation: {}", protocol::ACTOR_DAEMON, error);
+            return Ok(0);
+        }
+    };
+
+    let mut reconciled = 0usize;
+    let now = chrono::Utc::now();
+
+    for workflow in workflows {
+        if workflow.status != WorkflowStatus::Running {
+            continue;
+        }
+
+        let timeout_secs = cli_timeout_override
+            .or_else(|| {
+                workflow
+                    .workflow_ref
+                    .as_deref()
+                    .and_then(|wref| workflow_config.workflows.iter().find(|w| w.id == wref))
+                    .and_then(|def| def.timeout_secs)
+            })
+            .unwrap_or(DEFAULT_WORKFLOW_TIMEOUT_SECS);
+
+        if timeout_secs == 0 {
+            continue;
+        }
+
+        let elapsed = now.signed_duration_since(workflow.started_at).num_seconds().max(0) as u64;
+        if elapsed < timeout_secs {
+            continue;
+        }
+
+        let reason = format!("workflow timed out after {} seconds (limit: {}s)", elapsed, timeout_secs);
+        eprintln!(
+            "{}: cancelling timed-out workflow {} subject={} task={} — {}",
+            protocol::ACTOR_DAEMON,
+            workflow.id,
+            workflow.subject.id(),
+            workflow.task_id,
+            reason
+        );
+
+        let outcome = dispatch_workflow_event(
+            hub.clone(),
+            project_root,
+            WorkflowEvent::Cancel { workflow_id: workflow.id.clone() },
+        )
+        .await;
+
+        match outcome {
+            Ok(outcome) => {
+                if let Some(updated) = outcome.workflow {
+                    project_terminal_workflow_result(
+                        hub.clone(),
+                        project_root,
+                        updated.subject.id(),
+                        Some(updated.task_id.as_str()),
+                        updated.workflow_ref.as_deref(),
+                        Some(updated.id.as_str()),
+                        updated.status,
+                        Some(&reason),
+                    )
+                    .await;
+                }
+                reconciled = reconciled.saturating_add(1);
+            }
+            Err(error) => {
+                eprintln!("{}: failed to cancel timed-out workflow {}: {}", protocol::ACTOR_DAEMON, workflow.id, error);
+            }
+        }
+    }
+
+    Ok(reconciled)
 }
 
 pub async fn reconcile_runner_blocked_tasks(hub: Arc<dyn ServiceHub>, _project_root: &str) -> Result<usize> {

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::services::runtime::execution_fact_projection::reconcile_completed_processes;
 use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
-    reconcile_manual_phase_timeouts, reconcile_runner_blocked_tasks, recover_orphaned_running_workflows,
+    reconcile_manual_phase_timeouts, reconcile_runner_blocked_tasks, reconcile_workflow_timeouts,
+    recover_orphaned_running_workflows,
 };
 use anyhow::Result;
 use orchestrator_core::services::ServiceHub;
@@ -11,11 +12,13 @@ use orchestrator_daemon_runtime::{
 };
 use std::sync::Arc;
 
-pub(crate) struct CliProjectTickServices;
+pub(crate) struct CliProjectTickServices {
+    idle_timeout_secs: Option<u64>,
+}
 
 impl CliProjectTickServices {
-    fn new(_args: &DaemonRuntimeOptions) -> Self {
-        Self
+    fn new(args: &DaemonRuntimeOptions) -> Self {
+        Self { idle_timeout_secs: args.idle_timeout_secs }
     }
 }
 
@@ -51,6 +54,19 @@ impl DefaultProjectTickServices for CliProjectTickServices {
 
     async fn reconcile_manual_timeouts(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {
         reconcile_manual_phase_timeouts(hub, root).await
+    }
+
+    async fn reconcile_workflow_timeouts(
+        &mut self,
+        hub: Arc<dyn ServiceHub>,
+        root: &str,
+        cli_timeout_override: Option<u64>,
+    ) -> Result<usize> {
+        reconcile_workflow_timeouts(hub, root, cli_timeout_override).await
+    }
+
+    fn workflow_timeout_override(&self) -> Option<u64> {
+        self.idle_timeout_secs
     }
 
     async fn reconcile_runner_blocked_tasks(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {

--- a/crates/orchestrator-config/src/agent_runtime_config.rs
+++ b/crates/orchestrator-config/src/agent_runtime_config.rs
@@ -69,6 +69,19 @@ pub struct PhaseDecisionContract {
 
 pub const DEFAULT_MAX_REWORK_ATTEMPTS: u32 = 3;
 
+pub const DEFAULT_PHASE_TIMEOUT_SECS: u64 = 1800;
+pub const DEFAULT_TRIAGE_PHASE_TIMEOUT_SECS: u64 = 600;
+pub const DEFAULT_WORKFLOW_TIMEOUT_SECS: u64 = 2700;
+
+pub fn default_phase_timeout_secs(phase_id: &str) -> u64 {
+    let lower = phase_id.to_ascii_lowercase();
+    if lower.contains("triage") || lower.contains("requirements") || lower.contains("research") {
+        DEFAULT_TRIAGE_PHASE_TIMEOUT_SECS
+    } else {
+        DEFAULT_PHASE_TIMEOUT_SECS
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackoffConfig {
     pub initial_secs: u64,
@@ -642,6 +655,10 @@ impl AgentRuntimeConfig {
             .and_then(|definition| definition.runtime.as_ref())
             .and_then(|runtime| runtime.timeout_secs)
             .or_else(|| self.phase_agent_profile(phase_id).and_then(|profile| profile.timeout_secs))
+    }
+
+    pub fn phase_timeout_secs_with_default(&self, phase_id: &str) -> u64 {
+        self.phase_timeout_secs(phase_id).unwrap_or_else(|| default_phase_timeout_secs(phase_id))
     }
 
     pub fn phase_max_attempts(&self, phase_id: &str) -> Option<usize> {
@@ -2062,6 +2079,7 @@ cli_tools:
             phases: vec!["pack-review".to_string().into()],
             post_success: None,
             variables: Vec::new(),
+            timeout_secs: None,
         });
         crate::workflow_config::write_workflow_config(temp.path(), &workflow).expect("write workflow config");
 

--- a/crates/orchestrator-config/src/workflow_config/builtins.rs
+++ b/crates/orchestrator-config/src/workflow_config/builtins.rs
@@ -100,6 +100,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 phases: vec![WorkflowPhaseEntry::SubWorkflow(SubWorkflowRef { workflow_ref: "standard".to_string() })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: UI_UX_WORKFLOW_REF.to_string(),
@@ -110,6 +111,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: REQUIREMENT_TASK_GENERATION_WORKFLOW_REF.to_string(),
@@ -120,6 +122,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: REQUIREMENT_TASK_GENERATION_RUN_WORKFLOW_REF.to_string(),
@@ -130,6 +133,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.task/quick-fix".to_string(),
@@ -140,6 +144,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.task/gated".to_string(),
@@ -150,6 +155,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.task/triage".to_string(),
@@ -160,6 +166,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.task/refine".to_string(),
@@ -170,6 +177,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.review/cycle".to_string(),
@@ -180,6 +188,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.requirement/draft".to_string(),
@@ -190,6 +199,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.requirement/refine".to_string(),
@@ -200,6 +210,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.vision/draft".to_string(),
@@ -210,6 +221,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ao.vision/refine".to_string(),
@@ -220,6 +232,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 })],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "standard".to_string(),
@@ -234,6 +247,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 ],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
             WorkflowDefinition {
                 id: "ui-ux-standard".to_string(),
@@ -251,6 +265,7 @@ pub(crate) fn builtin_workflow_config_base() -> WorkflowConfig {
                 ],
                 post_success: None,
                 variables: Vec::new(),
+                timeout_secs: None,
             },
         ],
         phase_definitions: BTreeMap::new(),

--- a/crates/orchestrator-config/src/workflow_config/tests.rs
+++ b/crates/orchestrator-config/src/workflow_config/tests.rs
@@ -99,6 +99,7 @@ fn validation_rejects_on_verdict_targeting_nonexistent_phase() {
         max_rework_attempts: 3,
         on_verdict,
         skip_if: Vec::new(),
+        timeout_secs: None,
     });
 
     let err = validate_workflow_config(&config).expect_err("on_verdict with nonexistent target should fail validation");
@@ -120,6 +121,7 @@ fn validation_rejects_zero_max_rework_attempts() {
         max_rework_attempts: 0,
         on_verdict: HashMap::new(),
         skip_if: Vec::new(),
+        timeout_secs: None,
     });
 
     let err = validate_workflow_config(&config).expect_err("zero max_rework_attempts should fail validation");
@@ -268,6 +270,7 @@ fn resolve_workflow_skip_guards_extracts_guards_from_config() {
             max_rework_attempts: 3,
             on_verdict: HashMap::new(),
             skip_if: vec!["task_type == 'docs'".to_string()],
+            timeout_secs: None,
         }),
         "implementation".to_string().into(),
     ];
@@ -652,6 +655,7 @@ fn make_pipeline(id: &str, phases: Vec<WorkflowPhaseEntry>) -> WorkflowDefinitio
         phases,
         post_success: None,
         variables: Vec::new(),
+        timeout_secs: None,
     }
 }
 
@@ -793,6 +797,7 @@ fn expand_preserves_rich_phase_config() {
                 max_rework_attempts: 3,
                 on_verdict: on_verdict.clone(),
                 skip_if: vec!["task_type == 'docs'".into()],
+                timeout_secs: None,
             })],
         ),
         make_pipeline(
@@ -886,6 +891,7 @@ fn resolve_phase_plan_expands_sub_pipelines() {
         phases: vec![WorkflowPhaseEntry::Simple("code-review".into()), WorkflowPhaseEntry::Simple("testing".into())],
         post_success: None,
         variables: Vec::new(),
+        timeout_secs: None,
     });
 
     let standard = config.workflows.iter_mut().find(|p| p.id == "standard").expect("standard workflow");
@@ -945,6 +951,7 @@ fn validate_rejects_circular_sub_pipeline() {
             phases: vec![WorkflowPhaseEntry::SubWorkflow(SubWorkflowRef { workflow_ref: "review".into() })],
             post_success: None,
             variables: Vec::new(),
+            timeout_secs: None,
         },
         WorkflowDefinition {
             id: "review".into(),
@@ -953,6 +960,7 @@ fn validate_rejects_circular_sub_pipeline() {
             phases: vec![WorkflowPhaseEntry::SubWorkflow(SubWorkflowRef { workflow_ref: "standard".into() })],
             post_success: None,
             variables: Vec::new(),
+            timeout_secs: None,
         },
     ];
 
@@ -2102,6 +2110,7 @@ fn pipeline_variables_not_serialized_when_empty() {
         phases: Vec::new(),
         post_success: None,
         variables: Vec::new(),
+        timeout_secs: None,
     };
     let json = serde_json::to_value(&workflow).expect("serialize");
     let obj = json.as_object().expect("json object");

--- a/crates/orchestrator-config/src/workflow_config/types.rs
+++ b/crates/orchestrator-config/src/workflow_config/types.rs
@@ -52,6 +52,8 @@ pub struct WorkflowPhaseConfig {
     pub on_verdict: HashMap<String, PhaseTransitionConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skip_if: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,6 +106,13 @@ impl WorkflowPhaseEntry {
         }
     }
 
+    pub fn timeout_secs(&self) -> Option<u64> {
+        match self {
+            WorkflowPhaseEntry::Simple(_) | WorkflowPhaseEntry::SubWorkflow(_) => None,
+            WorkflowPhaseEntry::Rich(config) => config.timeout_secs,
+        }
+    }
+
     pub fn is_sub_workflow(&self) -> bool {
         matches!(self, WorkflowPhaseEntry::SubWorkflow(_))
     }
@@ -138,6 +147,8 @@ pub struct WorkflowDefinition {
     pub post_success: Option<PostSuccessConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub variables: Vec<WorkflowVariable>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/orchestrator-config/src/workflow_config/yaml_parser.rs
+++ b/crates/orchestrator-config/src/workflow_config/yaml_parser.rs
@@ -115,6 +115,7 @@ pub(super) fn workflow_phase_entry_to_yaml(entry: &WorkflowPhaseEntry) -> YamlPh
                     max_rework_attempts: config.max_rework_attempts,
                     skip_if: config.skip_if.clone(),
                     on_verdict: config.on_verdict.clone(),
+                    timeout_secs: config.timeout_secs,
                 },
             );
             YamlPhaseEntry::Rich(map)
@@ -130,6 +131,7 @@ pub(super) fn workflow_definition_to_yaml(definition: &WorkflowDefinition) -> Ya
         phases: definition.phases.iter().map(workflow_phase_entry_to_yaml).collect(),
         post_success: definition.post_success.clone().map(post_success_config_to_yaml),
         variables: definition.variables.clone(),
+        timeout_secs: definition.timeout_secs,
     }
 }
 
@@ -233,6 +235,7 @@ pub(super) fn yaml_phase_entry_to_workflow_phase_entry(entry: YamlPhaseEntry) ->
                 max_rework_attempts: config.max_rework_attempts,
                 on_verdict: config.on_verdict,
                 skip_if: config.skip_if,
+                timeout_secs: config.timeout_secs,
             }))
         }
     }
@@ -252,6 +255,7 @@ pub(super) fn yaml_workflow_to_workflow_definition(yaml: YamlWorkflowDefinition)
         phases,
         post_success,
         variables: yaml.variables,
+        timeout_secs: yaml.timeout_secs,
     })
 }
 

--- a/crates/orchestrator-config/src/workflow_config/yaml_types.rs
+++ b/crates/orchestrator-config/src/workflow_config/yaml_types.rs
@@ -23,6 +23,8 @@ pub(super) struct YamlPhaseRichConfig {
     pub(super) skip_if: Vec<String>,
     #[serde(default)]
     pub(super) on_verdict: HashMap<String, PhaseTransitionConfig>,
+    #[serde(default)]
+    pub(super) timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,6 +54,8 @@ pub(super) struct YamlWorkflowDefinition {
     pub(super) post_success: Option<YamlPostSuccessConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(super) variables: Vec<WorkflowVariable>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/orchestrator-core/src/services/tests.rs
+++ b/crates/orchestrator-core/src/services/tests.rs
@@ -734,6 +734,7 @@ async fn file_hub_uses_custom_pipeline_from_workflow_config_v2() {
         ],
         post_success: None,
         variables: Vec::new(),
+        timeout_secs: None,
     });
     crate::write_workflow_config(temp.path(), &workflow_config).expect("workflow config should be written");
 
@@ -867,6 +868,7 @@ async fn planning_execute_starts_workflows_with_config_phase_plan() {
         ],
         post_success: None,
         variables: Vec::new(),
+        timeout_secs: None,
     });
     crate::write_workflow_config(temp.path(), &workflow_config).expect("write config");
 

--- a/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
@@ -52,6 +52,19 @@ pub trait DefaultProjectTickServices {
         Ok(0)
     }
 
+    async fn reconcile_workflow_timeouts(
+        &mut self,
+        _hub: Arc<dyn ServiceHub>,
+        _root: &str,
+        _cli_timeout_override: Option<u64>,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+
+    fn workflow_timeout_override(&self) -> Option<u64> {
+        None
+    }
+
     async fn reconcile_runner_blocked_tasks(&mut self, _hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
         Ok(0)
     }
@@ -200,6 +213,11 @@ where
     async fn reconcile_manual_timeouts(&mut self, root: &str) -> Result<usize> {
         let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
         self.services.reconcile_manual_timeouts(hub, root).await
+    }
+
+    async fn reconcile_workflow_timeouts(&mut self, root: &str) -> Result<usize> {
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        self.services.reconcile_workflow_timeouts(hub, root, self.services.workflow_timeout_override()).await
     }
 
     async fn reconcile_runner_blocked_tasks(&mut self, root: &str) -> Result<usize> {

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
@@ -23,6 +23,10 @@ pub trait ProjectTickHooks {
         Ok(0)
     }
 
+    async fn reconcile_workflow_timeouts(&mut self, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn reconcile_runner_blocked_tasks(&mut self, _root: &str) -> Result<usize> {
         Ok(0)
     }

--- a/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
@@ -39,11 +39,12 @@ where
     let snapshot = hooks.capture_snapshot(root).await?;
     let preparation = mode.build_preparation(&context, args, now, pool_draining, &snapshot);
     let reconciled_workflows = hooks.reconcile_manual_timeouts(root).await?;
+    let reconciled_workflow_timeouts = hooks.reconcile_workflow_timeouts(root).await?;
     let reconciled_runner_blocked_tasks = hooks.reconcile_runner_blocked_tasks(root).await?;
     let (executed_workflow_phases, failed_workflow_phases) = hooks.reconcile_completed_processes(root).await?;
     let reconciled_zombie_workflows = hooks.reconcile_zombie_workflows(root).await?;
     let mut execution_outcome = ProjectTickExecutionOutcome {
-        reconciled_workflows: reconciled_workflows + reconciled_zombie_workflows,
+        reconciled_workflows: reconciled_workflows + reconciled_workflow_timeouts + reconciled_zombie_workflows,
         reconciled_runner_blocked_tasks,
         executed_workflow_phases,
         failed_workflow_phases,

--- a/crates/orchestrator-web-api/src/services/web_api_service/workflows_handlers.rs
+++ b/crates/orchestrator-web-api/src/services/web_api_service/workflows_handlers.rs
@@ -425,11 +425,13 @@ impl WebApiService {
                     obj.get("skip_if").and_then(|v| serde_json::from_value(v.clone()).ok()).unwrap_or_default();
                 let on_verdict: HashMap<String, orchestrator_config::workflow_config::PhaseTransitionConfig> =
                     obj.get("on_verdict").and_then(|v| serde_json::from_value(v.clone()).ok()).unwrap_or_default();
+                let timeout_secs: Option<u64> = obj.get("timeout_secs").and_then(|v| v.as_u64());
                 Ok(WorkflowPhaseEntry::Rich(WorkflowPhaseConfig {
                     id: phase_id,
                     max_rework_attempts,
                     on_verdict,
                     skip_if,
+                    timeout_secs,
                 }))
             })
             .collect::<Result<Vec<_>, WebApiError>>()?;
@@ -447,6 +449,7 @@ impl WebApiService {
             phases,
             post_success: None,
             variables,
+            timeout_secs: None,
         };
 
         if let Some(pos) = config.workflows.iter().position(|w| w.id == id) {
@@ -606,6 +609,7 @@ mod tests {
             phases: vec!["requirements".to_string().into()],
             post_success: None,
             variables: Vec::new(),
+            timeout_secs: None,
         });
         write_workflow_config(temp.path(), &workflow_config).expect("write config");
         write_agent_runtime_config(temp.path(), &builtin_agent_runtime_config()).expect("write runtime config");


### PR DESCRIPTION
## Summary
- Adds `timeout_secs` field to `WorkflowDefinition` and `WorkflowPhaseConfig` with YAML overlay support
- Implements per-phase default timeouts (30min for implementation, 10min for triage/requirements/research) via `default_phase_timeout_secs()`
- Wires workflow total timeout reconciliation into the daemon tick loop, using CLI `--idle-timeout-secs` override → per-workflow config → default (45min)
- Adds context-thrashing detection in oai-runner: aborts after 3 consecutive message truncations with a synthesized fallback response

## Test plan
- [x] `cargo ao-bin-check` passes
- [x] `cargo ao-fmt` clean
- [x] `cargo ao-lint` passes (zero errors)
- [x] `cargo test -p orchestrator-config` passes (222 tests)
- [x] `cargo test -p oai-runner` passes (4 tests)
- [ ] Manual: set `timeout_secs` in `.ao/workflows.yaml` phase config and verify enforcement
- [ ] Manual: trigger context thrashing in oai-runner and verify abort after 3 consecutive drops