### PR TITLE
release: v0.6.2 — bootable Docker image + current default plugin pins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,8 @@ node_modules/
 mockups/
 memory/
 docs/
+# orchestrator-core/daemon-runtime embed this doc via include_str!; keep it in
+# the build context even though the rest of docs/ is ignored.
+!docs/architecture/multi-tenant-rbac-v0.5.5.md
 .agents/
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-21
+
+**v0.6.2 — bootable Docker image + current default plugin pins.**
+
+- **Docker image rebuilt for v0.6** (the published image had been stale since
+  v0.4.4 and no longer built): builder bumped `rust:1.89` → `rust:1.96` to match
+  `rust-toolchain.toml`; added `libdbus-1-dev`/`pkg-config` (builder) and
+  `libdbus-1-3` (runtime) for the `libdbus-sys` dep behind `animus secret`;
+  COPY the root-level `flavors/` + the RBAC doc embedded via `include_str!`
+  (with a `.dockerignore` exception); install the full required-role plugin set
+  via `install-defaults` (incl. the now-published `config_source`); run the
+  foreground `daemon run` instead of the detaching `daemon start`.
+- **Refreshed curated default plugin pins:** `animus-workflow-runner-default`
+  v0.4.5 → **v0.4.8** (brings the autonomous approval gate into default
+  installs) and `animus-queue-default` v0.3.0 → **v0.3.3**.
+
 ## [0.6.1] - 2026-06-21
 
 **v0.6.1 — protocol crates leave the CLI; config-yaml ships.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,32 @@
 # subjects/transports can be added at runtime via `animus plugin install`.
 
 # ── Stage 1: Build all daemon binaries ─────────────────────────────────────────
-FROM rust:1.89-bookworm AS builder
+# Match rust-toolchain.toml (1.96.0). The kernel uses APIs (e.g.
+# Duration::from_mins) that are not available on older toolchains.
+FROM rust:1.96-bookworm AS builder
 
 ARG TARGETARCH=amd64
 ARG BUILDARCH=amd64
 
 WORKDIR /src
 
+# System build deps. `libdbus-sys` (pulled transitively by the keyring /
+# secret-service layer behind `animus secret`) needs the dbus dev headers +
+# pkg-config to compile on Linux.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libdbus-1-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy workspace and crates
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo .cargo
 COPY crates crates
+# Root-level files embedded into the binary via include_str!: the curated
+# flavor manifest (plugin_registry / scope) and the RBAC policy doc
+# (orchestrator-core principal + daemon-runtime policy).
+COPY flavors flavors
+COPY docs/architecture/multi-tenant-rbac-v0.5.5.md docs/architecture/multi-tenant-rbac-v0.5.5.md
 
 # Build daemon binaries with optimized release profile
 # Uses workspace settings: strip=true, lto=thin, codegen-units=1, opt-level=z.
@@ -39,13 +54,18 @@ RUN ls -lh \
     target/release/animus
 
 # ── Stage 2: Minimal runtime image ──────────────────────────────────────────────
