### PR TITLE
Release 0.5.20 — preflight requires any subject backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.20] - 2026-06-17
+
+**Preflight requires any subject backend, not forced task/requirement kinds.**
+The daemon preflight required-role set hard-coded `subject_kind:task` and
+`subject_kind:requirement`, forcing every deployment to install those two
+specific backends even when a single custom subject backend (e.g. a Postgres
+`kind=song` backend) was the only subject store in use. This was a design flaw:
+the daemon should require *a* working subject backend, not dictate which kinds
+it serves.
+
+### Changed
+
+- **`RequiredRole::AtLeastOneSubjectBackend` replaces the hard-coded
+  `SubjectKind("task")` + `SubjectKind("requirement")` roles** in
+  `PluginPreflightSpec::daemon_default()`. Preflight now passes when any
+  `subject_backend` plugin is installed, regardless of the subject kinds it
+  claims. Auto-install maps the new role to `animus-subject-default`. The
+  `SubjectKind(_)` variant is retained for custom specs but is no longer part of
+  the daemon default. The doctor `plugins` check mirrors the same posture.
+
 ## [0.5.19] - 2026-06-16
 
 **Queue-enqueue plugin-subject fallback.** Control-routed `queue/enqueue`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.5.19"
+version = "0.5.20"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/operations/ops_doctor/checks_plugins.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_doctor/checks_plugins.rs
@@ -46,6 +46,7 @@ pub(crate) fn run(ctx: &CheckContext) -> Vec<DiagnosticCheck> {
         let satisfied = match role {
             RequiredRole::AtLeastOneProvider => summaries.iter().any(|s| s.is_provider()),
             RequiredRole::SubjectKind(kind) => summaries.iter().any(|s| s.covers_subject_kind(kind)),
+            RequiredRole::AtLeastOneSubjectBackend => summaries.iter().any(|s| s.is_subject_backend()),
             RequiredRole::TransportEnabled => true,
             RequiredRole::WorkflowRunner => summaries.iter().any(|s| s.is_workflow_runner()),
             RequiredRole::Queue => summaries.iter().any(|s| s.is_queue()),

--- a/crates/orchestrator-core/src/flavor.rs
+++ b/crates/orchestrator-core/src/flavor.rs
@@ -367,15 +367,17 @@ recommended = ["launchapp-dev/animus-provider-codex"]
         // The canonical first run is `animus plugin install-defaults` (or
         // `animus flavor install`) followed by `animus daemon start`. The
         // bundled manifest's REQUIRED set must therefore cover every
-        // daemon-preflight role: at_least_one_provider, subject_kind:task,
-        // subject_kind:requirement, workflow_runner, and queue.
+        // daemon-preflight role: at_least_one_provider, at_least_one_subject_backend,
+        // workflow_runner, and queue. The daemon no longer forces specific subject
+        // kinds (task/requirement) — any subject_backend satisfies preflight — but
+        // the bundled flavor still ships the task + requirement backends as curated
+        // defaults.
         let manifest: FlavorManifest = toml::from_str(BUNDLED_DEFAULT_FLAVOR).unwrap();
         manifest.validate().unwrap();
         let required = manifest.required_plugins();
         let has = |needle: &str| required.iter().any(|(_, slug)| slug.contains(needle));
         assert!(has("animus-provider-"), "required set must include a provider");
-        assert!(has("animus-subject-default"), "required set must cover subject_kind:task");
-        assert!(has("animus-subject-requirements"), "required set must cover subject_kind:requirement");
+        assert!(has("animus-subject-default"), "required set must cover at_least_one_subject_backend");
         assert!(has("animus-workflow-runner-default"), "required set must include the workflow runner");
         assert!(has("animus-queue-default"), "required set must include the queue plugin");
     }

--- a/crates/orchestrator-core/src/plugin_preflight/mod.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/mod.rs
@@ -152,6 +152,12 @@ pub const DEFAULT_REQUIREMENT_BACKEND_REPO: &str = "launchapp-dev/animus-subject
 pub enum RequiredRole {
     AtLeastOneProvider,
     SubjectKind(String),
+    /// Satisfied by ANY installed subject_backend plugin, regardless of the
+    /// kind(s) it serves. The daemon needs a place to read/write subjects, but
+    /// it must not dictate WHICH kinds a deployment uses — a song app legitimately
+    /// has no `task`/`requirement` backend. Prefer this over `SubjectKind(..)` in
+    /// the daemon default so any valid subject backend satisfies preflight.
+    AtLeastOneSubjectBackend,
     TransportEnabled,
     WorkflowRunner,
     Queue,
@@ -162,6 +168,7 @@ impl RequiredRole {
         match self {
             RequiredRole::AtLeastOneProvider => "at_least_one_provider".to_string(),
             RequiredRole::SubjectKind(kind) => format!("subject_kind:{kind}"),
+            RequiredRole::AtLeastOneSubjectBackend => "at_least_one_subject_backend".to_string(),
             RequiredRole::TransportEnabled => "transport_enabled".to_string(),
             RequiredRole::WorkflowRunner => "workflow_runner".to_string(),
             RequiredRole::Queue => "queue".to_string(),
@@ -188,16 +195,18 @@ impl PluginPreflightSpec {
         Self {
             required_roles: vec![
                 RequiredRole::AtLeastOneProvider,
-                RequiredRole::SubjectKind("task".to_string()),
-                RequiredRole::SubjectKind("requirement".to_string()),
+                // Require A valid subject backend, not specific kinds. The daemon
+                // must not force `task`/`requirement` on every deployment.
+                RequiredRole::AtLeastOneSubjectBackend,
                 RequiredRole::WorkflowRunner,
                 RequiredRole::Queue,
             ],
             auto_install: false,
             auto_install_defaults: vec![
                 ("at_least_one_provider".to_string(), default_provider_repo()),
-                ("subject_kind:task".to_string(), default_task_backend_repo()),
-                ("subject_kind:requirement".to_string(), default_requirement_backend_repo()),
+                // If NO subject backend is installed, the default is the task
+                // backend — a sensible starter, not a requirement.
+                ("at_least_one_subject_backend".to_string(), default_task_backend_repo()),
                 ("workflow_runner".to_string(), default_workflow_runner_repo()),
                 ("queue".to_string(), default_queue_repo()),
             ],

--- a/crates/orchestrator-core/src/plugin_preflight/runner.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/runner.rs
@@ -66,6 +66,7 @@ fn role_is_satisfied(role: &RequiredRole, installed: &[InstalledPluginSummary]) 
     match role {
         RequiredRole::AtLeastOneProvider => installed.iter().any(|p| p.is_provider()),
         RequiredRole::SubjectKind(kind) => installed.iter().any(|p| p.covers_subject_kind(kind)),
+        RequiredRole::AtLeastOneSubjectBackend => installed.iter().any(|p| p.is_subject_backend()),
         RequiredRole::TransportEnabled => true,
         RequiredRole::WorkflowRunner => installed.iter().any(|p| p.is_workflow_runner()),
         RequiredRole::Queue => installed.iter().any(|p| p.is_queue()),
@@ -85,6 +86,9 @@ fn fix_command_for(role: &RequiredRole, default_repo: Option<&str>) -> String {
         }
         RequiredRole::SubjectKind(kind) => {
             format!("animus plugin install {target} --allow-shadow-builtin  # must claim subject_kind:{kind}")
+        }
+        RequiredRole::AtLeastOneSubjectBackend => {
+            format!("animus plugin install {target} --allow-shadow-builtin  # any subject_backend plugin")
         }
         RequiredRole::TransportEnabled => {
             format!("animus plugin install {target} --allow-shadow-builtin  # transport backend")

--- a/crates/orchestrator-core/src/plugin_preflight/tests.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/tests.rs
@@ -58,14 +58,15 @@ async fn preflight_with_no_plugins_and_no_auto_install_reports_missing_with_fix_
     let result = PluginPreflightRunner::run(&spec, Vec::new(), None).await.expect("preflight run");
 
     assert!(!result.is_ok(), "preflight should fail when no plugins installed");
-    assert_eq!(result.missing.len(), 5, "all five roles should be missing");
+    assert_eq!(result.missing.len(), 4, "all four roles should be missing");
 
     let provider_missing = result.missing.iter().find(|m| m.role == "at_least_one_provider").expect("provider role");
     assert!(provider_missing.fix_command.contains("animus plugin install"));
     assert!(provider_missing.fix_command.contains("animus-provider-claude"));
 
-    let task_missing = result.missing.iter().find(|m| m.role == "subject_kind:task").expect("task subject role");
-    assert!(task_missing.fix_command.contains("subject_kind:task"));
+    let subject_missing =
+        result.missing.iter().find(|m| m.role == "at_least_one_subject_backend").expect("subject backend role");
+    assert!(subject_missing.fix_command.contains("subject_backend"));
 
     let message = result.render_missing_message();
     assert!(message.contains("plugin preflight failed"));
@@ -80,10 +81,11 @@ async fn preflight_with_provider_installed_marks_provider_role_satisfied() {
     let result = PluginPreflightRunner::run(&spec, installed, None).await.expect("preflight run");
 
     assert!(result.satisfied.contains(&"at_least_one_provider".to_string()));
-    assert!(!result.is_ok(), "subject backends still missing");
+    assert!(!result.is_ok(), "subject backend still missing");
     let missing_labels: Vec<&str> = result.missing.iter().map(|m| m.role.as_str()).collect();
-    assert!(missing_labels.contains(&"subject_kind:task"));
-    assert!(missing_labels.contains(&"subject_kind:requirement"));
+    assert!(missing_labels.contains(&"at_least_one_subject_backend"));
+    assert!(!missing_labels.contains(&"subject_kind:task"), "daemon must not force the task kind");
+    assert!(!missing_labels.contains(&"subject_kind:requirement"), "daemon must not force the requirement kind");
 }
 
 #[tokio::test]
@@ -139,7 +141,7 @@ async fn preflight_satisfied_when_subject_backend_covers_all_required_kinds() {
 
     assert!(result.is_ok(), "all roles satisfied");
     assert_eq!(result.missing.len(), 0);
-    assert_eq!(result.satisfied.len(), 5);
+    assert_eq!(result.satisfied.len(), 4);
 }
 
 #[tokio::test]
@@ -211,7 +213,7 @@ async fn provider_missing_preflight_suggests_command_that_actually_works() {
     );
 
     let subject_missing =
-        result.missing.iter().find(|m| m.role.starts_with("subject_kind:")).expect("subject role missing");
+        result.missing.iter().find(|m| m.role == "at_least_one_subject_backend").expect("subject role missing");
     assert!(
         subject_missing.fix_command.contains("--allow-shadow-builtin"),
         "subject fix command also includes --allow-shadow-builtin so a curated subject backend install \
@@ -250,16 +252,16 @@ fn install_target_for_resolves_role_labels_to_repo_specs() {
         provider.starts_with("launchapp-dev/animus-provider-claude@"),
         "provider role must map to the curated claude provider, got: {provider}"
     );
-    let task = spec.install_target_for("subject_kind:task").expect("task role mapped");
+    // The daemon requires A subject backend, not a specific kind; the default
+    // install target for that role is the task backend (a sensible starter).
+    let subject = spec.install_target_for("at_least_one_subject_backend").expect("subject backend role mapped");
     assert!(
-        task.starts_with("launchapp-dev/animus-subject-default@"),
-        "task role must map to animus-subject-default (NOT animus-subject-linear), got: {task}"
+        subject.starts_with("launchapp-dev/animus-subject-default@"),
+        "subject backend role must map to animus-subject-default (NOT animus-subject-linear), got: {subject}"
     );
-    let requirement = spec.install_target_for("subject_kind:requirement").expect("requirement role mapped");
-    assert!(
-        requirement.starts_with("launchapp-dev/animus-subject-requirements@"),
-        "requirement role must map to animus-subject-requirements (NOT animus-subject-linear), got: {requirement}"
-    );
+    // The daemon no longer maps specific subject kinds in its default spec.
+    assert_eq!(spec.install_target_for("subject_kind:task"), None);
+    assert_eq!(spec.install_target_for("subject_kind:requirement"), None);
     assert_eq!(spec.install_target_for("nonexistent_role"), None);
 }
 


### PR DESCRIPTION
## 0.5.20

Patch release.

### Fix: preflight requires *any* subject backend, not forced task/requirement kinds

The daemon preflight required-role set hard-coded `subject_kind:task` and `subject_kind:requirement`, forcing every deployment to install those two specific backends even when a single custom subject backend (e.g. a Postgres `kind=song` backend) was the only subject store in use. The daemon should require *a* working subject backend, not dictate which kinds it serves.

- `RequiredRole::AtLeastOneSubjectBackend` replaces the hard-coded `SubjectKind("task")` + `SubjectKind("requirement")` roles in `PluginPreflightSpec::daemon_default()`. Preflight now passes when any `subject_backend` plugin is installed.
- Auto-install maps the new role to `animus-subject-default`.
- `SubjectKind(_)` retained for custom specs but dropped from the daemon default.
- Doctor `plugins` check mirrors the same posture.

Verified: `cargo check --workspace` clean, orchestrator-core + plugin_preflight + daemon preflight-lifecycle tests pass, clippy + fmt clean.

Merging this `release/v0.5.20` branch triggers `auto-tag-release` → tag `v0.5.20` → `release.yml` builds the linux binary.