### PR TITLE
release: v0.5.17 — plugin release/update hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.17] - 2026-06-16
+
+**Plugin release/update hardening.** Recommend the binary-shipping queue plugin,
+and warn loudly when a stale one is installed.
+
+### Changed
+
+- **Recommended `animus-queue-default` pin bumped v0.3.0 → v0.3.3.** v0.3.0
+  shipped no release binaries (so `animus plugin install …@vX` and `plugin
+  update` failed with "no release asset matched platform") and predated the
+  dedup-safe enqueue + precise-wake fixes. v0.3.3 is the first release that
+  ships platform binaries.
+
+### Added
+
+- **Stale queue-plugin preflight warning.** The daemon surfaces a non-fatal
+  warning at startup when an installed `queue` plugin is below the precise-wake
+  floor (v0.3.2) — "lacks precise-wake … upgrade with `animus plugin update`" —
+  instead of silently falling back to the heartbeat for reactive dispatch.
+  Mirrors the existing workflow-runner under-pin warning.
+
 ## [0.5.16] - 2026-06-16
 
 **Daemon queue-dispatch reliability.** The enqueue → lease → run → drain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.5.16"
+version = "0.5.17"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Patch release. Plugin release/update hardening (the second half of the queue-dispatch work).

## Changed
- Bump recommended `animus-queue-default` pin **v0.3.0 → v0.3.3** — the first release that ships platform binaries (v0.3.0 had none, so `plugin install @vX` / `plugin update` failed) and that carries the dedup-safe enqueue + precise-wake fixes.

## Added
- Stale queue-plugin **preflight warning** at daemon start (below precise-wake floor v0.3.2) — mirrors the workflow-runner under-pin warning, so a stale queue plugin fails loudly instead of silently degrading reactive dispatch.

Merging auto-tags v0.5.17 and triggers the binary release.