### PR TITLE
release: v0.5.16 — daemon queue-dispatch reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.16] - 2026-06-16
+
+**Daemon queue-dispatch reliability.** The enqueue → lease → run → drain
+pipeline now works end to end — two compounding bugs that stranded queued work
+are fixed — plus foreign-skill log-spam suppression.
+
+### Fixed
+
+- **Dispatch queue never drained — leases were starved.** The daemon eagerly
+  spawned every installed `subject_backend` plugin at startup and held them
+  alive, exhausting the plugin-process cap (50). The queue plugin's
+  spawn-per-call lease was then refused, so enqueued work sat `pending` forever.
+  Subject plugins now spawn **lazily** on first route to their kind (bounded LRU
+  host cache with lease-pinning + per-plugin spawn locks), so a project only
+  spins up the backends it actually uses.
+- **Completed queue entries were stranded as `assigned`.** The
+  `queue/completion` request passed the real run `workflow_id`, which never
+  matched the id the queue plugin synthesizes at lease time, so the plugin
+  refused to prune the entry. The daemon now omits it (the unique `entry_id` +
+  `workflow_ref` identify the entry), so dispatches drain
+  `pending → assigned → completed → gone`.
+- **Daemon foreign-skill parse-warning spam.** The daemon no longer sprays
+  `could not parse markdown skill` warnings for foreign agent-host skill dirs
+  (`~/.claude`, `~/.codex`, `~/.cursor`, `~/.config/opencode`) on every tick,
+  which could bloat `daemon.log` and fill the disk.
+
 ### Changed
 
 - **`animus mcp auth` auto-detects advertised OAuth scopes.** When neither

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/animus-mcp-oauth/tests/auth_scope.rs
+++ b/crates/animus-mcp-oauth/tests/auth_scope.rs
@@ -319,6 +319,7 @@ async fn consent_callback_sees_auto_detected_scopes() {
     let (base, _state) = spawn_as().await;
     let root = project_root();
 
+    #[allow(clippy::type_complexity)]
     let seen: Arc<std::sync::Mutex<Option<(Vec<String>, bool)>>> = Arc::new(std::sync::Mutex::new(None));
     let seen_cb = seen.clone();
     let opts = RunAuthOptions {

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.5.15"
+version = "0.5.16"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/operations/ops_init.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_init.rs
@@ -1925,7 +1925,6 @@ mod tests {
         run_walkthrough(&args_no_packs, project.path(), InitMode::NonInteractive, true)
             .await
             .expect("plan should succeed");
-        ();
 
         // --no-packs with --install-packs: no_packs wins
         let args_conflict = InitArgs {
@@ -1946,6 +1945,5 @@ mod tests {
         run_walkthrough(&args_conflict, project.path(), InitMode::NonInteractive, true)
             .await
             .expect("plan should succeed with conflicting flags");
-        ();
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_subject.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_subject.rs
@@ -829,6 +829,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // The test-env serialization lock is intentionally held across the await to
+    // keep HOME / the disable-plugins env stable for the whole async test body.
+    #[allow(clippy::await_holding_lock)]
     async fn run_subject_batch_continue_marks_each_item_failed_without_backend() {
         // Isolated from any globally installed subject plugins (codex review
         // P2): pin HOME to a temp dir and force subject plugin discovery off


### PR DESCRIPTION
Patch release. Ships the daemon queue-dispatch reliability fixes already merged to main, plus the foreign-skill log-spam suppression.

## Fixed
- **Dispatch queue never drained — leases starved.** Daemon eagerly spawned every installed subject_backend plugin at startup, exhausting the 50 plugin-process cap and refusing the queue plugin's spawn-per-call lease. Subject plugins now spawn lazily on first route (bounded LRU cache + per-plugin spawn locks). Verified: a project only spins up the backends it uses.
- **Completed entries stranded as `assigned`.** queue/completion passed the real run workflow_id, which never matched the plugin's synthesized id, so the plugin refused to prune the entry. Now omits it (entry_id + workflow_ref identify it). Verified end-to-end: `pending → assigned → completed → drained`.
- **Daemon foreign-skill parse-warning spam** suppressed (could fill the disk).

Merging this `release/` PR auto-tags `v0.5.16` and triggers the binary release.