### PR TITLE
fix(config): reap config_source plugin after config/load — v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-22
+
+**v0.6.3 — fix the config_source plugin process/connection leak (fleet-wide).**
+
+- `orchestrator-config` `config_source_client::resolve_plugin_base` spawned a
+  fresh `config_source` plugin process for every `config/load` and **never shut
+  it down**: `spawn_with_options` sets `kill_on_drop(true)`, but the child lives
+  inside shared state held by the host's background reader task, so dropping the
+  `PluginHost` handle didn't drop (or kill) the child — and a persistent stdio
+  plugin never sees stdin EOF. The daemon calls this on **every config reload**,
+  so each reload leaked one process (and, for DB-backed sources like
+  `animus-config-postgres`, an open Postgres connection pool) — exhausting the
+  container `pids` cap / Postgres `max_connections` over time (observed: 51
+  lingering processes on the launchapp portal → `sorry, too many clients`).
+  Fix: borrow the host for handshake + `config/load`, then **always
+  `host.shutdown()`** on every exit path so the process is reaped. Affects every
+  v0.6 daemon (the default `animus-config-yaml` source leaked the same way,
+  without the Postgres amplifier).
+
 ## [0.6.2] - 2026-06-21
 
 **v0.6.2 — bootable Docker image + current default plugin pins.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-config/src/workflow_config/config_source_client.rs
+++ b/crates/orchestrator-config/src/workflow_config/config_source_client.rs
@@ -65,6 +65,32 @@ async fn load_from_plugin(plugin: DiscoveredPlugin, project_root: PathBuf) -> Re
     let host = PluginHost::spawn_with_options(&plugin.path, &[], options)
         .await
         .with_context(|| format!("spawning config_source plugin {}", plugin.name))?;
+
+    // Borrow the host for the handshake + config/load, then ALWAYS shut it down
+    // so the spawned config_source process is reaped. `spawn_with_options` sets
+    // `kill_on_drop(true)`, but the `Child` lives inside shared state held by the
+    // host's background reader task, so dropping THIS handle does not drop the
+    // child — the bg task keeps it alive until the plugin's stdout EOFs, which a
+    // persistent stdio plugin never does. The daemon calls this on every config
+    // reload, so without an explicit `shutdown()` each reload leaks one process
+    // (and, for DB-backed sources like config-postgres, an open connection pool),
+    // exhausting `pids` / Postgres `max_connections` over time.
+    let loaded = load_via_host(&host, &plugin, &project_root).await;
+    // Best-effort reap. `shutdown` always `start_kill`s the child internally
+    // (even when it returns Err on the graceful-drain leg), so ignoring the
+    // result still terminates the process — we just must CALL it.
+    let _ = host.shutdown().await;
+    loaded
+}
+
+/// Handshake + `config/load` against an already-spawned config_source host,
+/// returning the compiled base config. Split out from [`load_from_plugin`] so
+/// the host is reaped (`shutdown`) on every exit path, not just success.
+async fn load_via_host(
+    host: &PluginHost,
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+) -> Result<(WorkflowConfig, String)> {
     host.handshake().await.with_context(|| format!("handshake with config_source plugin {}", plugin.name))?;
 
     // Compute the repo-scope id from the project root so config_source plugins
@@ -72,7 +98,7 @@ async fn load_from_plugin(plugin: DiscoveredPlugin, project_root: PathBuf) -> Re
     // get a real scope, not null.
     let params = serde_json::json!({
         "project_root": project_root,
-        "repo_scope": protocol::repository_scope_for_path(&project_root),
+        "repo_scope": protocol::repository_scope_for_path(project_root),
     });
     let value = host
         .request_typed_with_timeout("config/load", Some(params), CONFIG_LOAD_TIMEOUT)


### PR DESCRIPTION
## v0.6.3 — config_source process/connection leak (fleet-wide)

`orchestrator-config` `config_source_client::resolve_plugin_base` spawned a fresh `config_source` plugin process for **every** `config/load` and never shut it down. `spawn_with_options` sets `kill_on_drop(true)`, but the `Child` lives in shared state held by the host's background reader task, so dropping the `PluginHost` handle never dropped/killed the child — and a persistent stdio plugin never sees stdin EOF. The daemon reloads config on every tick, so **each reload leaked one process** (plus, for DB-backed sources like `animus-config-postgres`, an open Postgres connection pool).

Observed on the launchapp portal: **51 lingering `animus-config-postgres` processes** (all ppid=daemon) → Postgres `sorry, too many clients` (53300) → Better Auth session gate 500s on every page. The default `animus-config-yaml` source leaks the same way on every v0.6 daemon, just without the Postgres amplifier (process/pids growth over time).

### Fix
Borrow the host for handshake + `config/load` in a new `load_via_host`, then **always `host.shutdown()`** on every exit path. `shutdown` is bounded (shutdown RPC + exit notify under `SHUTDOWN_GRACE`=2s, then `child.wait`/`start_kill`), and instant when the plugin has already exited.

### Verification
`cargo build -p orchestrator-cli` + `clippy -p orchestrator-config` clean; `config_source` tests pass. On the portal (with the complementary config-postgres self-exit) the leaked-process count went 51 → 0 and `too many clients` stopped.