### PR TITLE
fix(orchestrator-cli): recover from poisoned env lock in tests

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_doctor.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_doctor.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn doctor_fix_creates_default_daemon_config_when_missing() {
         let temp = tempfile::tempdir().expect("tempdir should be created");
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let report = DoctorReport::run_for_project(temp.path());
         let actions = apply_doctor_fixes(temp.path().to_string_lossy().as_ref(), &report);

--- a/crates/orchestrator-cli/src/services/operations/ops_errors.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_errors.rs
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn sync_errors_ingests_notification_lifecycle_events() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
 
         let config_root = TempDir::new().expect("config temp dir");
         let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -1252,7 +1252,7 @@ fn resolve_daemon_events_project_root_uses_default_when_override_blank() {
 
 #[test]
 fn build_daemon_events_poll_result_returns_non_null_structured_events() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let config_root = TempDir::new().expect("config temp dir");
     let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
     let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -1281,7 +1281,7 @@ fn build_daemon_events_poll_result_returns_non_null_structured_events() {
 
 #[test]
 fn build_daemon_events_poll_result_filters_by_project_root() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let config_root = TempDir::new().expect("config temp dir");
     let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
     let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -1310,7 +1310,7 @@ fn build_daemon_events_poll_result_filters_by_project_root() {
 
 #[test]
 fn build_daemon_events_poll_result_blank_project_root_falls_back_to_default() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let config_root = TempDir::new().expect("config temp dir");
     let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
     let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -1393,7 +1393,7 @@ fn build_output_tail_result_rejects_unsafe_run_id() {
 
 #[test]
 fn build_output_tail_result_filters_out_events_for_other_runs() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1435,7 +1435,7 @@ fn build_output_tail_result_filters_out_events_for_other_runs() {
 
 #[test]
 fn build_output_tail_result_returns_empty_when_events_log_missing() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1463,7 +1463,7 @@ fn build_output_tail_result_returns_empty_when_events_log_missing() {
 
 #[test]
 fn build_output_tail_result_skips_invalid_utf8_log_lines() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1501,7 +1501,7 @@ fn build_output_tail_result_skips_invalid_utf8_log_lines() {
 
 #[test]
 fn build_output_tail_result_defaults_to_output_and_thinking() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1545,7 +1545,7 @@ fn build_output_tail_result_defaults_to_output_and_thinking() {
 
 #[test]
 fn build_output_tail_result_normalizes_output_stream_types() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1584,7 +1584,7 @@ fn build_output_tail_result_normalizes_output_stream_types() {
 
 #[test]
 fn build_output_tail_result_applies_filter_and_limit_in_order() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1623,7 +1623,7 @@ fn build_output_tail_result_applies_filter_and_limit_in_order() {
 
 #[test]
 fn build_output_tail_result_clamps_limit_to_minimum() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");
@@ -1653,7 +1653,7 @@ fn build_output_tail_result_clamps_limit_to_minimum() {
 
 #[test]
 fn build_output_tail_result_resolves_task_to_running_workflow_run() {
-    let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+    let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let temp = TempDir::new().expect("tempdir should be created");
     let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
     let project_root = temp.path().join("project");

--- a/crates/orchestrator-cli/src/services/operations/ops_output.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_output.rs
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn run_dir_candidates_prioritize_scoped_canonical_path() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn run_dir_candidates_fall_back_to_legacy_paths() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn get_run_jsonl_entries_prefer_canonical_path_over_legacy_fallbacks() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn get_run_jsonl_entries_keep_lookup_repo_scoped_under_global_runner_scope() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let _scope = EnvVarGuard::set("AO_RUNNER_SCOPE", Some("global"));
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn get_run_jsonl_entries_merges_deterministically_with_source_metadata() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn get_run_jsonl_entries_reads_events_persisted_via_runner_helpers() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -440,7 +440,7 @@ mod tests {
 
     #[test]
     fn get_run_jsonl_entries_supports_legacy_lookup_paths() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn get_phase_outputs_reads_persisted_payloads() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");

--- a/crates/orchestrator-cli/src/services/operations/ops_requirements/state.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_requirements/state.rs
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn load_requirements_map_falls_back_to_generated_docs_when_core_state_is_empty() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn write_generated_requirement_docs_prunes_stale_requirement_files() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
@@ -466,7 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn approve_manual_phase_continues_non_terminal_workflow() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = TempDir::new().expect("temp dir");
         let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         init_git_repo(&temp);
@@ -549,7 +549,7 @@ mod tests {
 
     #[tokio::test]
     async fn reject_manual_phase_fails_workflow() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = TempDir::new().expect("temp dir");
         let _home_guard = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         init_git_repo(&temp);

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_events.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_events.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn read_daemon_event_records_returns_ordered_tail_and_skips_invalid_lines() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let config_root = TempDir::new().expect("config temp dir");
         let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
         let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn read_daemon_event_records_filters_by_project_root() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let config_root = TempDir::new().expect("config temp dir");
         let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
         let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn poll_daemon_events_returns_metadata_and_count() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let config_root = TempDir::new().expect("config temp dir");
         let _config_guard = EnvVarGuard::set("AO_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
         let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -175,7 +175,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn lock_env() -> MutexGuard<'static, ()> {
-        crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+        crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner())
     }
 
     use protocol::test_utils::EnvVarGuard;

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_scheduler.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_scheduler.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn runtime_options_use_workflow_daemon_auto_run_ready_when_pm_config_missing() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
 
         let home_root = tempfile::TempDir::new().expect("home temp dir");
         let _home_guard = EnvVarGuard::set("HOME", Some(home_root.path().to_string_lossy().as_ref()));
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn runtime_options_keep_persisted_auto_run_ready_over_workflow_yaml() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
 
         let home_root = tempfile::TempDir::new().expect("home temp dir");
         let _home_guard = EnvVarGuard::set("HOME", Some(home_root.path().to_string_lossy().as_ref()));

--- a/crates/orchestrator-cli/src/services/runtime/runtime_project_task/task.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_project_task/task.rs
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn infer_human_assignee_prefers_ao_assignee_user_id() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_assignee = EnvVarGuard::set("AO_ASSIGNEE_USER_ID", Some("assignee-user"));
         let _ao_user = EnvVarGuard::set("AO_USER_ID", Some("ao-user"));
         let _user = EnvVarGuard::set("USER", Some("shell-user"));
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn infer_human_assignee_prefers_git_identity_before_shell_user() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_assignee = EnvVarGuard::set("AO_ASSIGNEE_USER_ID", None);
         let _ao_user = EnvVarGuard::set("AO_USER_ID", None);
         let _user = EnvVarGuard::set("USER", Some("shell-user"));
@@ -671,7 +671,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_task_status_in_progress_assigns_human_when_identity_is_available() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_assignee = EnvVarGuard::set("AO_ASSIGNEE_USER_ID", Some("operator@example.com"));
         let _ao_user = EnvVarGuard::set("AO_USER_ID", None);
 
@@ -707,7 +707,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_task_status_in_progress_keeps_unassigned_when_identity_is_unavailable() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_assignee = EnvVarGuard::set("AO_ASSIGNEE_USER_ID", None);
         let _ao_user = EnvVarGuard::set("AO_USER_ID", None);
         let _user = EnvVarGuard::set("USER", None);
@@ -745,7 +745,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_task_status_non_in_progress_does_not_assign_human() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_assignee = EnvVarGuard::set("AO_ASSIGNEE_USER_ID", Some("operator@example.com"));
 
         let hub = Arc::new(InMemoryServiceHub::new());

--- a/crates/orchestrator-cli/src/shared.rs
+++ b/crates/orchestrator-cli/src/shared.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn runner_config_dir_defaults_to_project_scope() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_config = EnvVarGuard::set("AO_CONFIG_DIR", None);
         let _legacy_config = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
         let _scope = EnvVarGuard::set("AO_RUNNER_SCOPE", None);
@@ -79,7 +79,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn runner_config_dir_shortens_long_unix_socket_paths() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _ao_config = EnvVarGuard::set("AO_CONFIG_DIR", None);
         let _legacy_config = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
         let _scope = EnvVarGuard::set("AO_RUNNER_SCOPE", None);
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn run_dir_defaults_to_scoped_runtime_runs_root() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project-root");
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn run_dir_scopes_missing_project_paths_with_protocol_fallback() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("Missing Repo 2026");
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn run_dir_stays_repo_scoped_when_runner_scope_is_global() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let override_dir = temp.path().join("override-config");
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn build_agent_context_accepts_managed_worktree_cwd() {
-        let _lock = test_env_lock().lock().expect("env lock should be available");
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
 

--- a/crates/orchestrator-cli/src/shared/parsing.rs
+++ b/crates/orchestrator-cli/src/shared/parsing.rs
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn read_agent_status_reads_scoped_events_and_reports_path() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let project_root = temp.path().join("project");
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn read_agent_status_keeps_lookup_repo_scoped_under_global_runner_scope() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
         let _scope = EnvVarGuard::set("AO_RUNNER_SCOPE", Some("global"));

--- a/crates/orchestrator-cli/src/shared/runner.rs
+++ b/crates/orchestrator-cli/src/shared/runner.rs
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn runner_config_dir_defaults_to_project_scope() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _config = EnvVarGuard::set("AO_CONFIG_DIR", None);
         let _runner_config = EnvVarGuard::set("AO_RUNNER_CONFIG_DIR", None);
         let _legacy_config = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn runner_config_dir_shortens_long_unix_socket_paths() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let long_root = Path::new("/tmp").join("a".repeat(120));
         let _config = EnvVarGuard::set("AO_CONFIG_DIR", None);
         let _runner_config = EnvVarGuard::set("AO_RUNNER_CONFIG_DIR", None);
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn build_agent_context_accepts_managed_worktree_cwd() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _config = EnvVarGuard::set("AO_CONFIG_DIR", None);
         let _runner_config = EnvVarGuard::set("AO_RUNNER_CONFIG_DIR", None);
         let _legacy_config = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn run_dir_stays_repo_scoped_when_runner_scope_is_global() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _scope = EnvVarGuard::set("AO_RUNNER_SCOPE", Some("global"));
         let project_root = "/tmp/project-root";
         let run_id = RunId("run-1234".to_string());
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn collect_json_payload_lines_parses_mixed_output() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let input = "plain text\n{\"key\":\"value\"}\nmore text\n[1,2,3]\n42\n";
         let rows = collect_json_payload_lines(input);
         assert_eq!(rows.len(), 2);
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn claude_bypass_permissions_is_disabled_by_default() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", None);
         let contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn claude_bypass_permissions_respects_disable_toggle() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", Some("false"));
         let contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -366,7 +366,7 @@ mod tests {
 
     #[test]
     fn claude_bypass_permissions_treats_empty_value_as_disabled() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", Some(""));
         let contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn inject_claude_permission_mode_override_is_disabled_by_default() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", None);
         let contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn inject_claude_permission_mode_override_respects_enable_toggle() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", Some("true"));
         let mut contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn inject_claude_permission_mode_override_respects_disable_toggle() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", Some("false"));
         let mut contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn inject_claude_permission_mode_override_treats_empty_toggle_as_disabled() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock should be available");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", Some(""));
         let mut contract =
             build_runtime_contract("claude", "claude-opus-4-1", "hello").expect("runtime contract should build");
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn build_runtime_contract_with_resume_injects_claude_session_id() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _bypass = EnvVarGuard::set("AO_CLAUDE_BYPASS_PERMISSIONS", None);
         let plan = orchestrator_core::runtime_contract::CliSessionResumePlan {
             mode: orchestrator_core::runtime_contract::CliSessionResumeMode::NativeId,
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn build_runtime_contract_with_resume_injects_gemini_resume_flag() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let plan = orchestrator_core::runtime_contract::CliSessionResumePlan {
             mode: orchestrator_core::runtime_contract::CliSessionResumeMode::NativeId,
             session_key: "wf:test-wf:research".to_string(),
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn build_runtime_contract_with_resume_codex_uses_exec_resume_last() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let plan = orchestrator_core::runtime_contract::CliSessionResumePlan {
             mode: orchestrator_core::runtime_contract::CliSessionResumeMode::NativeId,
             session_key: "wf:test-wf:implementation".to_string(),
@@ -540,7 +540,7 @@ mod tests {
 
     #[test]
     fn build_runtime_contract_without_resume_has_no_session_metadata() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let contract =
             build_runtime_contract("claude", "claude-sonnet-4-6", "hello").expect("runtime contract should build");
         let session = contract.pointer("/cli/session");
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn authenticate_runner_stream_uses_scoped_config_dir_token() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let global_dir = TempDir::new().expect("global temp dir");
         let scoped_dir = TempDir::new().expect("scoped temp dir");
         write_config(global_dir.path(), Some("global-token"));
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn authenticate_runner_stream_fails_when_scoped_token_missing() {
-        let _lock = crate::shared::test_env_lock().lock().expect("env lock");
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let scoped_dir = TempDir::new().expect("scoped temp dir");
         write_config(scoped_dir.path(), None);
         let _token_override = EnvVarGuard::set("AGENT_RUNNER_TOKEN", None);


### PR DESCRIPTION
## Summary
- Replace `.lock().expect(...)` with `.lock().unwrap_or_else(|p| p.into_inner())` on all `test_env_lock()` call sites across 13 files in `orchestrator-cli`
- When a test panics, `std::sync::Mutex` becomes poisoned. The previous `.expect()` calls caused every subsequent test to also panic, turning 1 real failure into 34 cascade failures
- The new pattern recovers the lock guard from a poisoned mutex, isolating failures to the test that actually broke

## Test plan
- [x] `cargo fmt -p orchestrator-cli` — clean
- [x] `cargo clippy -p orchestrator-cli` — no new warnings
- [x] `cargo test -p orchestrator-cli` — 272 passed, 1 failed (pre-existing `daemon_run_emits_task_state_change_events`, unrelated to this change)

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)