### PR TITLE
release: v0.5.23 — oai-runner → agentic multi-step provider + robust capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.23] - 2026-06-21
+
+**`oai-runner` routes to the agentic multi-step provider; robust reasoning-model result capture.**
+
+`canonical_tool_alias` mapped `oai-runner` / `animus-oai-runner` to `oai` (the
+one-shot completion provider `animus-provider-oai`), and providers are keyed by
+name-derived `provider_tool`, so the multi-step agentic provider
+`animus-provider-oai-agent` (`provider_tool = "oai-agent"`, write-capable, MCP,
+agent loop) was unreachable. A one-shot completion provider cannot run a
+reasoning / tool-calling model — it emits tool calls and a prose-then-JSON answer
+the one-shot drops, so the result JSON is never captured. `oai-runner` now
+resolves to `oai-agent`; `oai-agent` is reserved; raw `tool: oai` still selects the
+one-shot provider for callers that want the simple single-turn path.
+
+Also adds `collect_balanced_json_objects` + `extract_result_payload` to
+`animus-runtime-shared` (balanced-brace scan honoring JSON string literals,
+last-object-by-kind) so a chatty model's prose-then-JSON / multi-line / tool-call
+output is captured reliably instead of dropped by the whole-line scan.
+
+**BREAKING:** workflows using `tool: oai-runner` now require
+`animus-provider-oai-agent` installed; switch to `tool: oai` for the one-shot path.
+
 ## [0.5.22] - 2026-06-19
 
 **Queue-enqueue stores the derived subject kind (completes the 0.5.21 fix).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.5.22"
+version = "0.5.23"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Release **v0.5.23**.

- `tool: oai-runner` now resolves to the agentic multi-step provider `oai-agent` (a one-shot completion provider can't run a reasoning/tool-calling model — it drops the tool calls + prose-then-JSON answer, so the result is never captured).
- Adds `collect_balanced_json_objects` + `extract_result_payload` to `animus-runtime-shared` for robust reasoning-model result capture.

See CHANGELOG for detail. **BREAKING:** `tool: oai-runner` now requires `animus-provider-oai-agent` installed; use `tool: oai` for the one-shot path.

Merging this `release/v0.5.23` branch auto-tags `v0.5.23` → Release Binaries CI.