-FROM debian:bookworm-slim
+# Trixie (glibc 2.41), not bookworm (glibc 2.36): several launchapp-dev plugin
+# release binaries are built against glibc 2.38/2.39 and won't load on bookworm.
+# The `animus` binary built on the bookworm builder (glibc 2.36) runs fine here
+# (glibc is backward compatible).
+FROM debian:trixie-slim
 
 # Install runtime dependencies + Node.js
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     git \
+    libdbus-1-3 \
     openssh-client \
     openssl \
     unzip \

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-core/src/plugin_registry.rs
+++ b/crates/orchestrator-core/src/plugin_registry.rs
@@ -17,7 +17,7 @@
 /// first entry is the one preflight points users at for
 /// `at_least_one_provider`.
 pub const DEFAULT_PROVIDER_PLUGINS: &[(&str, &str)] = &[
-    ("launchapp-dev/animus-provider-claude", "v0.2.2"),
+    ("launchapp-dev/animus-provider-claude", "v0.2.8"),
     ("launchapp-dev/animus-provider-codex", "v0.2.3"),
     ("launchapp-dev/animus-provider-gemini", "v0.2.6"),
     ("launchapp-dev/animus-provider-opencode", "v0.2.6"),
@@ -28,10 +28,10 @@ pub const DEFAULT_PROVIDER_PLUGINS: &[(&str, &str)] = &[
 /// flavor. Required for `animus daemon start` once the plugin-only path
 /// is the default (deletion gate in Wave 3 "Out of scope").
 pub const DEFAULT_WORKFLOW_RUNNER_PLUGINS: &[(&str, &str)] =
-    &[("launchapp-dev/animus-workflow-runner-default", "v0.4.5")];
+    &[("launchapp-dev/animus-workflow-runner-default", "v0.4.8")];
 
 /// v0.5 queue plugin. See [`DEFAULT_WORKFLOW_RUNNER_PLUGINS`].
-pub const DEFAULT_QUEUE_PLUGINS: &[(&str, &str)] = &[("launchapp-dev/animus-queue-default", "v0.3.0")];
+pub const DEFAULT_QUEUE_PLUGINS: &[(&str, &str)] = &[("launchapp-dev/animus-queue-default", "v0.3.3")];
 
 /// v0.6 config-source plugin (the default YAML source for the `config_source`
 /// plugin role). Published as `launchapp-dev/animus-config-yaml` v0.1.0 in the
@@ -56,7 +56,7 @@ pub const DEFAULT_MEMORY_STORE_PLUGINS: &[(&str, &str)] = &[];
 pub const DEFAULT_NOTIFIER_PLUGINS: &[(&str, &str)] = &[("launchapp-dev/animus-notifier-http", "v0.1.0")];
 
 /// Optional add-on opted in by `--include-oai-agent`.
-pub const DEFAULT_OAI_AGENT_PLUGINS: &[(&str, &str)] = &[("launchapp-dev/animus-provider-oai-agent", "v0.1.4")];
+pub const DEFAULT_OAI_AGENT_PLUGINS: &[(&str, &str)] = &[("launchapp-dev/animus-provider-oai-agent", "v0.1.5")];
 
 /// Subject backends installed by `--include-subjects`. Indexed lookups
 /// below (`default_subject_repo_for_kind`) assume each entry is listed


### PR DESCRIPTION
## v0.6.2

The published Docker image had been stale since v0.4.4 and no longer built. This makes it build, boot, and pass preflight on v0.6, and refreshes the curated default plugin pins.

### Docker (verified: container boots, daemon runs, config_source loads config)
- builder `rust:1.89` → `rust:1.96` (match `rust-toolchain.toml`; the kernel uses `Duration::from_mins`)
- builder: `libdbus-1-dev` + `pkg-config`; runtime: `libdbus-1-3` (`libdbus-sys` behind `animus secret`)
- COPY root-level `flavors/` + the `include_str!`'d RBAC doc (with a `.dockerignore` exception)
- runtime base `debian:bookworm-slim` (glibc 2.36) → `debian:trixie-slim` (glibc 2.41): several plugin release binaries need glibc 2.38/2.39
- install the full required-role set via `install-defaults` (incl. the now-published `config_source`); foreground `daemon run` (the old `daemon start` detaches → container exits)

### Refreshed curated default plugin pins
- `workflow-runner-default` v0.4.5 → **v0.4.8** (autonomous approval gate into default installs)
- `queue-default` v0.3.0 → **v0.3.3**
- `provider-claude` v0.2.2 → **v0.2.8** (approval PreToolUse hook)
- `provider-oai-agent` v0.1.4 → **v0.1.5**

### Verification
`docker build --platform linux/amd64` succeeds (`install-defaults`: installed=8 failed=0). In-container: `animus 0.6.2`; `daemon preflight` → all 5 required roles satisfied; `daemon run` boots fully (plugins discovered, config_source `yaml-compile`/`workflow-config-reloaded`, health/queue/workflow loops, graceful drain).