### PR TITLE
release: v0.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.15] - 2026-06-12
+
+**Hooks, conformance, and provider parity.** Harness hooks (kernel `animus-hook`
+spine + claude PreToolUse policy enforcement + author-controlled agent `hooks:`),
+SDK-conformant AskUserQuestion/permission-prompt handling with structured-question
+parity across all providers, plus observability and config-validate polish.
+
 ### Added
 
 - **Harness-hook activation (claude) + agent-level author-controlled hooks.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.5.14"
+version = "0.5.15"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Cuts v0.5.15. See CHANGELOG.md for the full entry.

Highlights since v0.5.14:
- **Harness hooks**: `animus-hook` binary + compiled hook-policy evaluator (kernel spine); claude PreToolUse policy enforcement via per-session generated settings; author-controlled agent-level `hooks:` block (policy_rules + observers) with deny-wins merge semantics — a guardrail no prompt drift can bypass.
- **SDK conformance**: `animus.agent.request_approval` now emits the exact `{behavior, updatedInput}` shape the claude CLI parses; native AskUserQuestion supported with structured questions/answers; `--select`/`--remember`/`--updated-input` answer surface.
- **Provider parity**: structured `questions[]` on `animus.agent.ask` gives codex/gemini/opencode the same expressiveness as claude's native channel.
- Observability + config-validate polish; runner v0.4.4 + oai-agent v0.1.5 pins (phase skills live in production; all providers have MCP + approvals).

Verification: full workspace suite green (incl. plugin-contract/agent-run e2e against testkit binaries); hook-policy + interaction conformance golden tests.

Merging auto-tags v0.5.15 (tag re-pushed manually for the bot-token workflow-trigger limitation).