### PR TITLE
[TASK-145] Structured output escalations continue post-fix — triage and implementation phases

### DIFF
--- a/crates/oai-runner/src/runner/agent_loop.rs
+++ b/crates/oai-runner/src/runner/agent_loop.rs
@@ -105,7 +105,7 @@ fn synthesize_fallback(model: &str, summary: &str, confidence: f64) -> Value {
         "commit_message": format!("Implementation by {}", model),
         "phase_decision": {
             "kind": "phase_decision",
-            "verdict": "rework",
+            "verdict": "fail",
             "confidence": confidence,
             "risk": "high",
             "reason": format!("Agent did not produce valid structured output. Summary: {}", summary)
@@ -709,10 +709,10 @@ mod tests {
     }
 
     #[test]
-    fn fallback_uses_rework_verdict() {
+    fn fallback_uses_fail_verdict_for_structured_output_failure() {
         let fallback = synthesize_fallback("test-model", "test summary", 0.4);
         let decision = &fallback["phase_decision"];
-        assert_eq!(decision["verdict"], "rework");
+        assert_eq!(decision["verdict"], "fail");
         assert_eq!(decision["confidence"], 0.4);
         assert_eq!(decision["risk"], "high");
     }


### PR DESCRIPTION
Automated update for task TASK-145.

## URGENT: Structured output escalations in triage AND implementation phases despite TASK-031/TASK-100 marked done

### Escalation Pattern
20 escalated workflows in recent history — ALL with identical failure:
```
"rework budget exceeded for phase [X] (3 reworks, max 3): 
 Agent did not produce valid structured output. Summary: "
```

### Phases Affected
- `triage` phase: TASK-028, TASK-030, TASK-031 (escalated multiple times)
- `implementation` phase: TASK-020, TASK-025, TASK-028, TASK-029, TASK-030, TASK-031, TASK-036
- Also seen: `standard` workflow failures with "schema validation failed: missing required field 'phase_decision'"

### Timeline (most recent first)
- 09:42 — TASK-036 (standard/implementation) escalated
- 09:40 — TASK-035 (triage) escalated  
- 09:37 — TASK-034 (triage) escalated
- 08:37 — TASK-030 (triage) escalated
- 08:33 — TASK-030 (triage) escalated
- 08:02 — TASK-031 (triage) escalated
- 07:10 — TASK-031 (standard/implementation) escalated
- 06:48 — TASK-029 (standard/implementation) escalated
- 06:17 — TASK-028 (standard/implementation) escalated
- 05:33 — TASK-026 (triage) escalated

### Context
- TASK-031 ("Structured output contract: schema-first parsing") was marked done at 2026-03-21 07:04
- TASK-100 ("Structured output capability registry") was marked done at 2026-03-21 17:05
- Escalations are STILL occurring AFTER these fixes

### Investigation Required
1. Were the fixes deployed/compiled into the running daemon? Check git log for when TASK-031 was merged
2. Are the fixes being applied to the correct execution path? The escalations suggest the old behavior is still active
3. Check if the triage phase prompt/definition references the structured output schema correctly
4. Verify oai-runner is using the capability registry for model selection (TASK-100)
5. The "Summary: " field is empty — this suggests the agent is failing silently, not producing ANY structured output

### Specific Failure to Debug
- Phase: triage
- Error: "Agent did not produce valid structured output" 
- The empty "Summary:" suggests the agent produces no parseable output at all
- This could indicate the triage prompt itself has issues, or the model being used doesn't support structured output

### Related Tasks
- TASK-031 (done, but escalations continue) 
- TASK-100 (done, capability registry may not be active)
- TASK-030 (agent phase YAML timeout — related to rework loop)

Tags: auto-optimizer, model-pipeline-failure, structured-output