### PR TITLE
[TASK-236] REGRESSION: "No commits between develop" PR failures STILL happening — TASK-102 not effective

### DIFF
--- a/crates/workflow-runner-v2/src/workflow_execute.rs
+++ b/crates/workflow-runner-v2/src/workflow_execute.rs
@@ -768,7 +768,9 @@ async fn execute_post_success_actions(
             "git",
             execution_cwd,
             &["log", "--oneline", &format!("origin/{}..{}", target_branch, source_branch)],
-        ).await {
+        )
+        .await
+        {
             Ok(output) if output.status.success() => {
                 let log_output = String::from_utf8_lossy(&output.stdout);
                 !log_output.trim().is_empty()


### PR DESCRIPTION
Automated update for task TASK-236.

## Issue
Despite TASK-102 ("Fix 'No commits between develop and branch' PR creation failures") being marked **done**, the "No commits between develop" error continues to appear in workflow failures.

## Evidence of Persistence
Recent failed workflows with this error:
- `7f6aceae-1854-4d0f-962b-f6f6d2891f55` (TASK-171, standard-minimax, 2026-03-22 01:06) 
- `4cb0d697-452d-44e7-ac20-7e986a3ca9d5` (TASK-131, standard-minimax, 2026-03-22 22:24)
- Multiple retries on TASK-131 showing the same error repeated 8+ times
- `a5ebf941-80c2-43cc-8ebb-90e5e2bbdc7f`, `b5a304de-9809-4cb3-98dc-cc315d52575c`, etc.

## Root Cause Analysis
The create-pr phase in standard-minimax is failing because:
1. The workflow thinks there are changes to commit
2. But git reports "No commits between develop and ao/task-XXX"
3. This suggests the push-branch phase is not actually creating commits, or commits are being made to a different branch

## Investigation Steps
1. Check if TASK-102's fix was actually applied
2. Verify the push-branch phase is creating commits correctly
3. Check if there's a branch naming mismatch (ao/task-XXX vs ao/task-XXX-1 etc.)
4. Check if the implementation phase is actually making file changes
5. Look at the git log for these specific task branches

## Pattern Observed
This error occurs primarily on standard-minimax workflows, suggesting the issue may be in the minimax-implementation phase not properly creating/modifying files before the push-branch phase runs.