### PR TITLE
fix(orchestrator-config): align test assertion with standard-workflow ID rename

### DIFF
--- a/crates/orchestrator-config/src/workflow_config/tests.rs
+++ b/crates/orchestrator-config/src/workflow_config/tests.rs
@@ -27,10 +27,10 @@ fn builtin_workflow_config_includes_planning_workflow_refs() {
     let config = builtin_workflow_config();
     let workflow_ids = config.workflows.iter().map(|workflow| workflow.id.as_str()).collect::<Vec<_>>();
 
-    assert_eq!(config.default_workflow_ref, "standard");
+    assert_eq!(config.default_workflow_ref, "standard-workflow");
     assert!(workflow_ids.contains(&"ao.vision/draft"));
     assert!(workflow_ids.contains(&"ao.vision/refine"));
-    assert!(workflow_ids.contains(&"standard"));
+    assert!(workflow_ids.contains(&"standard-workflow"));
     assert!(workflow_ids.contains(&"ui-ux-standard"));
     assert!(workflow_ids.contains(&"builtin/vision-draft"));
     assert!(workflow_ids.contains(&"builtin/vision-refine"));


### PR DESCRIPTION
## Summary
- The builtin workflow ID was renamed from `"standard"` to `"standard-workflow"` but the test `builtin_workflow_config_includes_planning_workflow_refs` was not updated to match
- Updates two assertions in the test: `default_workflow_ref` check and `workflow_ids.contains` check

## Test plan
- [x] `cargo test -p orchestrator-config builtin_workflow_config_includes_planning_workflow_refs` passes
- [x] `cargo fmt` and `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)