### PR TITLE
fix(llm-cli-wrapper): replace hardcoded fixture paths with CARGO_MANIFEST_DIR

### DIFF
--- a/crates/llm-cli-wrapper/src/session/claude/backend.rs
+++ b/crates/llm-cli-wrapper/src/session/claude/backend.rs
@@ -189,7 +189,7 @@ mod tests {
     #[cfg(unix)]
     async fn claude_backend_emits_metadata_and_final_text_from_fixture() {
         let backend = ClaudeSessionBackend::new();
-        let fixture = "/Users/samishukri/ao-cli/crates/llm-cli-wrapper/tests/fixtures/claude_real.jsonl";
+        let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/claude_real.jsonl");
         let request = SessionRequest {
             tool: "sh".to_string(),
             model: String::new(),

--- a/crates/llm-cli-wrapper/src/session/codex/backend.rs
+++ b/crates/llm-cli-wrapper/src/session/codex/backend.rs
@@ -145,7 +145,7 @@ mod tests {
     #[cfg(unix)]
     async fn codex_backend_emits_thinking_and_final_text_from_fixture() {
         let backend = CodexSessionBackend::new();
-        let fixture = "/Users/samishukri/ao-cli/crates/llm-cli-wrapper/tests/fixtures/codex_real.jsonl";
+        let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/codex_real.jsonl");
         let request = SessionRequest {
             tool: "sh".to_string(),
             model: String::new(),

--- a/crates/llm-cli-wrapper/src/session/gemini/backend.rs
+++ b/crates/llm-cli-wrapper/src/session/gemini/backend.rs
@@ -146,7 +146,7 @@ mod tests {
     #[cfg(unix)]
     async fn gemini_backend_emits_metadata_and_final_text_from_fixture() {
         let backend = GeminiSessionBackend::new();
-        let fixture = "/Users/samishukri/ao-cli/crates/llm-cli-wrapper/tests/fixtures/gemini_real.jsonl";
+        let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/gemini_real.jsonl");
         let request = SessionRequest {
             tool: "sh".to_string(),
             model: String::new(),


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/samishukri/ao-cli/` fixture paths in claude, codex, and gemini backend tests with `concat!(env!("CARGO_MANIFEST_DIR"), ...)`
- Same root cause as #199 — these 3 tests were missed in that fix
- All 48 llm-cli-wrapper tests now pass (was 45 pass / 3 fail)

Closes the remaining fixture-path failures from #116.

## Test plan
- [x] `cargo test -p llm-cli-wrapper --lib` — 48/48 pass
- [x] `cargo fmt --check` — clean
- [x] Verified 34 orchestrator-cli failures are pre-existing on main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)