### PR TITLE
fix: remove continue-on-error from rustfmt CI job

### DIFF
--- a/.github/workflows/rust-workspace-ci.yml
+++ b/.github/workflows/rust-workspace-ci.yml
@@ -16,7 +16,6 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the rustfmt CI job so formatting violations now block PRs

## Test plan
- [x] Verified no existing fmt violations (`cargo fmt --all -- --check` passes)
- [ ] CI should now fail on rustfmt violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)