### PR TITLE
fix(clippy): rfind() instead of filter().last() (green CI on v0.6.0 main)

### DIFF
--- a/crates/animus-runtime-shared/src/ipc.rs
+++ b/crates/animus-runtime-shared/src/ipc.rs
@@ -258,11 +258,10 @@ fn balanced_object_end(bytes: &[u8], start: usize) -> Option<usize> {
 pub fn extract_result_payload(text: &str, expected_kind: &str, required_fields: &[&str]) -> Option<Value> {
     collect_balanced_json_objects(text)
         .into_iter()
-        .filter(|value| {
+        .rfind(|value| {
             value.get("kind").and_then(Value::as_str) == Some(expected_kind)
                 && required_fields.iter().all(|field| field_is_present(value, field))
         })
-        .last()
 }
 
 fn field_is_present(value: &Value, field: &str) -> bool {


### PR DESCRIPTION
Post-v0.6.0 lint fix: extract_result_payload used filter().last() on a DoubleEndedIterator (clippy -D warnings failed CI on the merge). Use rfind(), equivalent + efficient. Build-only locally missed it; clippy --all-targets clean now.