### PR TITLE
fix(resolver): route oai-runner to the agentic multi-step provider + robust result capture

### DIFF
--- a/crates/animus-runtime-shared/src/ipc.rs
+++ b/crates/animus-runtime-shared/src/ipc.rs
@@ -186,6 +186,95 @@ pub fn collect_json_payload_lines(text: &str) -> Vec<(String, Value)> {
         .collect()
 }
 
+/// Scan `text` for every balanced `{...}` span and return those that parse as
+/// JSON objects, in document order. Unlike [`collect_json_payload_lines`] this
+/// tolerates prose around the JSON, pretty-printed / multi-line objects, and
+/// objects embedded mid-line — the shapes reasoning + tool-calling models emit
+/// (a chatty preamble or tool-call noise, then the real result object). Brace
+/// counting respects JSON string literals so `{` / `}` inside string values
+/// (e.g. song lyrics) don't throw off the span.
+pub fn collect_balanced_json_objects(text: &str) -> Vec<Value> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            if let Some(end) = balanced_object_end(bytes, i) {
+                if let Ok(value) = serde_json::from_str::<Value>(&text[i..=end]) {
+                    if value.is_object() {
+                        out.push(value);
+                    }
+                }
+                i = end + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Index of the `}` that closes the object opened at `start`
+/// (`bytes[start] == b'{'`), or `None` if unbalanced. Skips braces inside JSON
+/// string literals (honoring `\` escapes).
+fn balanced_object_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, &c) in bytes.iter().enumerate().skip(start) {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            b'"' => in_string = true,
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Extract the authoritative result object from a model's full output `text`:
+/// the LAST balanced JSON object whose `kind` equals `expected_kind` and that
+/// carries every field in `required_fields` as a present, non-empty value.
+///
+/// Reasoning + tool-calling models routinely emit prose, a planning stub, or
+/// tool-call noise before the real answer, with the real object last. Selecting
+/// the last *complete* match (not the first JSON line) is what makes capture
+/// robust against those shapes.
+pub fn extract_result_payload(text: &str, expected_kind: &str, required_fields: &[&str]) -> Option<Value> {
+    collect_balanced_json_objects(text)
+        .into_iter()
+        .filter(|value| {
+            value.get("kind").and_then(Value::as_str) == Some(expected_kind)
+                && required_fields.iter().all(|field| field_is_present(value, field))
+        })
+        .last()
+}
+
+fn field_is_present(value: &Value, field: &str) -> bool {
+    match value.get(field) {
+        None | Some(Value::Null) => false,
+        Some(Value::String(s)) => !s.trim().is_empty(),
+        Some(Value::Array(a)) => !a.is_empty(),
+        Some(Value::Object(o)) => !o.is_empty(),
+        Some(_) => true,
+    }
+}
+
 pub fn append_line(path: &Path, line: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -246,6 +335,47 @@ mod tests {
         assert_eq!(pairs.len(), 2);
         assert!(pairs[0].0.contains("key"));
         assert!(pairs[1].0.contains('['));
+    }
+
+    #[test]
+    fn extract_result_payload_pulls_json_after_a_prose_preamble() {
+        // The exact shape a reasoning model emits: explanation, then the object.
+        let text = "The profile was empty so I wrote a generic song.\n\
+                    {\"kind\":\"lyrics_result\",\"lyrics\":\"la la la\",\"title\":\"Your Song\"}";
+        let got = extract_result_payload(text, "lyrics_result", &["lyrics", "title"]).unwrap();
+        assert_eq!(got.get("title").and_then(Value::as_str), Some("Your Song"));
+    }
+
+    #[test]
+    fn extract_result_payload_handles_pretty_printed_multiline_json() {
+        let text = "Here you go:\n{\n  \"kind\": \"lyrics_result\",\n  \"lyrics\": \"line one\\nline two\",\n  \"title\": \"Mia\"\n}\nDone!";
+        let got = extract_result_payload(text, "lyrics_result", &["lyrics", "title"]).unwrap();
+        assert_eq!(got.get("lyrics").and_then(Value::as_str), Some("line one\nline two"));
+    }
+
+    #[test]
+    fn extract_result_payload_prefers_last_valid_over_earlier_stub() {
+        // An early planning stub (missing fields) must lose to the final object.
+        let text = "Plan: {\"kind\":\"lyrics_result\"}\n\
+                    ...thinking...\n\
+                    {\"kind\":\"lyrics_result\",\"lyrics\":\"real lyrics\",\"title\":\"Real\"}";
+        let got = extract_result_payload(text, "lyrics_result", &["lyrics", "title"]).unwrap();
+        assert_eq!(got.get("title").and_then(Value::as_str), Some("Real"));
+    }
+
+    #[test]
+    fn extract_result_payload_survives_braces_inside_lyrics_and_tool_noise() {
+        let text = "<|tool_call|>functions.shell {\"command\":\"find /app\"}<|end|>\n\
+                    {\"kind\":\"lyrics_result\",\"lyrics\":\"use {happy} {braces}\",\"title\":\"Braces\"}";
+        let got = extract_result_payload(text, "lyrics_result", &["lyrics", "title"]).unwrap();
+        assert_eq!(got.get("lyrics").and_then(Value::as_str), Some("use {happy} {braces}"));
+    }
+
+    #[test]
+    fn extract_result_payload_rejects_missing_required_fields() {
+        let text = "{\"kind\":\"lyrics_result\",\"lyrics\":\"\",\"title\":\"   \"}";
+        // Empty strings count as absent — a blank result is not a valid capture.
+        assert!(extract_result_payload(text, "lyrics_result", &["lyrics", "title"]).is_none());
     }
 
     #[test]

--- a/crates/orchestrator-plugin-host/src/session/session_backend_resolver.rs
+++ b/crates/orchestrator-plugin-host/src/session/session_backend_resolver.rs
@@ -19,7 +19,8 @@ use super::plugin_backend::{discover_provider_plugins, PluginSessionBackend};
 /// unless the operator passes `--allow-shadow-builtin`. The resolver no
 /// longer emits a runtime warning because there is no longer a built-in to
 /// shadow; the install-time gate is the sole defense.
-pub const RESERVED_PROVIDER_TOOLS: &[&str] = &["claude", "codex", "gemini", "opencode", "oai", "oai-runner"];
+pub const RESERVED_PROVIDER_TOOLS: &[&str] =
+    &["claude", "codex", "gemini", "opencode", "oai", "oai-agent", "oai-runner"];
 
 /// Returns `true` when the supplied provider tool name collides with the
 /// canonical name of one of the externally-shipped first-party provider
@@ -30,15 +31,19 @@ pub fn is_reserved_provider_tool(tool: &str) -> bool {
 }
 
 /// Workflows historically named the OAI runner backend `oai-runner` or
-/// `animus-oai-runner`, but the published `launchapp-dev/animus-provider-oai`
-/// plugin registers under `provider_tool = "oai"` (plugin name minus the
-/// `animus-provider-` prefix). Normalize legacy aliases to the canonical
-/// plugin tool name before lookup so existing workflows keep resolving the
-/// first-party plugin without YAML rewrites.
+/// `animus-oai-runner`. The MULTI-STEP agentic provider
+/// `launchapp-dev/animus-provider-oai-agent` registers under
+/// `provider_tool = "oai-agent"` (plugin name minus the `animus-provider-`
+/// prefix) and is the canonical home of the `animus-oai-runner` agent loop
+/// (tool-calling, MCP client, multi-turn). Map the `oai-runner` aliases to it
+/// so `tool: oai-runner` reaches the multi-step runner — a one-shot completion
+/// provider cannot satisfy a reasoning/tool-calling model. Raw `tool: oai`
+/// still resolves to the one-shot completion provider `animus-provider-oai`
+/// for callers that explicitly want the simple, single-turn path.
 pub fn canonical_tool_alias(tool: &str) -> String {
     let lower = tool.trim().to_ascii_lowercase();
     match lower.as_str() {
-        "oai-runner" | "animus-oai-runner" => "oai".to_string(),
+        "oai-runner" | "animus-oai-runner" => "oai-agent".to_string(),
         _ => lower,
     }
 }
@@ -179,10 +184,10 @@ mod tests {
             super::provider_install_command("custom-tool"),
             "animus plugin install <publisher>/animus-provider-custom-tool --allow-shadow-builtin"
         );
-        // Legacy aliases normalize to the canonical plugin target.
+        // The oai-runner aliases now resolve to the multi-step agentic provider.
         assert_eq!(
             super::provider_install_command("oai-runner"),
-            "animus plugin install launchapp-dev/animus-provider-oai --allow-shadow-builtin"
+            "animus plugin install launchapp-dev/animus-provider-oai-agent --allow-shadow-builtin"
         );
         // The human-readable message embeds the same command verbatim.
         let resolver = SessionBackendResolver::new();
@@ -258,7 +263,7 @@ mod tests {
 
     #[test]
     fn reserved_provider_tools_includes_all_first_party_providers() {
-        for tool in ["claude", "codex", "gemini", "opencode", "oai", "oai-runner"] {
+        for tool in ["claude", "codex", "gemini", "opencode", "oai", "oai-agent", "oai-runner"] {
             assert!(super::is_reserved_provider_tool(tool), "{tool} should be reserved");
             assert!(super::is_reserved_provider_tool(&tool.to_ascii_uppercase()));
         }
@@ -267,11 +272,20 @@ mod tests {
     }
 
     #[test]
-    fn resolver_resolves_oai_runner_aliases_against_installed_oai_plugin() {
-        // The first-party plugin `launchapp-dev/animus-provider-oai` registers
-        // under provider_tool "oai", but historical workflows ask for tool
-        // "oai-runner" / "animus-oai-runner". The resolver must normalize.
+    fn resolver_routes_oai_runner_aliases_to_the_agentic_provider() {
+        // The `oai-runner` / `animus-oai-runner` aliases are the canonical
+        // workflow tool for the MULTI-STEP runner, which ships as
+        // `launchapp-dev/animus-provider-oai-agent` (provider_tool "oai-agent").
+        // Raw `tool: oai` stays pinned to the one-shot completion provider.
         let mut resolver = SessionBackendResolver::new();
+        resolver.plugin_providers.insert(
+            "oai-agent".to_string(),
+            std::sync::Arc::new(super::super::plugin_backend::PluginSessionBackend::new(
+                "animus-provider-oai-agent",
+                PathBuf::from("/tmp/animus-provider-oai-agent"),
+                "oai-agent",
+            )),
+        );
         resolver.plugin_providers.insert(
             "oai".to_string(),
             std::sync::Arc::new(super::super::plugin_backend::PluginSessionBackend::new(
@@ -281,20 +295,27 @@ mod tests {
             )),
         );
 
-        for alias in ["oai-runner", "animus-oai-runner", "OAI-Runner", "ANIMUS-OAI-RUNNER", "oai"] {
+        for alias in ["oai-runner", "animus-oai-runner", "OAI-Runner", "ANIMUS-OAI-RUNNER"] {
             let backend = expect_resolve_ok(&resolver, alias);
-            assert_eq!(backend.info().provider_tool, "oai", "alias {alias} should resolve to oai plugin");
+            assert_eq!(
+                backend.info().provider_tool,
+                "oai-agent",
+                "alias {alias} should resolve to the agentic multi-step provider"
+            );
         }
+        // Raw `oai` still resolves to the one-shot completion provider.
+        let oneshot = expect_resolve_ok(&resolver, "oai");
+        assert_eq!(oneshot.info().provider_tool, "oai", "raw oai must stay one-shot");
     }
 
     #[test]
-    fn missing_oai_runner_alias_hints_at_animus_provider_oai_install() {
+    fn missing_oai_runner_alias_hints_at_agentic_provider_install() {
         let resolver = SessionBackendResolver::new();
         for alias in ["oai-runner", "animus-oai-runner"] {
             let msg = expect_resolve_err(&resolver, alias);
             assert!(
-                msg.contains("animus plugin install launchapp-dev/animus-provider-oai"),
-                "alias {alias} should hint at the canonical animus-provider-oai install; got: {msg}"
+                msg.contains("animus plugin install launchapp-dev/animus-provider-oai-agent"),
+                "alias {alias} should hint at the agentic animus-provider-oai-agent install; got: {msg}"
             );
         }
     }


### PR DESCRIPTION
## Two fixes for running reasoning/tool-calling models on the oai path

### 1. Routing (`session_backend_resolver.rs`)
`canonical_tool_alias` mapped `oai-runner`/`animus-oai-runner` → `"oai"` (the one-shot completion provider `animus-provider-oai`). Providers are keyed by name-derived `provider_tool`, so the MULTI-STEP agentic provider `animus-provider-oai-agent` (`provider_tool "oai-agent"`, write_capable, mcp, agent_loop, ships the `animus-oai-runner` binary) was **unreachable**. A one-shot can't run a reasoning/tool-calling model — it emits tool calls + prose the one-shot drops. Map `oai-runner` → `"oai-agent"`; reserve `oai-agent`; raw `tool: oai` stays one-shot.

**BREAKING:** repos using `tool: oai-runner` now need `animus-provider-oai-agent` installed; use `tool: oai` for the one-shot path.

### 2. Robust result-payload extractor (`animus-runtime-shared/ipc.rs`)
`collect_json_payload_lines` parses only whole lines as JSON, so a reasoning model's output (prose preamble, multi-line/pretty JSON, tool-call noise) is never captured. Add `collect_balanced_json_objects` (brace-balanced, honors string literals) + `extract_result_payload` (last object matching kind + required fields). The `animus-workflow-runner-default` plugin already adopted the equivalent fix (v0.4.8).

Tests: 9/9 resolver, 8/8 ipc (5 new on real reasoning-model shapes), full crate suites green; fmt + clippy clean.