### PR TITLE
ci: publish daemon image to GHCR on version tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,73 @@
+name: Docker Publish
+
+# Builds the daemon image (Dockerfile) and pushes it to GHCR so
+# `docker-compose.yaml` (ghcr.io/launchapp-dev/animus:latest) pulls the
+# current release instead of a stale one. Runs on every version tag, and
+# can be fired manually for a specific ref via workflow_dispatch.
+#
+# Built for linux/amd64 only: several launchapp-dev plugin release binaries
+# ship no aarch64-unknown-linux-gnu asset, so an arm64 image cannot install
+# the required-role plugins at build time (see Dockerfile).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (tag or branch) to build and publish.
+        required: true
+        default: main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/launchapp-dev/animus
+
+jobs:
+  build-push:
+    name: build + push ${{ github.event.inputs.ref || github.ref_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Resolve image version tag
+        id: meta
+        run: |
+          set -euo pipefail
+          REF="${{ github.event.inputs.ref || github.ref_name }}"
+          # Strip a leading refs/tags/ or refs/heads/ and a leading v.
+          REF="${REF#refs/tags/}"; REF="${REF#refs/heads/}"
+          VERSION="${REF#v}"
+          # Sanitize for a docker tag (no slashes).
+          VERSION="${VERSION//\//-}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Only move :latest for real version tags (vX.Y.Z), not branch builds.
+          if [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tags=${IMAGE}:${VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: false


### PR DESCRIPTION
Adds `.github/workflows/docker-publish.yml` — builds the Dockerfile for linux/amd64 and pushes `ghcr.io/launchapp-dev/animus:<version>` (+ `:latest` on `vX.Y.Z`) so `docker-compose.yaml` pulls the current release instead of a stale image. Fires on version tags and via `workflow_dispatch` (ref input). amd64-only because some plugin release binaries ship no aarch64-linux asset (see Dockerfile).