### PR TITLE
release: v0.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.14] - 2026-06-12
+
+**The 9.5 campaign release: budgets that enforce, skills that supercharge any
+agent, a forensic chain that never dead-ends, and a smaller, honest surface.**
+Driven by an 8-surface product-owner review (baseline 6.2/10, re-reviewed at
+7.6 mid-campaign); every fix below was independently verified against the
+review findings. BREAKING items are marked.
+
 ### Added
 
 - Audited trust-on-first-use (TOFU) for plugin installs. The trusted-orgs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Cuts v0.5.14 — the 9.5-campaign release. See CHANGELOG.md for the full entry.

Highlights:
- Budget caps now ENFORCED by the daemon (housekeeping-sweep cadence, pause/fail/warn actions, per-run + fleet breach logs, `cost decisions` reader)
- Skills supercharge any agent: phase + ad-hoc + chat application, two-scope authoring, applied-skills verification, coordination coaching + FIFO memory retention
- `daemon observe` observability front-door; metrics offline fix; provider/model cost attribution; run_id forensic chain
- Project-scoped plugin installs with project lockfile; pack dependency closure + requires_plugins; manifest-driven flavor install with persisted active flavor; audited TOFU + revoke-trust
- BREAKING: `project` group deleted, `git` trimmed to inspection+prune, `self`→`update` unified, v0.5.13 aliases retired, `daemon start` always detaches, `metrics` folded under daemon

Verification: 54/54 workspace test targets + plugin-contract/agent-run e2e suites against real testkit binaries; full PO re-review mid-campaign (6.2→7.6 avg across 8 surfaces).

Merging auto-tags v0.5.14 (tag will be re-pushed manually for the bot-token workflow-trigger limitation).