### PR TITLE
feat(chat): pluggable conversation_store plugin role + per-user ownership

### DIFF
--- a/crates/animus-plugin-protocol/src/bin/export_schema.rs
+++ b/crates/animus-plugin-protocol/src/bin/export_schema.rs
@@ -23,6 +23,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use animus_plugin_protocol::conversation_store::{
+    ChatMessage, ConversationAppendMessageRequest, ConversationAppendMessageResponse, ConversationCreateRequest,
+    ConversationCreateResponse, ConversationDeleteRequest, ConversationDeleteResponse, ConversationListRequest,
+    ConversationListResponse, ConversationLoadMessagesRequest, ConversationLoadMessagesResponse,
+    ConversationLoadMetaRequest, ConversationLoadMetaResponse, ConversationMeta, ConversationSaveMetaRequest,
+    ConversationSaveMetaResponse, ConversationSummary,
+};
 use animus_plugin_protocol::{
     EnvRequirement, HealthCheckResult, HealthStatus, HostCapabilities, HostInfo, InitializeParams, InitializeResult,
     McpTool, PluginCapabilities, PluginInfo, PluginManifest, RpcError, RpcNotification, RpcRequest, RpcResponse,
@@ -81,6 +88,23 @@ pub fn all_schemas() -> Vec<(&'static str, Schema)> {
         ("TriggerWatchParams", schema_for!(TriggerWatchParams)),
         ("TriggerEvent", schema_for!(TriggerEvent)),
         ("TriggerAckParams", schema_for!(TriggerAckParams)),
+        ("ConversationMeta", schema_for!(ConversationMeta)),
+        ("ChatMessage", schema_for!(ChatMessage)),
+        ("ConversationSummary", schema_for!(ConversationSummary)),
+        ("ConversationCreateRequest", schema_for!(ConversationCreateRequest)),
+        ("ConversationCreateResponse", schema_for!(ConversationCreateResponse)),
+        ("ConversationLoadMetaRequest", schema_for!(ConversationLoadMetaRequest)),
+        ("ConversationLoadMetaResponse", schema_for!(ConversationLoadMetaResponse)),
+        ("ConversationSaveMetaRequest", schema_for!(ConversationSaveMetaRequest)),
+        ("ConversationSaveMetaResponse", schema_for!(ConversationSaveMetaResponse)),
+        ("ConversationAppendMessageRequest", schema_for!(ConversationAppendMessageRequest)),
+        ("ConversationAppendMessageResponse", schema_for!(ConversationAppendMessageResponse)),
+        ("ConversationLoadMessagesRequest", schema_for!(ConversationLoadMessagesRequest)),
+        ("ConversationLoadMessagesResponse", schema_for!(ConversationLoadMessagesResponse)),
+        ("ConversationListRequest", schema_for!(ConversationListRequest)),
+        ("ConversationListResponse", schema_for!(ConversationListResponse)),
+        ("ConversationDeleteRequest", schema_for!(ConversationDeleteRequest)),
+        ("ConversationDeleteResponse", schema_for!(ConversationDeleteResponse)),
     ]
 }
 

--- a/crates/animus-plugin-protocol/src/lib.rs
+++ b/crates/animus-plugin-protocol/src/lib.rs
@@ -92,6 +92,19 @@ pub const PLUGIN_KIND_TRANSPORT_BACKEND: &str = "transport_backend";
 /// [`PLUGIN_KIND_TRANSPORT_BACKEND`] by `animus web serve`.
 pub const PLUGIN_KIND_WEB_UI: &str = "web_ui";
 
+/// Plugin kind for conversation store backend plugins (Postgres, hosted
+/// SaaS, ...).
+///
+/// Conversation store backends own chat-history persistence: the data ops
+/// behind `animus chat new` / `send` / `get` / `list` / `delete`. They
+/// implement the `conversation/*` method family — see
+/// [`conversation_store`]. The role is **optional**: when no such plugin is
+/// installed the CLI falls back to the in-tree filesystem store, so chat
+/// works with zero plugins. A Postgres-backed implementation adds per-user
+/// ownership + sharing (the `owner` / `visibility` fields on
+/// [`conversation_store::ConversationMeta`]).
+pub const PLUGIN_KIND_CONVERSATION_STORE: &str = "conversation_store";
+
 /// Method name for the log-storage `log/entry` notification.
 ///
 /// Emitted by any supervised plugin to forward a structured log entry to
@@ -148,6 +161,9 @@ pub enum PluginKind {
     TransportBackend,
     /// Web UI plugin. See [`PLUGIN_KIND_WEB_UI`].
     WebUi,
+    /// Conversation store backend plugin. See
+    /// [`PLUGIN_KIND_CONVERSATION_STORE`].
+    ConversationStore,
     /// Generic custom plugin. See [`PLUGIN_KIND_CUSTOM`].
     Custom,
     /// Any kind not understood by this crate version. Preserves the wire
@@ -167,6 +183,7 @@ impl PluginKind {
             PluginKind::LogStorageBackend => PLUGIN_KIND_LOG_STORAGE_BACKEND,
             PluginKind::TransportBackend => PLUGIN_KIND_TRANSPORT_BACKEND,
             PluginKind::WebUi => PLUGIN_KIND_WEB_UI,
+            PluginKind::ConversationStore => PLUGIN_KIND_CONVERSATION_STORE,
             PluginKind::Custom => PLUGIN_KIND_CUSTOM,
             PluginKind::Other(value) => value.as_str(),
         }
@@ -198,6 +215,7 @@ impl From<String> for PluginKind {
             PLUGIN_KIND_LOG_STORAGE_BACKEND => PluginKind::LogStorageBackend,
             PLUGIN_KIND_TRANSPORT_BACKEND => PluginKind::TransportBackend,
             PLUGIN_KIND_WEB_UI => PluginKind::WebUi,
+            PLUGIN_KIND_CONVERSATION_STORE => PluginKind::ConversationStore,
             PLUGIN_KIND_CUSTOM => PluginKind::Custom,
             _ => PluginKind::Other(value),
         }
@@ -858,6 +876,372 @@ impl From<TriggerAckStatus> for String {
     }
 }
 
+/// Wire contract for the optional `conversation_store` plugin role.
+///
+/// A conversation store backend owns chat-history persistence. The kernel's
+/// in-tree filesystem store is the default; when a
+/// [`PLUGIN_KIND_CONVERSATION_STORE`] plugin is installed the CLI routes the
+/// chat data ops to it over JSON-RPC instead. This mirrors the
+/// `subject_backend` and `config_source` roles: method-name string constants
+/// plus serde request/response envelopes the host and plugin agree on.
+///
+/// # Methods
+///
+/// Each method's `params` is the matching `*Request` and its `result` is the
+/// matching `*Response` from this module:
+///
+/// | Method                       | Request                      | Response                      |
+/// |------------------------------|------------------------------|-------------------------------|
+/// | [`METHOD_CONVERSATION_CREATE`]        | [`ConversationCreateRequest`]        | [`ConversationCreateResponse`]        |
+/// | [`METHOD_CONVERSATION_LOAD_META`]     | [`ConversationLoadMetaRequest`]      | [`ConversationLoadMetaResponse`]      |
+/// | [`METHOD_CONVERSATION_SAVE_META`]     | [`ConversationSaveMetaRequest`]      | [`ConversationSaveMetaResponse`]      |
+/// | [`METHOD_CONVERSATION_APPEND_MESSAGE`]| [`ConversationAppendMessageRequest`] | [`ConversationAppendMessageResponse`] |
+/// | [`METHOD_CONVERSATION_LOAD_MESSAGES`] | [`ConversationLoadMessagesRequest`]  | [`ConversationLoadMessagesResponse`]  |
+/// | [`METHOD_CONVERSATION_LIST`]          | [`ConversationListRequest`]          | [`ConversationListResponse`]          |
+/// | [`METHOD_CONVERSATION_DELETE`]        | [`ConversationDeleteRequest`]        | [`ConversationDeleteResponse`]        |
+///
+/// Cross-process serialization of concurrent turns (the in-tree store's
+/// `try_lock_conversation`) is intentionally **NOT** on the wire — it is a
+/// store-internal concern. A DB-backed plugin uses a transaction or advisory
+/// lock per conversation instead.
+///
+/// # Concurrency contract (REQUIRED for multi-host backends)
+///
+/// The kernel assigns each turn's `seq` client-side from the conversation's
+/// current `message_count`, then issues separate
+/// [`METHOD_CONVERSATION_APPEND_MESSAGE`] and
+/// [`METHOD_CONVERSATION_SAVE_META`] calls around the (slow) provider call.
+/// The `seq` is **client-authoritative**: the kernel filters the just-appended
+/// user turn by that exact `seq` on the replay path and saves counts from it,
+/// so a backend MUST persist messages at the `seq` it is given and MUST NOT
+/// renumber them (there is no server-assigned-seq field on
+/// [`ConversationAppendMessageResponse`] to feed a renumber back to the
+/// caller).
+///
+/// The kernel serializes concurrent turns to one conversation only with a
+/// **host-local** advisory file lock, which does NOT span multiple Animus
+/// hosts sharing one backend. Therefore a backend reachable from more than one
+/// host (the hosted Postgres case) **MUST** make turn writes safe under
+/// concurrency itself, by either:
+///
+/// 1. enforcing a `UNIQUE (conversation_id, seq)` constraint and rejecting a
+///    colliding [`METHOD_CONVERSATION_APPEND_MESSAGE`] with an error so the
+///    racing turn fails loudly instead of silently corrupting the log; or
+/// 2. holding a per-conversation advisory lock (e.g. Postgres
+///    `pg_advisory_xact_lock`) for the append+save pair.
+///
+/// Renumbering a colliding append to `MAX(seq)+1` is **not** a valid strategy:
+/// it would desync the kernel's replay filter and its saved `message_count`.
+/// A single-host deployment (the default in-tree store, and a Postgres backend
+/// used from one daemon) is fully serialized by the host-local lock and needs
+/// none of the above.
+///
+/// # Scope identity
+///
+/// Every request carries `project_root` and `repo_scope` (the repository
+/// scope id, as `config_source` does) so a multi-tenant backend can isolate
+/// conversations per scope.
+///
+/// # Ownership and visibility
+///
+/// [`ConversationMeta`] carries `owner` (the portal's authenticated user id;
+/// `None` = unowned/legacy) and `visibility` ([`Visibility`], default
+/// [`Visibility::Private`]). These are the foundation for per-user history
+/// with sharing. The query-layer filtering — "X's own conversations PLUS any
+/// `Shared` ones" — is requested via [`ConversationListRequest::as_user`];
+/// a backend that ignores it simply returns everything (the in-tree store's
+/// behavior, which has no auth context).
+pub mod conversation_store {
+    use super::*;
+
+    /// `conversation/create` — create a fresh conversation, return its meta.
+    pub const METHOD_CONVERSATION_CREATE: &str = "conversation/create";
+    /// `conversation/load_meta` — load one conversation's meta (or `None`).
+    pub const METHOD_CONVERSATION_LOAD_META: &str = "conversation/load_meta";
+    /// `conversation/save_meta` — persist updated meta.
+    pub const METHOD_CONVERSATION_SAVE_META: &str = "conversation/save_meta";
+    /// `conversation/append_message` — append one turn to the event log.
+    pub const METHOD_CONVERSATION_APPEND_MESSAGE: &str = "conversation/append_message";
+    /// `conversation/load_messages` — read the full ordered turn history.
+    pub const METHOD_CONVERSATION_LOAD_MESSAGES: &str = "conversation/load_messages";
+    /// `conversation/list` — list conversation summaries, newest-first.
+    pub const METHOD_CONVERSATION_LIST: &str = "conversation/list";
+    /// `conversation/delete` — permanently remove a conversation (idempotent).
+    pub const METHOD_CONVERSATION_DELETE: &str = "conversation/delete";
+
+    /// Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]
+    /// filtering surfaces it to users other than its `owner`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+    #[serde(rename_all = "snake_case")]
+    pub enum Visibility {
+        /// Visible only to the conversation's `owner` (and to unscoped/admin
+        /// queries that pass no `as_user`). The default.
+        #[default]
+        Private,
+        /// Visible to every user, in addition to its owner.
+        Shared,
+    }
+
+    /// Conversation metadata — the continuity pointer, identity, and the
+    /// ownership/visibility fields that power per-user history.
+    ///
+    /// The shape matches the kernel's on-disk `meta.json` exactly so existing
+    /// filesystem conversations and plugin-backed ones are interchangeable.
+    /// `owner` and `visibility` use serde defaults so legacy `meta.json`
+    /// files (which lack both) still deserialize as unowned + private.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationMeta {
+        /// Stable conversation id.
+        pub id: String,
+        /// Wrapped tool that currently owns the native session. `None` until
+        /// the first turn completes.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tool: Option<String>,
+        /// Model used on the most recent turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        /// The wrapped tool's native session handle, for resume continuity.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub session_id: Option<String>,
+        /// Optional human-facing title.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub title: Option<String>,
+        /// RFC 3339 creation timestamp.
+        pub created_at: String,
+        /// RFC 3339 timestamp of the most recent turn.
+        pub updated_at: String,
+        /// Count of persisted turns (user + assistant).
+        #[serde(default)]
+        pub message_count: u64,
+        /// Authenticated user id that owns this conversation. `None` = unowned
+        /// (legacy on-disk conversations, or ones created without `--as-user`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub owner: Option<String>,
+        /// Visibility. Defaults to [`Visibility::Private`] for legacy metas.
+        #[serde(default)]
+        pub visibility: Visibility,
+    }
+
+    /// One persisted turn in a conversation, in the kernel's portable
+    /// provider-agnostic shape. The plugin persists and returns it verbatim;
+    /// `usage` / `blocks` are opaque JSON to this crate (their schema lives in
+    /// the kernel's chat store) so the protocol stays free of a `protocol`
+    /// crate dependency.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ChatMessage {
+        /// Monotonic 0-based index within the conversation.
+        pub seq: u64,
+        /// `"user"` or `"assistant"`.
+        pub role: String,
+        /// Aggregated text content of the turn.
+        pub content: String,
+        /// RFC 3339 timestamp when the turn was recorded.
+        pub recorded_at: String,
+        /// Provider tool that produced an assistant turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tool: Option<String>,
+        /// Model that produced an assistant turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        /// Token usage reported by the provider (opaque JSON object).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub usage: Option<Value>,
+        /// Provider-reported USD cost for an assistant turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub cost_usd: Option<f64>,
+        /// Ordered timeline of the assistant turn (opaque JSON array).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub blocks: Vec<Value>,
+    }
+
+    /// One-line summary returned by [`METHOD_CONVERSATION_LIST`].
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationSummary {
+        /// Conversation id.
+        pub id: String,
+        /// Title, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub title: Option<String>,
+        /// Tool that owns the native session, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tool: Option<String>,
+        /// Model used on the most recent turn, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        /// Persisted turn count.
+        pub message_count: u64,
+        /// RFC 3339 timestamp of the most recent turn.
+        pub updated_at: String,
+        /// Owner of the conversation, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub owner: Option<String>,
+        /// Visibility of the conversation.
+        #[serde(default)]
+        pub visibility: Visibility,
+    }
+
+    /// Fields common to every conversation-store request: the project + scope
+    /// identity a multi-tenant backend partitions on. Flattened into each
+    /// request so the wire payload stays flat.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationScope {
+        /// Absolute project root path of the calling CLI/daemon.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub project_root: Option<String>,
+        /// Repository scope id (see `protocol::repository_scope_for_path`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub repo_scope: Option<String>,
+    }
+
+    /// `conversation/create` request.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationCreateRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// Explicit conversation id; the backend assigns one when `None`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub id: Option<String>,
+        /// Owner to stamp onto the new conversation's meta.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub owner: Option<String>,
+        /// Initial visibility for the new conversation.
+        #[serde(default)]
+        pub visibility: Visibility,
+    }
+
+    /// `conversation/create` response.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationCreateResponse {
+        /// Meta of the freshly-created conversation.
+        pub meta: ConversationMeta,
+    }
+
+    /// `conversation/load_meta` request.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationLoadMetaRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// Conversation id to load.
+        pub id: String,
+        /// Acting user id, when known. A backend MAY use it to authorize the
+        /// read (e.g. deny a private conversation owned by another user).
+        /// `None` for unscoped/admin access.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub as_user: Option<String>,
+    }
+
+    /// `conversation/load_meta` response. `meta` is `None` when the
+    /// conversation does not exist.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationLoadMetaResponse {
+        /// The conversation meta, or `None` when not found.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub meta: Option<ConversationMeta>,
+    }
+
+    /// `conversation/save_meta` request.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationSaveMetaRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// The meta to persist.
+        pub meta: ConversationMeta,
+        /// Acting user id, when known. A backend MAY use it to authorize the
+        /// mutation. `None` for unscoped/admin access.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub as_user: Option<String>,
+    }
+
+    /// `conversation/save_meta` response (empty on success).
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationSaveMetaResponse {}
+
+    /// `conversation/append_message` request.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationAppendMessageRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// Conversation id to append to.
+        pub id: String,
+        /// The turn to append.
+        pub message: ChatMessage,
+        /// Acting user id, when known. A backend MAY use it to authorize the
+        /// mutation. `None` for unscoped/admin access.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub as_user: Option<String>,
+    }
+
+    /// `conversation/append_message` response (empty on success).
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationAppendMessageResponse {}
+
+    /// `conversation/load_messages` request.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationLoadMessagesRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// Conversation id whose messages to read.
+        pub id: String,
+        /// Acting user id, when known. A backend MAY use it to authorize the
+        /// read. `None` for unscoped/admin access.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub as_user: Option<String>,
+    }
+
+    /// `conversation/load_messages` response.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationLoadMessagesResponse {
+        /// The ordered turn history.
+        #[serde(default)]
+        pub messages: Vec<ChatMessage>,
+    }
+
+    /// `conversation/list` request.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationListRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// When set, the backend returns conversations owned by this user id
+        /// PLUS any [`Visibility::Shared`] ones. When `None`, all
+        /// conversations are returned (legacy/admin view). A backend without
+        /// auth context may ignore this and return everything.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub as_user: Option<String>,
+    }
+
+    /// `conversation/list` response, summaries newest-first.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationListResponse {
+        /// Conversation summaries, most-recently-updated first.
+        #[serde(default)]
+        pub conversations: Vec<ConversationSummary>,
+    }
+
+    /// `conversation/delete` request.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationDeleteRequest {
+        /// Scope identity.
+        #[serde(flatten)]
+        pub scope: ConversationScope,
+        /// Conversation id to delete.
+        pub id: String,
+        /// Acting user id, when known. A backend MAY use it to authorize the
+        /// delete. `None` for unscoped/admin access.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub as_user: Option<String>,
+    }
+
+    /// `conversation/delete` response (empty; delete is idempotent).
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+    pub struct ConversationDeleteResponse {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -996,6 +1380,7 @@ mod tests {
             (PluginKind::LogStorageBackend, "log_storage_backend"),
             (PluginKind::TransportBackend, "transport_backend"),
             (PluginKind::WebUi, "web_ui"),
+            (PluginKind::ConversationStore, "conversation_store"),
             (PluginKind::Custom, "custom"),
         ] {
             assert!(variant.is_known(), "{variant:?} should be known");
@@ -1061,5 +1446,48 @@ mod tests {
         let params = TriggerWatchParams::default();
         let encoded = serde_json::to_value(&params).unwrap();
         assert_eq!(encoded, serde_json::json!({}));
+    }
+
+    #[test]
+    fn conversation_store_kind_round_trips() {
+        let decoded: PluginKind = serde_json::from_value(serde_json::json!("conversation_store")).unwrap();
+        assert_eq!(decoded, PluginKind::ConversationStore);
+        assert!(decoded.is_known());
+        assert_eq!(decoded.as_str(), PLUGIN_KIND_CONVERSATION_STORE);
+    }
+
+    #[test]
+    fn legacy_conversation_meta_without_owner_or_visibility_defaults() {
+        use conversation_store::{ConversationMeta, Visibility};
+        // A pre-existing meta.json lacks `owner` and `visibility` entirely.
+        let legacy = r#"{"id":"conv-x","created_at":"2026-06-08T00:00:00Z","updated_at":"2026-06-08T00:00:00Z"}"#;
+        let meta: ConversationMeta = serde_json::from_str(legacy).expect("legacy meta must parse");
+        assert_eq!(meta.owner, None, "missing owner must default to None (unowned)");
+        assert_eq!(meta.visibility, Visibility::Private, "missing visibility must default to Private");
+    }
+
+    #[test]
+    fn conversation_visibility_serializes_snake_case() {
+        use conversation_store::Visibility;
+        assert_eq!(serde_json::to_value(Visibility::Shared).unwrap(), serde_json::json!("shared"));
+        assert_eq!(serde_json::to_value(Visibility::Private).unwrap(), serde_json::json!("private"));
+    }
+
+    #[test]
+    fn conversation_list_request_flattens_scope() {
+        use conversation_store::{ConversationListRequest, ConversationScope};
+        let req = ConversationListRequest {
+            scope: ConversationScope {
+                project_root: Some("/repo".to_string()),
+                repo_scope: Some("scope-1".to_string()),
+            },
+            as_user: Some("user-7".to_string()),
+        };
+        let encoded = serde_json::to_value(&req).unwrap();
+        // Scope fields are flattened to the top level, not nested under "scope".
+        assert_eq!(encoded.get("project_root"), Some(&serde_json::json!("/repo")));
+        assert_eq!(encoded.get("repo_scope"), Some(&serde_json::json!("scope-1")));
+        assert_eq!(encoded.get("as_user"), Some(&serde_json::json!("user-7")));
+        assert!(encoded.get("scope").is_none(), "scope must be flattened, not nested");
     }
 }

--- a/crates/orchestrator-cli/src/cli_types/chat_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/chat_types.rs
@@ -16,7 +16,7 @@ pub(crate) enum ChatCommand {
     /// Print a conversation's full transcript.
     Get(ChatGetArgs),
     /// List conversations, most-recently-updated first.
-    List,
+    List(ChatListArgs),
     /// Set or clear a conversation's title.
     Rename(ChatRenameArgs),
     /// Permanently delete a conversation.
@@ -36,6 +36,15 @@ pub(crate) enum ChatExportFormat {
     Json,
 }
 
+/// Conversation visibility for `animus chat new`.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum ChatVisibilityArg {
+    /// Visible only to the owner (and to admin/unscoped listings). Default.
+    Private,
+    /// Visible to every user, in addition to the owner.
+    Shared,
+}
+
 #[derive(Debug, Args)]
 pub(crate) struct ChatNewArgs {
     /// Explicit conversation id. Omit to auto-generate (`conv-<uuid>`).
@@ -44,6 +53,22 @@ pub(crate) struct ChatNewArgs {
     /// Optional human-facing title.
     #[arg(long)]
     pub(crate) title: Option<String>,
+    /// Owner (authenticated user id) to stamp onto the conversation. Used by a
+    /// `conversation_store` plugin for per-user history; advisory for the
+    /// in-tree filesystem store.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
+    /// Conversation visibility: private (owner-only) or shared.
+    #[arg(long, value_enum, default_value = "private")]
+    pub(crate) visibility: ChatVisibilityArg,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ChatListArgs {
+    /// Limit the listing to conversations owned by this user id PLUS any
+    /// shared ones. Omit for the full (legacy/admin) listing.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -104,6 +129,14 @@ pub(crate) struct ChatSendArgs {
     /// Drop the built-in `animus` MCP server from the resolved set.
     #[arg(long)]
     pub(crate) no_animus_mcp: bool,
+    /// Owner (authenticated user id) stamped onto a conversation created by
+    /// this send (when `--conversation` is omitted). Advisory for the in-tree
+    /// store; used by a `conversation_store` plugin for per-user history.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
+    /// Visibility for a conversation created by this send.
+    #[arg(long, value_enum, default_value = "private")]
+    pub(crate) visibility: ChatVisibilityArg,
 }
 
 #[derive(Debug, Args)]
@@ -111,6 +144,10 @@ pub(crate) struct ChatGetArgs {
     /// Conversation id to read.
     #[arg(value_name = "ID")]
     pub(crate) id: String,
+    /// Acting user id. Advisory for the in-tree store; a `conversation_store`
+    /// plugin may use it to enforce read access.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -121,6 +158,10 @@ pub(crate) struct ChatRenameArgs {
     /// New title. Pass an empty string to clear it.
     #[arg(long)]
     pub(crate) title: String,
+    /// Acting user id. Advisory for the in-tree store; a `conversation_store`
+    /// plugin may use it to enforce rename (mutation) access.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -128,6 +169,10 @@ pub(crate) struct ChatDeleteArgs {
     /// Conversation id to delete.
     #[arg(value_name = "ID")]
     pub(crate) id: String,
+    /// Acting user id. Advisory for the in-tree store; a `conversation_store`
+    /// plugin may use it to enforce delete access.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -141,6 +186,10 @@ pub(crate) struct ChatExportArgs {
     /// Write to this file instead of stdout.
     #[arg(long, value_name = "PATH")]
     pub(crate) output: Option<String>,
+    /// Acting user id. Advisory for the in-tree store; a `conversation_store`
+    /// plugin may use it to enforce read access on the exported transcript.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -154,4 +203,8 @@ pub(crate) struct ChatSearchArgs {
     /// Match case-sensitively (default is case-insensitive).
     #[arg(long)]
     pub(crate) case_sensitive: bool,
+    /// Limit the search to conversations owned by this user id PLUS any shared
+    /// ones. Omit for the full (legacy/admin) search.
+    #[arg(long, value_name = "USER_ID")]
+    pub(crate) as_user: Option<String>,
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_cost.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_cost.rs
@@ -21,7 +21,8 @@ use crate::services::cost::{
     aggregator::{clamp_cost, COST_STATE_SCHEMA_ID},
     enforce_caps, read_decision_records, refresh_cost_state, CostState, PhaseCost, WorkflowCost,
 };
-use crate::services::runtime::runtime_chat::store::{ConversationStore, FileConversationStore};
+use crate::services::runtime::runtime_chat::client::ConversationStoreClient;
+use crate::services::runtime::runtime_chat::store::ConversationStore;
 use crate::{invalid_input_error, not_found_error, print_value};
 
 const SUMMARY_SCHEMA: &str = "animus.cost.summary.v1";
@@ -255,7 +256,7 @@ fn aggregate_conversation_cost(
 /// folding the `usage` / `cost_usd` fields recorded on each assistant
 /// [`ChatMessage`](crate::services::runtime::runtime_chat::store::ChatMessage).
 fn handle_conversation(project_path: &Path, args: CostConversationArgs, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(project_path)?;
+    let store = ConversationStoreClient::for_project(project_path)?;
     if store.load_meta(&args.conversation_id)?.is_none() {
         return Err(not_found_error(format!("conversation '{}' not found", args.conversation_id)));
     }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_chat/client.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_chat/client.rs
@@ -1,0 +1,567 @@
+//! Backend selection for chat conversation persistence.
+//!
+//! [`ConversationStoreClient`] is the seam that lets chat history be served
+//! either by the in-tree filesystem store (the default — chat works with zero
+//! plugins installed) or by an installed `conversation_store` plugin (e.g. a
+//! Postgres backend with per-user ownership + sharing). This mirrors how
+//! `config_source` and `subject_backend` choose a backend at runtime:
+//!
+//! * if a [`PLUGIN_KIND_CONVERSATION_STORE`] plugin is discovered, every data
+//!   op routes to it over JSON-RPC. Each call spawns a plugin host, runs one
+//!   RPC, and ALWAYS reaps the host with `host.shutdown().await` — never
+//!   leaking a host per call (the v0.6.3 leak lesson);
+//! * else the call falls through to [`FileConversationStore`].
+//!
+//! The `conversation_store` role is **optional**: it is NOT a required
+//! preflight role, and the daemon never refuses to start without it.
+//!
+//! [`PLUGIN_KIND_CONVERSATION_STORE`]: animus_plugin_protocol::PLUGIN_KIND_CONVERSATION_STORE
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use animus_plugin_protocol::conversation_store as proto;
+use anyhow::{Context, Result};
+use orchestrator_plugin_host::{discover_by_kind, DiscoveredPlugin, PluginHost, PluginSpawnOptions};
+
+use super::store::{
+    ChatMessage, ConversationLock, ConversationMeta, ConversationStore, ConversationSummary, FileConversationStore,
+};
+
+const CONVERSATION_STORE_KIND: &str = "conversation_store";
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Runtime-selected conversation store: the in-tree filesystem store, or a
+/// discovered `conversation_store` plugin.
+pub(crate) enum ConversationStoreClient {
+    /// Default backend: the scoped-state filesystem store.
+    File(FileConversationStore),
+    /// An installed `conversation_store` plugin handles persistence. Boxed so
+    /// the common `File` variant does not pay for the plugin client's larger
+    /// footprint (a `DiscoveredPlugin` + `PathBuf`).
+    Plugin(Box<PluginConversationStore>),
+}
+
+impl ConversationStoreClient {
+    /// Resolve the conversation store for `project_root`, with no acting user.
+    /// Routes to an installed `conversation_store` plugin when one is
+    /// discovered, else falls back to the in-tree filesystem store.
+    pub(crate) fn for_project(project_root: &Path) -> Result<Self> {
+        Self::for_project_as_user(project_root, None)
+    }
+
+    /// Like [`Self::for_project`] but records the acting user id. When a
+    /// `conversation_store` plugin is selected, that id rides every
+    /// per-conversation RPC (`load_meta`, `save_meta`, `append_message`,
+    /// `load_messages`, `delete`) so the backend can authorize the actor — the
+    /// foundation for per-user access enforcement. The in-tree file store has
+    /// no auth context and ignores it (filtering happens at the query layer).
+    pub(crate) fn for_project_as_user(project_root: &Path, as_user: Option<&str>) -> Result<Self> {
+        let plugins = discover_by_kind(project_root.to_path_buf(), CONVERSATION_STORE_KIND)
+            .with_context(|| format!("discovering conversation_store plugins for {}", project_root.display()))?;
+        match plugins.into_iter().next() {
+            Some(plugin) => Ok(Self::Plugin(Box::new(PluginConversationStore::new(
+                plugin,
+                project_root.to_path_buf(),
+                as_user.map(ToOwned::to_owned),
+                FileConversationStore::for_project(project_root)?,
+            )))),
+            None => Ok(Self::File(FileConversationStore::for_project(project_root)?)),
+        }
+    }
+
+    /// Build a `File`-backed client rooted at an explicit directory. Test-only
+    /// escape hatch mirroring [`FileConversationStore::with_root_for_test`] so
+    /// query-layer helpers that take a `ConversationStoreClient` can be
+    /// exercised against a temp dir.
+    #[cfg(test)]
+    pub(crate) fn with_root_for_test(root: PathBuf) -> Self {
+        Self::File(FileConversationStore::with_root_for_test(root))
+    }
+}
+
+impl ConversationStore for ConversationStoreClient {
+    fn try_lock_conversation(&self, id: &str) -> Result<Option<ConversationLock>> {
+        match self {
+            // The turn loop holds this guard across the whole read-meta →
+            // append → run → save-meta critical section. Seq is assigned
+            // client-side from `meta.message_count`, so even the plugin path
+            // needs whole-turn serialization or two concurrent sends to one
+            // conversation race the seq and last-writer-win the meta. We reuse
+            // the host-local file lock for BOTH backends: it serializes turns
+            // on this host (the common case). A multi-host DB-backed plugin
+            // should additionally serialize via its own transaction/advisory
+            // lock — which the contract enables (the data ops are individual
+            // RPCs), but is the plugin's responsibility, not the kernel's.
+            Self::File(store) => store.try_lock_conversation(id),
+            Self::Plugin(plugin) => plugin.try_lock_conversation(id),
+        }
+    }
+
+    fn create(&self, id: Option<String>) -> Result<ConversationMeta> {
+        self.create_with_ownership(id, None, Default::default())
+    }
+
+    fn load_meta(&self, id: &str) -> Result<Option<ConversationMeta>> {
+        match self {
+            Self::File(store) => store.load_meta(id),
+            Self::Plugin(plugin) => plugin.load_meta(id),
+        }
+    }
+
+    fn save_meta(&self, meta: &ConversationMeta) -> Result<()> {
+        match self {
+            Self::File(store) => store.save_meta(meta),
+            Self::Plugin(plugin) => plugin.save_meta(meta),
+        }
+    }
+
+    fn append_message(&self, id: &str, message: &ChatMessage) -> Result<()> {
+        match self {
+            Self::File(store) => store.append_message(id, message),
+            Self::Plugin(plugin) => plugin.append_message(id, message),
+        }
+    }
+
+    fn load_messages(&self, id: &str) -> Result<Vec<ChatMessage>> {
+        match self {
+            Self::File(store) => store.load_messages(id),
+            Self::Plugin(plugin) => plugin.load_messages(id),
+        }
+    }
+
+    fn list(&self) -> Result<Vec<ConversationSummary>> {
+        self.list_for_user(None)
+    }
+
+    fn delete(&self, id: &str) -> Result<()> {
+        match self {
+            Self::File(store) => store.delete(id),
+            Self::Plugin(plugin) => plugin.delete(id),
+        }
+    }
+}
+
+impl ConversationStoreClient {
+    /// Create a conversation, stamping `owner` + `visibility` onto its meta.
+    /// For the file store the fields are applied via a follow-up `save_meta`;
+    /// for the plugin they ride the `conversation/create` request.
+    pub(crate) fn create_with_ownership(
+        &self,
+        id: Option<String>,
+        owner: Option<String>,
+        visibility: super::store::Visibility,
+    ) -> Result<ConversationMeta> {
+        match self {
+            Self::File(store) => {
+                let mut meta = store.create(id)?;
+                if owner.is_some() || visibility != super::store::Visibility::Private {
+                    meta.owner = owner;
+                    meta.visibility = visibility;
+                    store.save_meta(&meta)?;
+                }
+                Ok(meta)
+            }
+            Self::Plugin(plugin) => plugin.create(id, owner, visibility),
+        }
+    }
+
+    /// List conversations, applying owner-aware filtering when `as_user` is
+    /// `Some`: the file store has no auth context, so it returns everything
+    /// and filtering happens here (owner == user OR visibility == Shared); the
+    /// plugin receives `as_user` and applies the same rule server-side.
+    pub(crate) fn list_for_user(&self, as_user: Option<&str>) -> Result<Vec<ConversationSummary>> {
+        match self {
+            Self::File(store) => {
+                let all = store.list()?;
+                Ok(filter_for_user(all, as_user))
+            }
+            // Defense in depth: the plugin receives `as_user` and is expected
+            // to filter server-side, but the contract permits an auth-unaware
+            // backend to ignore it and return everything. Re-apply the same
+            // owner/visibility rule client-side so a private conversation owned
+            // by another user can never leak through an over-broad listing.
+            Self::Plugin(plugin) => Ok(filter_for_user(plugin.list(as_user)?, as_user)),
+        }
+    }
+}
+
+/// `true` when `as_user` may access `meta` under the owner/shared rule: no
+/// acting user is the legacy/admin view (always allowed); otherwise the user
+/// must own the conversation OR it must be [`super::store::Visibility::Shared`].
+pub(crate) fn user_may_access(meta: &ConversationMeta, as_user: Option<&str>) -> bool {
+    match as_user {
+        None => true,
+        Some(user) => {
+            matches!(meta.visibility, super::store::Visibility::Shared) || meta.owner.as_deref() == Some(user)
+        }
+    }
+}
+
+/// Enforce [`user_may_access`] on a direct-ID read/write, returning a uniform
+/// "not found" error (not "forbidden") so a probe cannot distinguish a private
+/// conversation it may not see from one that does not exist. This is the
+/// client-side backstop for `get` / `export` / `rename` / `delete`: the plugin
+/// receives `as_user` and is expected to authorize server-side, but the
+/// contract permits an auth-unaware backend to return rows by id regardless, so
+/// the kernel re-checks before exposing or mutating the conversation.
+pub(crate) fn ensure_user_may_access(meta: &ConversationMeta, id: &str, as_user: Option<&str>) -> Result<()> {
+    if user_may_access(meta, as_user) {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("conversation '{id}' not found"))
+    }
+}
+
+/// Owner-aware filter applied to file-store listings (the plugin applies the
+/// equivalent rule server-side). With no `as_user`, everything passes
+/// (legacy/admin view). With an `as_user`, a conversation passes when the user
+/// owns it OR it is [`super::store::Visibility::Shared`].
+fn filter_for_user(summaries: Vec<ConversationSummary>, as_user: Option<&str>) -> Vec<ConversationSummary> {
+    match as_user {
+        None => summaries,
+        Some(user) => summaries
+            .into_iter()
+            .filter(|s| matches!(s.visibility, super::store::Visibility::Shared) || s.owner.as_deref() == Some(user))
+            .collect(),
+    }
+}
+
+/// JSON-RPC client over a discovered `conversation_store` plugin. Each method
+/// spawns a host, runs one RPC, and reaps the host on every exit path.
+pub(crate) struct PluginConversationStore {
+    plugin: DiscoveredPlugin,
+    project_root: PathBuf,
+    /// Acting user id (from the chat verb's `--as-user`), threaded onto every
+    /// per-conversation RPC so the backend can authorize the actor. `None` for
+    /// unscoped/admin access.
+    acting_user: Option<String>,
+    /// Host-local file store used SOLELY for its per-conversation cross-process
+    /// lock, so the turn loop's whole-turn serialization holds for the plugin
+    /// backend too (seq is assigned client-side). No chat data is read or
+    /// written through it.
+    lock_store: FileConversationStore,
+}
+
+impl PluginConversationStore {
+    fn new(
+        plugin: DiscoveredPlugin,
+        project_root: PathBuf,
+        acting_user: Option<String>,
+        lock_store: FileConversationStore,
+    ) -> Self {
+        Self { plugin, project_root, acting_user, lock_store }
+    }
+
+    fn try_lock_conversation(&self, id: &str) -> Result<Option<ConversationLock>> {
+        // Host-local turn serialization only. This guarantees correctness for a
+        // single Animus host (the common case). When the SAME backend is shared
+        // by multiple hosts, this lock cannot span them, so the backend MUST
+        // make turn appends concurrency-safe itself (server-side seq allocation,
+        // a `UNIQUE (conversation_id, seq)` constraint, or a per-conversation
+        // advisory lock) — see the "Concurrency contract" section in
+        // `animus_plugin_protocol::conversation_store`.
+        self.lock_store.try_lock_conversation(id)
+    }
+
+    fn acting_user(&self) -> Option<String> {
+        self.acting_user.clone()
+    }
+
+    fn scope(&self) -> proto::ConversationScope {
+        proto::ConversationScope {
+            project_root: Some(self.project_root.to_string_lossy().into_owned()),
+            repo_scope: Some(protocol::repository_scope_for_path(&self.project_root)),
+        }
+    }
+
+    fn create(
+        &self,
+        id: Option<String>,
+        owner: Option<String>,
+        visibility: super::store::Visibility,
+    ) -> Result<ConversationMeta> {
+        let request = proto::ConversationCreateRequest {
+            scope: self.scope(),
+            id,
+            owner,
+            visibility: to_proto_visibility(visibility),
+        };
+        let resp: proto::ConversationCreateResponse = self.call(proto::METHOD_CONVERSATION_CREATE, &request)?;
+        from_proto_meta(resp.meta)
+    }
+
+    fn load_meta(&self, id: &str) -> Result<Option<ConversationMeta>> {
+        let request =
+            proto::ConversationLoadMetaRequest { scope: self.scope(), id: id.to_string(), as_user: self.acting_user() };
+        let resp: proto::ConversationLoadMetaResponse = self.call(proto::METHOD_CONVERSATION_LOAD_META, &request)?;
+        resp.meta.map(from_proto_meta).transpose()
+    }
+
+    fn save_meta(&self, meta: &ConversationMeta) -> Result<()> {
+        let request = proto::ConversationSaveMetaRequest {
+            scope: self.scope(),
+            meta: to_proto_meta(meta)?,
+            as_user: self.acting_user(),
+        };
+        let _: proto::ConversationSaveMetaResponse = self.call(proto::METHOD_CONVERSATION_SAVE_META, &request)?;
+        Ok(())
+    }
+
+    fn append_message(&self, id: &str, message: &ChatMessage) -> Result<()> {
+        let request = proto::ConversationAppendMessageRequest {
+            scope: self.scope(),
+            id: id.to_string(),
+            message: to_proto_message(message)?,
+            as_user: self.acting_user(),
+        };
+        let _: proto::ConversationAppendMessageResponse =
+            self.call(proto::METHOD_CONVERSATION_APPEND_MESSAGE, &request)?;
+        Ok(())
+    }
+
+    fn load_messages(&self, id: &str) -> Result<Vec<ChatMessage>> {
+        let request = proto::ConversationLoadMessagesRequest {
+            scope: self.scope(),
+            id: id.to_string(),
+            as_user: self.acting_user(),
+        };
+        let resp: proto::ConversationLoadMessagesResponse =
+            self.call(proto::METHOD_CONVERSATION_LOAD_MESSAGES, &request)?;
+        resp.messages.into_iter().map(from_proto_message).collect()
+    }
+
+    fn list(&self, as_user: Option<&str>) -> Result<Vec<ConversationSummary>> {
+        let request = proto::ConversationListRequest { scope: self.scope(), as_user: as_user.map(ToOwned::to_owned) };
+        let resp: proto::ConversationListResponse = self.call(proto::METHOD_CONVERSATION_LIST, &request)?;
+        Ok(resp.conversations.into_iter().map(from_proto_summary).collect())
+    }
+
+    fn delete(&self, id: &str) -> Result<()> {
+        let request =
+            proto::ConversationDeleteRequest { scope: self.scope(), id: id.to_string(), as_user: self.acting_user() };
+        let _: proto::ConversationDeleteResponse = self.call(proto::METHOD_CONVERSATION_DELETE, &request)?;
+        Ok(())
+    }
+
+    /// Spawn the plugin host, handshake, run one RPC, and ALWAYS reap the host.
+    fn call<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        method: &str,
+        request: &Req,
+    ) -> Result<Resp> {
+        let params = serde_json::to_value(request).context("serializing conversation_store request")?;
+        run_blocking(self.call_async(method, params))?
+    }
+
+    async fn call_async<Resp: serde::de::DeserializeOwned>(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<Resp> {
+        let options = PluginSpawnOptions::for_manifest(
+            self.plugin.name.clone(),
+            &self.plugin.manifest.env_required,
+            std::iter::empty::<String>(),
+            None,
+        )
+        .with_working_dir(self.project_root.clone());
+        let host = PluginHost::spawn_with_options(&self.plugin.path, &[], options)
+            .await
+            .with_context(|| format!("spawning conversation_store plugin {}", self.plugin.name))?;
+        // Run the handshake + RPC, then ALWAYS shut the host down so the spawned
+        // process (and any DB connection pool it holds) is reaped — a persistent
+        // stdio plugin never EOFs, so dropping the handle alone would leak it.
+        let result = self.handshake_and_call(&host, method, params).await;
+        let _ = host.shutdown().await;
+        result
+    }
+
+    async fn handshake_and_call<Resp: serde::de::DeserializeOwned>(
+        &self,
+        host: &PluginHost,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<Resp> {
+        host.handshake()
+            .await
+            .with_context(|| format!("handshake with conversation_store plugin {}", self.plugin.name))?;
+        let value = host
+            .request_typed_with_timeout(method, Some(params), RPC_TIMEOUT)
+            .await
+            .with_context(|| format!("{method} on conversation_store plugin {}", self.plugin.name))?;
+        serde_json::from_value(value).with_context(|| format!("decoding {method} response"))
+    }
+}
+
+/// Bridge an async future into the sync `ConversationStore` trait. Works
+/// whether or not a tokio runtime is already running (daemon = inside a
+/// runtime; CLI = none). Mirrors `config_source_client::run_blocking`.
+fn run_blocking<F: Future>(fut: F) -> Result<F::Output> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(fut))),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("building tokio runtime for conversation_store call")?;
+            Ok(rt.block_on(fut))
+        }
+    }
+}
+
+fn to_proto_visibility(visibility: super::store::Visibility) -> proto::Visibility {
+    match visibility {
+        super::store::Visibility::Private => proto::Visibility::Private,
+        super::store::Visibility::Shared => proto::Visibility::Shared,
+    }
+}
+
+fn from_proto_visibility(visibility: proto::Visibility) -> super::store::Visibility {
+    match visibility {
+        proto::Visibility::Private => super::store::Visibility::Private,
+        proto::Visibility::Shared => super::store::Visibility::Shared,
+    }
+}
+
+/// Convert a kernel meta into the protocol shape. The two structs are
+/// field-identical except `Visibility`, so a JSON round-trip is the cheapest
+/// faithful conversion and keeps the two in lockstep.
+fn to_proto_meta(meta: &ConversationMeta) -> Result<proto::ConversationMeta> {
+    serde_json::from_value(serde_json::to_value(meta).context("serializing ConversationMeta")?)
+        .context("converting ConversationMeta to protocol shape")
+}
+
+fn from_proto_meta(meta: proto::ConversationMeta) -> Result<ConversationMeta> {
+    serde_json::from_value(serde_json::to_value(meta).context("serializing protocol ConversationMeta")?)
+        .context("converting protocol ConversationMeta to kernel shape")
+}
+
+fn to_proto_message(message: &ChatMessage) -> Result<proto::ChatMessage> {
+    serde_json::from_value(serde_json::to_value(message).context("serializing ChatMessage")?)
+        .context("converting ChatMessage to protocol shape")
+}
+
+fn from_proto_message(message: proto::ChatMessage) -> Result<ChatMessage> {
+    serde_json::from_value(serde_json::to_value(message).context("serializing protocol ChatMessage")?)
+        .context("converting protocol ChatMessage to kernel shape")
+}
+
+fn from_proto_summary(summary: proto::ConversationSummary) -> ConversationSummary {
+    ConversationSummary {
+        id: summary.id,
+        title: summary.title,
+        tool: summary.tool,
+        model: summary.model,
+        message_count: summary.message_count,
+        updated_at: summary.updated_at,
+        owner: summary.owner,
+        visibility: from_proto_visibility(summary.visibility),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::runtime::runtime_chat::store::Visibility;
+
+    fn summary(id: &str, owner: Option<&str>, visibility: Visibility) -> ConversationSummary {
+        ConversationSummary {
+            id: id.to_string(),
+            title: None,
+            tool: None,
+            model: None,
+            message_count: 0,
+            updated_at: "2026-06-21T00:00:00Z".to_string(),
+            owner: owner.map(ToOwned::to_owned),
+            visibility,
+        }
+    }
+
+    #[test]
+    fn filter_none_returns_everything() {
+        let all = vec![
+            summary("a", Some("u1"), Visibility::Private),
+            summary("b", None, Visibility::Private),
+            summary("c", Some("u2"), Visibility::Shared),
+        ];
+        assert_eq!(filter_for_user(all, None).len(), 3, "no as_user is the legacy/admin view");
+    }
+
+    #[test]
+    fn filter_user_returns_own_plus_shared() {
+        let all = vec![
+            summary("own-private", Some("u1"), Visibility::Private),
+            summary("other-private", Some("u2"), Visibility::Private),
+            summary("other-shared", Some("u2"), Visibility::Shared),
+            summary("unowned-private", None, Visibility::Private),
+        ];
+        let got: Vec<String> = filter_for_user(all, Some("u1")).into_iter().map(|s| s.id).collect();
+        assert_eq!(got, vec!["own-private".to_string(), "other-shared".to_string()]);
+    }
+
+    fn meta_with(owner: Option<&str>, visibility: Visibility) -> ConversationMeta {
+        ConversationMeta {
+            id: "conv-z".to_string(),
+            tool: None,
+            model: None,
+            session_id: None,
+            title: None,
+            created_at: "2026-06-21T00:00:00Z".to_string(),
+            updated_at: "2026-06-21T00:00:00Z".to_string(),
+            message_count: 0,
+            owner: owner.map(ToOwned::to_owned),
+            visibility,
+        }
+    }
+
+    #[test]
+    fn user_may_access_enforces_owner_and_shared() {
+        // No acting user = legacy/admin view: everything is accessible.
+        assert!(user_may_access(&meta_with(Some("u2"), Visibility::Private), None));
+        // Owner sees their own private conversation.
+        assert!(user_may_access(&meta_with(Some("u1"), Visibility::Private), Some("u1")));
+        // Anyone sees a shared conversation.
+        assert!(user_may_access(&meta_with(Some("u2"), Visibility::Shared), Some("u1")));
+        // A non-owner is denied another user's private conversation.
+        assert!(!user_may_access(&meta_with(Some("u2"), Visibility::Private), Some("u1")));
+        // An unowned private conversation is denied to any scoped user.
+        assert!(!user_may_access(&meta_with(None, Visibility::Private), Some("u1")));
+    }
+
+    #[test]
+    fn ensure_user_may_access_denies_as_not_found() {
+        let denied = ensure_user_may_access(&meta_with(Some("u2"), Visibility::Private), "conv-z", Some("u1"));
+        let err = denied.unwrap_err().to_string();
+        assert!(err.contains("not found"), "denial must read as not-found, got: {err}");
+        // Allowed access returns Ok.
+        assert!(ensure_user_may_access(&meta_with(Some("u1"), Visibility::Private), "conv-z", Some("u1")).is_ok());
+    }
+
+    #[test]
+    fn meta_round_trips_through_proto_shape() {
+        let mut meta = ConversationMeta {
+            id: "conv-x".to_string(),
+            tool: Some("claude".to_string()),
+            model: Some("claude-sonnet-4-6".to_string()),
+            session_id: Some("sess-1".to_string()),
+            title: Some("Hi".to_string()),
+            created_at: "2026-06-21T00:00:00Z".to_string(),
+            updated_at: "2026-06-21T01:00:00Z".to_string(),
+            message_count: 4,
+            owner: Some("u1".to_string()),
+            visibility: Visibility::Shared,
+        };
+        let proto = to_proto_meta(&meta).unwrap();
+        assert_eq!(proto.owner.as_deref(), Some("u1"));
+        assert_eq!(proto.visibility, proto::Visibility::Shared);
+        let back = from_proto_meta(proto).unwrap();
+        // updated_at is the same across the round-trip; whole struct matches.
+        meta.updated_at = back.updated_at.clone();
+        assert_eq!(back.id, meta.id);
+        assert_eq!(back.owner, meta.owner);
+        assert_eq!(back.visibility, meta.visibility);
+        assert_eq!(back.session_id, meta.session_id);
+    }
+}

--- a/crates/orchestrator-cli/src/services/runtime/runtime_chat/mod.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_chat/mod.rs
@@ -11,17 +11,19 @@ use anyhow::Context;
 
 use crate::shared::{canonicalize_cwd_in_project, format_age, print_ok, print_value, render_table};
 use crate::{
-    ChatCommand, ChatDeleteArgs, ChatExportArgs, ChatExportFormat, ChatGetArgs, ChatNewArgs, ChatRenameArgs,
-    ChatSearchArgs, ChatSendArgs,
+    ChatCommand, ChatDeleteArgs, ChatExportArgs, ChatExportFormat, ChatGetArgs, ChatListArgs, ChatNewArgs,
+    ChatRenameArgs, ChatSearchArgs, ChatSendArgs, ChatVisibilityArg,
 };
 use serde::Serialize;
 
+pub(crate) mod client;
 pub(crate) mod sink;
 pub(crate) mod store;
 pub(crate) mod turn;
 
+use client::ConversationStoreClient;
 use sink::{ChatStreamSink, JsonlStdoutSink, NullSink, TextStdoutSink};
-use store::{ChatMessage, ChatRole, ConversationMeta, ConversationStore, FileConversationStore, TurnBlock};
+use store::{ChatMessage, ChatRole, ConversationMeta, ConversationStore, TurnBlock, Visibility};
 use turn::{run_turn, ResolverTurnProducer, TurnContext};
 
 pub(crate) async fn handle_chat(command: ChatCommand, project_root: &str, json: bool) -> Result<()> {
@@ -29,7 +31,7 @@ pub(crate) async fn handle_chat(command: ChatCommand, project_root: &str, json: 
         ChatCommand::New(args) => handle_chat_new(args, project_root, json),
         ChatCommand::Send(args) => handle_chat_send(args, project_root, json).await,
         ChatCommand::Get(args) => handle_chat_get(args, project_root, json),
-        ChatCommand::List => handle_chat_list(project_root, json),
+        ChatCommand::List(args) => handle_chat_list(args, project_root, json),
         ChatCommand::Rename(args) => handle_chat_rename(args, project_root, json),
         ChatCommand::Delete(args) => handle_chat_delete(args, project_root, json),
         ChatCommand::Export(args) => handle_chat_export(args, project_root, json),
@@ -100,19 +102,23 @@ fn snippet_around(content: &str, query: &str, case_insensitive: bool) -> Option<
     Some(s)
 }
 
-/// Scan every conversation (newest-first) for `query`, collecting up to `limit`
-/// matches with a preview snippet.
+/// Scan conversations (newest-first) for `query`, collecting up to `limit`
+/// matches with a preview snippet. When `as_user` is `Some`, only that user's
+/// own conversations plus shared ones are searched, so a multi-user
+/// `conversation_store` backend never leaks snippets from another user's
+/// private conversations through search.
 fn search_conversations(
-    store: &impl ConversationStore,
+    store: &ConversationStoreClient,
     query: &str,
     case_insensitive: bool,
     limit: usize,
+    as_user: Option<&str>,
 ) -> Result<Vec<SearchMatch>> {
     let mut out = Vec::new();
     if query.is_empty() {
         return Ok(out);
     }
-    for summary in store.list()? {
+    for summary in store.list_for_user(as_user)? {
         if out.len() >= limit {
             break;
         }
@@ -135,8 +141,8 @@ fn search_conversations(
 }
 
 fn handle_chat_search(args: ChatSearchArgs, project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
-    let matches = search_conversations(&store, &args.query, !args.case_sensitive, args.limit)?;
+    let store = ConversationStoreClient::for_project_as_user(Path::new(project_root), args.as_user.as_deref())?;
+    let matches = search_conversations(&store, &args.query, !args.case_sensitive, args.limit, args.as_user.as_deref())?;
     print_value(matches, json)
 }
 
@@ -195,8 +201,9 @@ fn render_markdown(meta: &ConversationMeta, messages: &[ChatMessage]) -> String 
 }
 
 fn handle_chat_export(args: ChatExportArgs, project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
+    let store = ConversationStoreClient::for_project_as_user(Path::new(project_root), args.as_user.as_deref())?;
     let meta = store.load_meta(&args.id)?.ok_or_else(|| anyhow!("conversation '{}' not found", args.id))?;
+    client::ensure_user_may_access(&meta, &args.id, args.as_user.as_deref())?;
     let messages = store.load_messages(&args.id)?;
     let (content, format_label) = match args.format {
         ChatExportFormat::Json => {
@@ -238,8 +245,9 @@ fn apply_conversation_title(store: &impl ConversationStore, id: &str, title: Opt
 }
 
 fn handle_chat_rename(args: ChatRenameArgs, project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
+    let store = ConversationStoreClient::for_project_as_user(Path::new(project_root), args.as_user.as_deref())?;
     let mut meta = store.load_meta(&args.id)?.ok_or_else(|| anyhow!("conversation '{}' not found", args.id))?;
+    client::ensure_user_may_access(&meta, &args.id, args.as_user.as_deref())?;
     let trimmed = args.title.trim();
     meta.title = if trimmed.is_empty() { None } else { Some(trimmed.to_string()) };
     store.save_meta(&meta)?;
@@ -247,35 +255,71 @@ fn handle_chat_rename(args: ChatRenameArgs, project_root: &str, json: bool) -> R
 }
 
 fn handle_chat_delete(args: ChatDeleteArgs, project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
-    let existed = store.load_meta(&args.id)?.is_some();
-    store.delete(&args.id)?;
+    let store = ConversationStoreClient::for_project_as_user(Path::new(project_root), args.as_user.as_deref())?;
+    // Authorize against the loaded meta before deleting: a user-scoped delete of
+    // another user's private conversation is rejected as "not found". A missing
+    // (or auth-hidden) conversation stays idempotent: with no meta there is
+    // nothing authorized to remove, so we skip the mutation entirely rather than
+    // issue a delete the backend might surface as a forbidden error.
+    let existed = match store.load_meta(&args.id)? {
+        Some(meta) => {
+            client::ensure_user_may_access(&meta, &args.id, args.as_user.as_deref())?;
+            store.delete(&args.id)?;
+            true
+        }
+        None => false,
+    };
     print_value(serde_json::json!({ "conversation_id": args.id, "deleted": existed }), json)
 }
 
+/// Map the CLI visibility flag to the store's [`Visibility`].
+fn visibility_from_arg(arg: ChatVisibilityArg) -> Visibility {
+    match arg {
+        ChatVisibilityArg::Private => Visibility::Private,
+        ChatVisibilityArg::Shared => Visibility::Shared,
+    }
+}
+
 fn handle_chat_new(args: ChatNewArgs, project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
-    let mut meta = store.create(args.id)?;
+    // Build the client with the acting user so a plugin backend authorizes the
+    // follow-up title `save_meta` as the same owner the create stamped, not as
+    // an unscoped/admin mutation.
+    let store = ConversationStoreClient::for_project_as_user(Path::new(project_root), args.as_user.as_deref())?;
+    let mut meta = store.create_with_ownership(args.id, args.as_user.clone(), visibility_from_arg(args.visibility))?;
     if args.title.is_some() {
         meta.title = args.title;
         store.save_meta(&meta)?;
     }
-    print_value(serde_json::json!({ "conversation_id": meta.id, "title": meta.title }), json)
+    print_value(
+        serde_json::json!({
+            "conversation_id": meta.id,
+            "title": meta.title,
+            "owner": meta.owner,
+            "visibility": meta.visibility,
+        }),
+        json,
+    )
 }
 
 async fn handle_chat_send(args: ChatSendArgs, project_root: &str, json: bool) -> Result<()> {
     let project_root_path = PathBuf::from(project_root);
-    let store = FileConversationStore::for_project(&project_root_path)?;
+    let store = ConversationStoreClient::for_project_as_user(&project_root_path, args.as_user.as_deref())?;
 
     // Resolve (or create) the target conversation.
     let (conversation_id, auto_created) = match args.conversation {
         Some(id) => {
-            if store.load_meta(&id)?.is_none() {
-                return Err(anyhow!("conversation '{id}' not found; create it with `animus chat new`"));
+            match store.load_meta(&id)? {
+                // Authorize the actor before sending into an existing
+                // conversation: a user-scoped send into another user's private
+                // conversation is rejected as "not found".
+                Some(meta) => client::ensure_user_may_access(&meta, &id, args.as_user.as_deref())?,
+                None => return Err(anyhow!("conversation '{id}' not found; create it with `animus chat new`")),
             }
             (id, false)
         }
-        None => (store.create(None)?.id, true),
+        None => {
+            (store.create_with_ownership(None, args.as_user.clone(), visibility_from_arg(args.visibility))?.id, true)
+        }
     };
 
     // Apply an optional title — names a freshly-created conversation or renames
@@ -406,15 +450,16 @@ async fn handle_chat_send(args: ChatSendArgs, project_root: &str, json: bool) ->
 }
 
 fn handle_chat_get(args: ChatGetArgs, project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
+    let store = ConversationStoreClient::for_project_as_user(Path::new(project_root), args.as_user.as_deref())?;
     let meta = store.load_meta(&args.id)?.ok_or_else(|| anyhow!("conversation '{}' not found", args.id))?;
+    client::ensure_user_may_access(&meta, &args.id, args.as_user.as_deref())?;
     let messages = store.load_messages(&args.id)?;
     print_value(serde_json::json!({ "meta": meta, "messages": messages }), json)
 }
 
-fn handle_chat_list(project_root: &str, json: bool) -> Result<()> {
-    let store = FileConversationStore::for_project(Path::new(project_root))?;
-    let summaries = store.list()?;
+fn handle_chat_list(args: ChatListArgs, project_root: &str, json: bool) -> Result<()> {
+    let store = ConversationStoreClient::for_project(Path::new(project_root))?;
+    let summaries = store.list_for_user(args.as_user.as_deref())?;
     if !json {
         if summaries.is_empty() {
             println!("No chat conversations yet. Start one with: animus chat new");
@@ -442,6 +487,7 @@ fn handle_chat_list(project_root: &str, json: bool) -> Result<()> {
 #[cfg(test)]
 mod export_tests {
     use super::*;
+    use store::FileConversationStore;
 
     fn sample_meta() -> ConversationMeta {
         ConversationMeta {
@@ -453,6 +499,8 @@ mod export_tests {
             created_at: "2026-06-09T00:00:00Z".into(),
             updated_at: "2026-06-09T01:00:00Z".into(),
             message_count: 2,
+            owner: None,
+            visibility: Visibility::Private,
         }
     }
 
@@ -576,26 +624,26 @@ mod export_tests {
     #[test]
     fn search_conversations_finds_limits_and_respects_case() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = FileConversationStore::with_root_for_test(tmp.path().join("chat"));
+        let store = ConversationStoreClient::with_root_for_test(tmp.path().join("chat"));
         store.create(Some("conv-s".into())).unwrap();
         store.append_message("conv-s", &msg(ChatRole::User, "Please fix the AUTH bug", vec![])).unwrap();
         store.append_message("conv-s", &msg(ChatRole::Assistant, "done, no issues", vec![])).unwrap();
 
         // case-insensitive hit on the user message
-        let m = search_conversations(&store, "auth", true, 20).unwrap();
+        let m = search_conversations(&store, "auth", true, 20, None).unwrap();
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].conversation_id, "conv-s");
         assert_eq!(m[0].role, "user");
         assert!(m[0].snippet.to_lowercase().contains("auth"), "{}", m[0].snippet);
 
         // case-sensitive "auth" does not match "AUTH"
-        assert!(search_conversations(&store, "auth", false, 20).unwrap().is_empty());
+        assert!(search_conversations(&store, "auth", false, 20, None).unwrap().is_empty());
 
         // empty query → no matches
-        assert!(search_conversations(&store, "", true, 20).unwrap().is_empty());
+        assert!(search_conversations(&store, "", true, 20, None).unwrap().is_empty());
 
         // limit is respected
         store.append_message("conv-s", &msg(ChatRole::User, "auth again", vec![])).unwrap();
-        assert_eq!(search_conversations(&store, "auth", true, 1).unwrap().len(), 1);
+        assert_eq!(search_conversations(&store, "auth", true, 1, None).unwrap().len(), 1);
     }
 }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_chat/store.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_chat/store.rs
@@ -109,6 +109,21 @@ pub(crate) struct ChatMessage {
     pub blocks: Vec<TurnBlock>,
 }
 
+/// Visibility of a conversation. Mirrors
+/// [`animus_plugin_protocol::conversation_store::Visibility`] on the wire.
+/// [`Visibility::Private`] is the default so legacy on-disk `meta.json` files
+/// (which predate this field) deserialize as private.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Visibility {
+    /// Visible only to the conversation's `owner` (and to unscoped/admin
+    /// `list` calls that pass no `--as-user`). The default.
+    #[default]
+    Private,
+    /// Visible to every user, in addition to its owner.
+    Shared,
+}
+
 /// Conversation metadata — the thin continuity pointer plus identity.
 ///
 /// `session_id` is the load-bearing field: it is the wrapped tool's native
@@ -145,6 +160,17 @@ pub(crate) struct ConversationMeta {
     /// Count of persisted turns (user + assistant).
     #[serde(default)]
     pub message_count: u64,
+    /// Authenticated user id that owns this conversation. `None` for unowned
+    /// conversations: legacy on-disk metas (the field is serde-defaulted) and
+    /// ones created without `--as-user`. Owner-aware filtering happens at the
+    /// query layer ([`crate::services::runtime::runtime_chat::client`]), not
+    /// in [`FileConversationStore::list`], which has no auth context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// Conversation visibility. Defaults to [`Visibility::Private`] so legacy
+    /// metas without the field load as private.
+    #[serde(default)]
+    pub visibility: Visibility,
 }
 
 impl ConversationMeta {
@@ -159,6 +185,8 @@ impl ConversationMeta {
             created_at: now.clone(),
             updated_at: now,
             message_count: 0,
+            owner: None,
+            visibility: Visibility::Private,
         }
     }
 }
@@ -172,6 +200,12 @@ pub(crate) struct ConversationSummary {
     pub model: Option<String>,
     pub message_count: u64,
     pub updated_at: String,
+    /// Owner of the conversation, if any. Carried so the query layer can
+    /// apply `--as-user` filtering without re-loading each meta.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// Visibility of the conversation, used by `--as-user` filtering.
+    pub visibility: Visibility,
 }
 
 impl From<&ConversationMeta> for ConversationSummary {
@@ -183,6 +217,8 @@ impl From<&ConversationMeta> for ConversationSummary {
             model: meta.model.clone(),
             message_count: meta.message_count,
             updated_at: meta.updated_at.clone(),
+            owner: meta.owner.clone(),
+            visibility: meta.visibility,
         }
     }
 }

--- a/docs/reference/chat.md
+++ b/docs/reference/chat.md
@@ -42,27 +42,28 @@ If a resume turn (case 1) comes back with an error indicating the native session
 
 ```bash
 # Start an empty conversation (prints the conversation id)
-animus chat new [--id <id>] [--title <title>]
+animus chat new [--id <id>] [--title <title>] \
+  [--as-user <user-id>] [--visibility private|shared]
 
 # Send a turn (creates a conversation if --conversation is omitted)
 animus chat send "your message" \
   [--conversation <id>] [--tool claude] [--model <model>] [--cwd <path>] \
-  [--stream] [--title <title>]
+  [--stream] [--title <title>] [--as-user <user-id>] [--visibility private|shared]
 
 # Read a full transcript
-animus chat get <id>
+animus chat get <id> [--as-user <user-id>]
 
 # List conversations, most-recently-updated first
-animus chat list
+animus chat list [--as-user <user-id>]
 
 # Set or clear a conversation title
-animus chat rename <id> --title <title>
+animus chat rename <id> --title <title> [--as-user <user-id>]
 
 # Permanently delete a conversation
-animus chat delete <id>
+animus chat delete <id> [--as-user <user-id>]
 
 # Export a conversation transcript as Markdown or JSON
-animus chat export <id> [--format markdown|json] [--output <path>]
+animus chat export <id> [--format markdown|json] [--output <path>] [--as-user <user-id>]
 ```
 
 `animus chat send --title` names a freshly-created conversation or renames the
@@ -90,9 +91,26 @@ animus cost conversation <id>   # token + USD spend for one conversation
 
 Per-turn `usage` and `cost_usd` are recorded on each assistant `ChatMessage` from the provider's metadata frames; `animus cost conversation` folds them into a per-conversation total.
 
+## Ownership and visibility
+
+Each conversation carries two optional identity fields on its `ConversationMeta`:
+
+- `owner` — the authenticated user id that owns the conversation. `None` for **unowned** conversations: legacy on-disk metas (the field is serde-defaulted, so existing conversations load unchanged) and ones created without `--as-user`.
+- `visibility` — `private` (the default) or `shared`.
+
+`--as-user <id>` stamps an owner on `animus chat new` and on an `animus chat send` that auto-creates a conversation; `--visibility` sets the initial visibility. `animus chat list --as-user <id>` returns that user's own conversations PLUS any `shared` ones; `animus chat list` with no `--as-user` returns everything (the legacy/admin view).
+
+Owner filtering is applied at the query layer (the in-tree store has no auth context and `list` always returns everything). Beyond `list`, the kernel also enforces the same owner/shared rule client-side on every **direct-id** verb when `--as-user` is given — `chat get`, `export`, `rename`, `delete`, and a `chat send` into an existing conversation: accessing another user's `private` conversation is rejected as `not found` (a uniform error, so a probe cannot tell a private conversation it may not see from one that does not exist). With no `--as-user`, all access is permitted (the legacy/admin view). When a `conversation_store` plugin is installed, the acting user from `--as-user` ALSO rides every per-conversation RPC (`load_meta`, `save_meta`, `append_message`, `load_messages`, `delete`) so the backend can authorize server-side; the client-side check is a backstop for backends that do not.
+
+## Pluggable conversation store
+
+Chat persistence is served by an **optional** `conversation_store` plugin role. With no plugin installed, the in-tree filesystem store (below) is used — chat works with zero plugins. When a `conversation_store` plugin is discovered, the chat data ops (`create` / `load_meta` / `save_meta` / `append_message` / `load_messages` / `list` / `delete`) route to it over JSON-RPC instead; this is how an out-of-tree Postgres backend serves chat history with real per-user ownership + sharing.
+
+The role is optional: it is **not** a required preflight role, and the daemon never refuses to start without it. The contract (method names + request/response types) lives in `crates/animus-plugin-protocol/src/lib.rs` under the `conversation_store` module; the `Visibility` enum, `ConversationMeta`, and `ChatMessage` wire shapes match the on-disk `meta.json` / `messages.jsonl` shapes exactly. Cross-process turn serialization (`try_lock_conversation`) is intentionally NOT on the wire — a DB-backed plugin uses a transaction or advisory lock per conversation instead. Each plugin call spawns a host, runs one RPC, and reaps the host (`host.shutdown().await`).
+
 ## State layout
 
-Conversations live under the scoped runtime root:
+When no `conversation_store` plugin is installed, conversations live under the scoped runtime root:
 
 - `~/.animus/<repo-scope>/chat/<conversation-id>/meta.json` — `ConversationMeta` (the continuity pointer: `session_id` + `tool` + `model`, plus counts and timestamps).
 - `~/.animus/<repo-scope>/chat/<conversation-id>/messages.jsonl` — append-only `ChatMessage` event log. Assistant turns carry both aggregated `content` and, when available, an ordered `blocks[]` timeline for text, thinking text, and tool activity.
@@ -100,5 +118,7 @@ Conversations live under the scoped runtime root:
 As with all Animus state, treat these as tool-managed — use the `animus chat` surface rather than hand-editing the JSON.
 
 ## Implementation notes
+
+Backend selection runs through `ConversationStoreClient` (`crates/orchestrator-cli/src/services/runtime/runtime_chat/client.rs`), which routes to a discovered `conversation_store` plugin or falls back to the in-tree `FileConversationStore`. Both implement the `ConversationStore` trait, so the turn loop and the CLI handlers are backend-agnostic.
 
 The turn loop is factored around a `TurnProducer` trait (`crates/orchestrator-cli/src/services/runtime/runtime_chat/turn.rs`). Production wires `ResolverTurnProducer`, which resolves the installed provider plugin and starts a session. The v0.5.11 `chat_provider` plugin role will slot in as an alternate `TurnProducer` without changing the continuity logic, and tests inject a scripted mock producer. The streaming sink is likewise abstracted behind `ChatStreamSink` so the same loop drives JSONL, text, and discard outputs.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1567,7 +1567,7 @@ mode. Pass `--json` to get the `animus.cli.v1` envelope instead.
 | `animus workflow list` | Table; empty set prints a "Start one with:" hint |
 | `animus agent list` | Table of configured agent profiles |
 | `animus agent interactions list` | Table of pending interactions with answer-command hints |
-| `animus chat list` | Table, most-recently-updated first |
+| `animus chat list` | Table, most-recently-updated first; `--as-user <id>` limits to that user's own + shared conversations |
 | `animus pack list` | Table; active packs flagged |
 | `animus skill list` | Table; `--verbose` surfaces per-file unparseable-skill warnings (otherwise suppressed/aggregated) |
 | `animus daemon preflight` | Checklist (pass/fail per role), not a JSON blob |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1030,6 +1030,19 @@ YAML-only projects.
 the first production `config_source` plugin. The general-audience release of the role
 tracks the publication of `launchapp-dev/animus-config-yaml`.
 
+### Optional `conversation_store` role
+
+Chat history (`animus chat`) is served by an **optional** `conversation_store` plugin
+role. With no plugin installed, the in-tree filesystem store under
+`~/.animus/<repo-scope>/chat/` is used, so chat works with zero plugins. When a
+`conversation_store` plugin is discovered (`discover_by_kind(.., "conversation_store")`),
+the chat data ops route to it over JSON-RPC instead — this is how an out-of-tree
+Postgres backend serves chat history with per-user ownership (`owner`) and sharing
+(`visibility`). Unlike `config_source`, this role is **never** a `RequiredRole`: it is
+not in `daemon_default()`, `animus daemon preflight` never reports it, and the daemon
+never refuses to start without it. The contract lives in the `conversation_store` module
+of `crates/animus-plugin-protocol`. See `docs/reference/chat.md` for the full surface.
+
 ## Notes
 
 - Project YAML is the authored workflow surface.

--- a/schemas/animus-plugin-protocol/ChatMessage.json
+++ b/schemas/animus-plugin-protocol/ChatMessage.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ChatMessage",
+  "description": "One persisted turn in a conversation, in the kernel's portable\nprovider-agnostic shape. The plugin persists and returns it verbatim;\n`usage` / `blocks` are opaque JSON to this crate (their schema lives in\nthe kernel's chat store) so the protocol stays free of a `protocol`\ncrate dependency.",
+  "type": "object",
+  "properties": {
+    "blocks": {
+      "description": "Ordered timeline of the assistant turn (opaque JSON array).",
+      "type": "array",
+      "items": true
+    },
+    "content": {
+      "description": "Aggregated text content of the turn.",
+      "type": "string"
+    },
+    "cost_usd": {
+      "description": "Provider-reported USD cost for an assistant turn.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
+    "model": {
+      "description": "Model that produced an assistant turn.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "recorded_at": {
+      "description": "RFC 3339 timestamp when the turn was recorded.",
+      "type": "string"
+    },
+    "role": {
+      "description": "`\"user\"` or `\"assistant\"`.",
+      "type": "string"
+    },
+    "seq": {
+      "description": "Monotonic 0-based index within the conversation.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    },
+    "tool": {
+      "description": "Provider tool that produced an assistant turn.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "usage": {
+      "description": "Token usage reported by the provider (opaque JSON object)."
+    }
+  },
+  "required": [
+    "seq",
+    "role",
+    "content",
+    "recorded_at"
+  ]
+}

--- a/schemas/animus-plugin-protocol/ConversationAppendMessageRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationAppendMessageRequest.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationAppendMessageRequest",
+  "description": "`conversation/append_message` request.",
+  "type": "object",
+  "properties": {
+    "as_user": {
+      "description": "Acting user id, when known. A backend MAY use it to authorize the\nmutation. `None` for unscoped/admin access.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "id": {
+      "description": "Conversation id to append to.",
+      "type": "string"
+    },
+    "message": {
+      "description": "The turn to append.",
+      "$ref": "#/$defs/ChatMessage"
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "message"
+  ],
+  "$defs": {
+    "ChatMessage": {
+      "description": "One persisted turn in a conversation, in the kernel's portable\nprovider-agnostic shape. The plugin persists and returns it verbatim;\n`usage` / `blocks` are opaque JSON to this crate (their schema lives in\nthe kernel's chat store) so the protocol stays free of a `protocol`\ncrate dependency.",
+      "type": "object",
+      "properties": {
+        "blocks": {
+          "description": "Ordered timeline of the assistant turn (opaque JSON array).",
+          "type": "array",
+          "items": true
+        },
+        "content": {
+          "description": "Aggregated text content of the turn.",
+          "type": "string"
+        },
+        "cost_usd": {
+          "description": "Provider-reported USD cost for an assistant turn.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "model": {
+          "description": "Model that produced an assistant turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recorded_at": {
+          "description": "RFC 3339 timestamp when the turn was recorded.",
+          "type": "string"
+        },
+        "role": {
+          "description": "`\"user\"` or `\"assistant\"`.",
+          "type": "string"
+        },
+        "seq": {
+          "description": "Monotonic 0-based index within the conversation.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "tool": {
+          "description": "Provider tool that produced an assistant turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "usage": {
+          "description": "Token usage reported by the provider (opaque JSON object)."
+        }
+      },
+      "required": [
+        "seq",
+        "role",
+        "content",
+        "recorded_at"
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationAppendMessageResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationAppendMessageResponse.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationAppendMessageResponse",
+  "description": "`conversation/append_message` response (empty on success).",
+  "type": "object"
+}

--- a/schemas/animus-plugin-protocol/ConversationCreateRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationCreateRequest.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationCreateRequest",
+  "description": "`conversation/create` request.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Explicit conversation id; the backend assigns one when `None`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "owner": {
+      "description": "Owner to stamp onto the new conversation's meta.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "visibility": {
+      "description": "Initial visibility for the new conversation.",
+      "$ref": "#/$defs/Visibility",
+      "default": "private"
+    }
+  },
+  "$defs": {
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationCreateResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationCreateResponse.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationCreateResponse",
+  "description": "`conversation/create` response.",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "description": "Meta of the freshly-created conversation.",
+      "$ref": "#/$defs/ConversationMeta"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "$defs": {
+    "ConversationMeta": {
+      "description": "Conversation metadata — the continuity pointer, identity, and the\nownership/visibility fields that power per-user history.\n\nThe shape matches the kernel's on-disk `meta.json` exactly so existing\nfilesystem conversations and plugin-backed ones are interchangeable.\n`owner` and `visibility` use serde defaults so legacy `meta.json`\nfiles (which lack both) still deserialize as unowned + private.",
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "description": "RFC 3339 creation timestamp.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable conversation id.",
+          "type": "string"
+        },
+        "message_count": {
+          "description": "Count of persisted turns (user + assistant).",
+          "type": "integer",
+          "format": "uint64",
+          "default": 0,
+          "minimum": 0
+        },
+        "model": {
+          "description": "Model used on the most recent turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Authenticated user id that owns this conversation. `None` = unowned\n(legacy on-disk conversations, or ones created without `--as-user`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_id": {
+          "description": "The wrapped tool's native session handle, for resume continuity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Optional human-facing title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "description": "Wrapped tool that currently owns the native session. `None` until\nthe first turn completes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "RFC 3339 timestamp of the most recent turn.",
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Visibility. Defaults to [`Visibility::Private`] for legacy metas.",
+          "$ref": "#/$defs/Visibility",
+          "default": "private"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationDeleteRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationDeleteRequest.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationDeleteRequest",
+  "description": "`conversation/delete` request.",
+  "type": "object",
+  "properties": {
+    "as_user": {
+      "description": "Acting user id, when known. A backend MAY use it to authorize the\ndelete. `None` for unscoped/admin access.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "id": {
+      "description": "Conversation id to delete.",
+      "type": "string"
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/schemas/animus-plugin-protocol/ConversationDeleteResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationDeleteResponse.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationDeleteResponse",
+  "description": "`conversation/delete` response (empty; delete is idempotent).",
+  "type": "object"
+}

--- a/schemas/animus-plugin-protocol/ConversationListRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationListRequest.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationListRequest",
+  "description": "`conversation/list` request.",
+  "type": "object",
+  "properties": {
+    "as_user": {
+      "description": "When set, the backend returns conversations owned by this user id\nPLUS any [`Visibility::Shared`] ones. When `None`, all\nconversations are returned (legacy/admin view). A backend without\nauth context may ignore this and return everything.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationListResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationListResponse.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationListResponse",
+  "description": "`conversation/list` response, summaries newest-first.",
+  "type": "object",
+  "properties": {
+    "conversations": {
+      "description": "Conversation summaries, most-recently-updated first.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ConversationSummary"
+      }
+    }
+  },
+  "$defs": {
+    "ConversationSummary": {
+      "description": "One-line summary returned by [`METHOD_CONVERSATION_LIST`].",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Conversation id.",
+          "type": "string"
+        },
+        "message_count": {
+          "description": "Persisted turn count.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "model": {
+          "description": "Model used on the most recent turn, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Owner of the conversation, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Title, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "description": "Tool that owns the native session, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "RFC 3339 timestamp of the most recent turn.",
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Visibility of the conversation.",
+          "$ref": "#/$defs/Visibility",
+          "default": "private"
+        }
+      },
+      "required": [
+        "id",
+        "message_count",
+        "updated_at"
+      ]
+    },
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationLoadMessagesRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationLoadMessagesRequest.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationLoadMessagesRequest",
+  "description": "`conversation/load_messages` request.",
+  "type": "object",
+  "properties": {
+    "as_user": {
+      "description": "Acting user id, when known. A backend MAY use it to authorize the\nread. `None` for unscoped/admin access.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "id": {
+      "description": "Conversation id whose messages to read.",
+      "type": "string"
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/schemas/animus-plugin-protocol/ConversationLoadMessagesResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationLoadMessagesResponse.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationLoadMessagesResponse",
+  "description": "`conversation/load_messages` response.",
+  "type": "object",
+  "properties": {
+    "messages": {
+      "description": "The ordered turn history.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ChatMessage"
+      }
+    }
+  },
+  "$defs": {
+    "ChatMessage": {
+      "description": "One persisted turn in a conversation, in the kernel's portable\nprovider-agnostic shape. The plugin persists and returns it verbatim;\n`usage` / `blocks` are opaque JSON to this crate (their schema lives in\nthe kernel's chat store) so the protocol stays free of a `protocol`\ncrate dependency.",
+      "type": "object",
+      "properties": {
+        "blocks": {
+          "description": "Ordered timeline of the assistant turn (opaque JSON array).",
+          "type": "array",
+          "items": true
+        },
+        "content": {
+          "description": "Aggregated text content of the turn.",
+          "type": "string"
+        },
+        "cost_usd": {
+          "description": "Provider-reported USD cost for an assistant turn.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "model": {
+          "description": "Model that produced an assistant turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recorded_at": {
+          "description": "RFC 3339 timestamp when the turn was recorded.",
+          "type": "string"
+        },
+        "role": {
+          "description": "`\"user\"` or `\"assistant\"`.",
+          "type": "string"
+        },
+        "seq": {
+          "description": "Monotonic 0-based index within the conversation.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "tool": {
+          "description": "Provider tool that produced an assistant turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "usage": {
+          "description": "Token usage reported by the provider (opaque JSON object)."
+        }
+      },
+      "required": [
+        "seq",
+        "role",
+        "content",
+        "recorded_at"
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationLoadMetaRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationLoadMetaRequest.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationLoadMetaRequest",
+  "description": "`conversation/load_meta` request.",
+  "type": "object",
+  "properties": {
+    "as_user": {
+      "description": "Acting user id, when known. A backend MAY use it to authorize the\nread (e.g. deny a private conversation owned by another user).\n`None` for unscoped/admin access.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "id": {
+      "description": "Conversation id to load.",
+      "type": "string"
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/schemas/animus-plugin-protocol/ConversationLoadMetaResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationLoadMetaResponse.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationLoadMetaResponse",
+  "description": "`conversation/load_meta` response. `meta` is `None` when the\nconversation does not exist.",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "description": "The conversation meta, or `None` when not found.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ConversationMeta"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "ConversationMeta": {
+      "description": "Conversation metadata — the continuity pointer, identity, and the\nownership/visibility fields that power per-user history.\n\nThe shape matches the kernel's on-disk `meta.json` exactly so existing\nfilesystem conversations and plugin-backed ones are interchangeable.\n`owner` and `visibility` use serde defaults so legacy `meta.json`\nfiles (which lack both) still deserialize as unowned + private.",
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "description": "RFC 3339 creation timestamp.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable conversation id.",
+          "type": "string"
+        },
+        "message_count": {
+          "description": "Count of persisted turns (user + assistant).",
+          "type": "integer",
+          "format": "uint64",
+          "default": 0,
+          "minimum": 0
+        },
+        "model": {
+          "description": "Model used on the most recent turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Authenticated user id that owns this conversation. `None` = unowned\n(legacy on-disk conversations, or ones created without `--as-user`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_id": {
+          "description": "The wrapped tool's native session handle, for resume continuity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Optional human-facing title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "description": "Wrapped tool that currently owns the native session. `None` until\nthe first turn completes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "RFC 3339 timestamp of the most recent turn.",
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Visibility. Defaults to [`Visibility::Private`] for legacy metas.",
+          "$ref": "#/$defs/Visibility",
+          "default": "private"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationMeta.json
+++ b/schemas/animus-plugin-protocol/ConversationMeta.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationMeta",
+  "description": "Conversation metadata — the continuity pointer, identity, and the\nownership/visibility fields that power per-user history.\n\nThe shape matches the kernel's on-disk `meta.json` exactly so existing\nfilesystem conversations and plugin-backed ones are interchangeable.\n`owner` and `visibility` use serde defaults so legacy `meta.json`\nfiles (which lack both) still deserialize as unowned + private.",
+  "type": "object",
+  "properties": {
+    "created_at": {
+      "description": "RFC 3339 creation timestamp.",
+      "type": "string"
+    },
+    "id": {
+      "description": "Stable conversation id.",
+      "type": "string"
+    },
+    "message_count": {
+      "description": "Count of persisted turns (user + assistant).",
+      "type": "integer",
+      "format": "uint64",
+      "default": 0,
+      "minimum": 0
+    },
+    "model": {
+      "description": "Model used on the most recent turn.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "owner": {
+      "description": "Authenticated user id that owns this conversation. `None` = unowned\n(legacy on-disk conversations, or ones created without `--as-user`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "session_id": {
+      "description": "The wrapped tool's native session handle, for resume continuity.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "title": {
+      "description": "Optional human-facing title.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "tool": {
+      "description": "Wrapped tool that currently owns the native session. `None` until\nthe first turn completes.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "updated_at": {
+      "description": "RFC 3339 timestamp of the most recent turn.",
+      "type": "string"
+    },
+    "visibility": {
+      "description": "Visibility. Defaults to [`Visibility::Private`] for legacy metas.",
+      "$ref": "#/$defs/Visibility",
+      "default": "private"
+    }
+  },
+  "required": [
+    "id",
+    "created_at",
+    "updated_at"
+  ],
+  "$defs": {
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationSaveMetaRequest.json
+++ b/schemas/animus-plugin-protocol/ConversationSaveMetaRequest.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationSaveMetaRequest",
+  "description": "`conversation/save_meta` request.",
+  "type": "object",
+  "properties": {
+    "as_user": {
+      "description": "Acting user id, when known. A backend MAY use it to authorize the\nmutation. `None` for unscoped/admin access.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "meta": {
+      "description": "The meta to persist.",
+      "$ref": "#/$defs/ConversationMeta"
+    },
+    "project_root": {
+      "description": "Absolute project root path of the calling CLI/daemon.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repo_scope": {
+      "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "$defs": {
+    "ConversationMeta": {
+      "description": "Conversation metadata — the continuity pointer, identity, and the\nownership/visibility fields that power per-user history.\n\nThe shape matches the kernel's on-disk `meta.json` exactly so existing\nfilesystem conversations and plugin-backed ones are interchangeable.\n`owner` and `visibility` use serde defaults so legacy `meta.json`\nfiles (which lack both) still deserialize as unowned + private.",
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "description": "RFC 3339 creation timestamp.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable conversation id.",
+          "type": "string"
+        },
+        "message_count": {
+          "description": "Count of persisted turns (user + assistant).",
+          "type": "integer",
+          "format": "uint64",
+          "default": 0,
+          "minimum": 0
+        },
+        "model": {
+          "description": "Model used on the most recent turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Authenticated user id that owns this conversation. `None` = unowned\n(legacy on-disk conversations, or ones created without `--as-user`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_id": {
+          "description": "The wrapped tool's native session handle, for resume continuity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Optional human-facing title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "description": "Wrapped tool that currently owns the native session. `None` until\nthe first turn completes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "RFC 3339 timestamp of the most recent turn.",
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Visibility. Defaults to [`Visibility::Private`] for legacy metas.",
+          "$ref": "#/$defs/Visibility",
+          "default": "private"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/ConversationSaveMetaResponse.json
+++ b/schemas/animus-plugin-protocol/ConversationSaveMetaResponse.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationSaveMetaResponse",
+  "description": "`conversation/save_meta` response (empty on success).",
+  "type": "object"
+}

--- a/schemas/animus-plugin-protocol/ConversationSummary.json
+++ b/schemas/animus-plugin-protocol/ConversationSummary.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationSummary",
+  "description": "One-line summary returned by [`METHOD_CONVERSATION_LIST`].",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Conversation id.",
+      "type": "string"
+    },
+    "message_count": {
+      "description": "Persisted turn count.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    },
+    "model": {
+      "description": "Model used on the most recent turn, if any.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "owner": {
+      "description": "Owner of the conversation, if any.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "title": {
+      "description": "Title, if any.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "tool": {
+      "description": "Tool that owns the native session, if any.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "updated_at": {
+      "description": "RFC 3339 timestamp of the most recent turn.",
+      "type": "string"
+    },
+    "visibility": {
+      "description": "Visibility of the conversation.",
+      "$ref": "#/$defs/Visibility",
+      "default": "private"
+    }
+  },
+  "required": [
+    "id",
+    "message_count",
+    "updated_at"
+  ],
+  "$defs": {
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string",
+          "const": "private"
+        },
+        {
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string",
+          "const": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/animus-plugin-protocol/_all.json
+++ b/schemas/animus-plugin-protocol/_all.json
@@ -1,5 +1,521 @@
 {
   "$defs": {
+    "ChatMessage": {
+      "description": "One persisted turn in a conversation, in the kernel's portable\nprovider-agnostic shape. The plugin persists and returns it verbatim;\n`usage` / `blocks` are opaque JSON to this crate (their schema lives in\nthe kernel's chat store) so the protocol stays free of a `protocol`\ncrate dependency.",
+      "properties": {
+        "blocks": {
+          "description": "Ordered timeline of the assistant turn (opaque JSON array).",
+          "items": true,
+          "type": "array"
+        },
+        "content": {
+          "description": "Aggregated text content of the turn.",
+          "type": "string"
+        },
+        "cost_usd": {
+          "description": "Provider-reported USD cost for an assistant turn.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "model": {
+          "description": "Model that produced an assistant turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recorded_at": {
+          "description": "RFC 3339 timestamp when the turn was recorded.",
+          "type": "string"
+        },
+        "role": {
+          "description": "`\"user\"` or `\"assistant\"`.",
+          "type": "string"
+        },
+        "seq": {
+          "description": "Monotonic 0-based index within the conversation.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tool": {
+          "description": "Provider tool that produced an assistant turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "usage": {
+          "description": "Token usage reported by the provider (opaque JSON object)."
+        }
+      },
+      "required": [
+        "seq",
+        "role",
+        "content",
+        "recorded_at"
+      ],
+      "title": "ChatMessage",
+      "type": "object"
+    },
+    "ConversationAppendMessageRequest": {
+      "description": "`conversation/append_message` request.",
+      "properties": {
+        "as_user": {
+          "description": "Acting user id, when known. A backend MAY use it to authorize the\nmutation. `None` for unscoped/admin access.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Conversation id to append to.",
+          "type": "string"
+        },
+        "message": {
+          "$ref": "#/$defs/ChatMessage",
+          "description": "The turn to append."
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "message"
+      ],
+      "title": "ConversationAppendMessageRequest",
+      "type": "object"
+    },
+    "ConversationAppendMessageResponse": {
+      "description": "`conversation/append_message` response (empty on success).",
+      "title": "ConversationAppendMessageResponse",
+      "type": "object"
+    },
+    "ConversationCreateRequest": {
+      "description": "`conversation/create` request.",
+      "properties": {
+        "id": {
+          "description": "Explicit conversation id; the backend assigns one when `None`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Owner to stamp onto the new conversation's meta.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "visibility": {
+          "$ref": "#/$defs/Visibility",
+          "default": "private",
+          "description": "Initial visibility for the new conversation."
+        }
+      },
+      "title": "ConversationCreateRequest",
+      "type": "object"
+    },
+    "ConversationCreateResponse": {
+      "description": "`conversation/create` response.",
+      "properties": {
+        "meta": {
+          "$ref": "#/$defs/ConversationMeta",
+          "description": "Meta of the freshly-created conversation."
+        }
+      },
+      "required": [
+        "meta"
+      ],
+      "title": "ConversationCreateResponse",
+      "type": "object"
+    },
+    "ConversationDeleteRequest": {
+      "description": "`conversation/delete` request.",
+      "properties": {
+        "as_user": {
+          "description": "Acting user id, when known. A backend MAY use it to authorize the\ndelete. `None` for unscoped/admin access.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Conversation id to delete.",
+          "type": "string"
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ConversationDeleteRequest",
+      "type": "object"
+    },
+    "ConversationDeleteResponse": {
+      "description": "`conversation/delete` response (empty; delete is idempotent).",
+      "title": "ConversationDeleteResponse",
+      "type": "object"
+    },
+    "ConversationListRequest": {
+      "description": "`conversation/list` request.",
+      "properties": {
+        "as_user": {
+          "description": "When set, the backend returns conversations owned by this user id\nPLUS any [`Visibility::Shared`] ones. When `None`, all\nconversations are returned (legacy/admin view). A backend without\nauth context may ignore this and return everything.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "ConversationListRequest",
+      "type": "object"
+    },
+    "ConversationListResponse": {
+      "description": "`conversation/list` response, summaries newest-first.",
+      "properties": {
+        "conversations": {
+          "default": [],
+          "description": "Conversation summaries, most-recently-updated first.",
+          "items": {
+            "$ref": "#/$defs/ConversationSummary"
+          },
+          "type": "array"
+        }
+      },
+      "title": "ConversationListResponse",
+      "type": "object"
+    },
+    "ConversationLoadMessagesRequest": {
+      "description": "`conversation/load_messages` request.",
+      "properties": {
+        "as_user": {
+          "description": "Acting user id, when known. A backend MAY use it to authorize the\nread. `None` for unscoped/admin access.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Conversation id whose messages to read.",
+          "type": "string"
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ConversationLoadMessagesRequest",
+      "type": "object"
+    },
+    "ConversationLoadMessagesResponse": {
+      "description": "`conversation/load_messages` response.",
+      "properties": {
+        "messages": {
+          "default": [],
+          "description": "The ordered turn history.",
+          "items": {
+            "$ref": "#/$defs/ChatMessage"
+          },
+          "type": "array"
+        }
+      },
+      "title": "ConversationLoadMessagesResponse",
+      "type": "object"
+    },
+    "ConversationLoadMetaRequest": {
+      "description": "`conversation/load_meta` request.",
+      "properties": {
+        "as_user": {
+          "description": "Acting user id, when known. A backend MAY use it to authorize the\nread (e.g. deny a private conversation owned by another user).\n`None` for unscoped/admin access.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Conversation id to load.",
+          "type": "string"
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ConversationLoadMetaRequest",
+      "type": "object"
+    },
+    "ConversationLoadMetaResponse": {
+      "description": "`conversation/load_meta` response. `meta` is `None` when the\nconversation does not exist.",
+      "properties": {
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConversationMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The conversation meta, or `None` when not found."
+        }
+      },
+      "title": "ConversationLoadMetaResponse",
+      "type": "object"
+    },
+    "ConversationMeta": {
+      "description": "Conversation metadata — the continuity pointer, identity, and the\nownership/visibility fields that power per-user history.\n\nThe shape matches the kernel's on-disk `meta.json` exactly so existing\nfilesystem conversations and plugin-backed ones are interchangeable.\n`owner` and `visibility` use serde defaults so legacy `meta.json`\nfiles (which lack both) still deserialize as unowned + private.",
+      "properties": {
+        "created_at": {
+          "description": "RFC 3339 creation timestamp.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable conversation id.",
+          "type": "string"
+        },
+        "message_count": {
+          "default": 0,
+          "description": "Count of persisted turns (user + assistant).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "model": {
+          "description": "Model used on the most recent turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Authenticated user id that owns this conversation. `None` = unowned\n(legacy on-disk conversations, or ones created without `--as-user`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_id": {
+          "description": "The wrapped tool's native session handle, for resume continuity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Optional human-facing title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "description": "Wrapped tool that currently owns the native session. `None` until\nthe first turn completes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "RFC 3339 timestamp of the most recent turn.",
+          "type": "string"
+        },
+        "visibility": {
+          "$ref": "#/$defs/Visibility",
+          "default": "private",
+          "description": "Visibility. Defaults to [`Visibility::Private`] for legacy metas."
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "ConversationMeta",
+      "type": "object"
+    },
+    "ConversationSaveMetaRequest": {
+      "description": "`conversation/save_meta` request.",
+      "properties": {
+        "as_user": {
+          "description": "Acting user id, when known. A backend MAY use it to authorize the\nmutation. `None` for unscoped/admin access.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": {
+          "$ref": "#/$defs/ConversationMeta",
+          "description": "The meta to persist."
+        },
+        "project_root": {
+          "description": "Absolute project root path of the calling CLI/daemon.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repo_scope": {
+          "description": "Repository scope id (see `protocol::repository_scope_for_path`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "meta"
+      ],
+      "title": "ConversationSaveMetaRequest",
+      "type": "object"
+    },
+    "ConversationSaveMetaResponse": {
+      "description": "`conversation/save_meta` response (empty on success).",
+      "title": "ConversationSaveMetaResponse",
+      "type": "object"
+    },
+    "ConversationSummary": {
+      "description": "One-line summary returned by [`METHOD_CONVERSATION_LIST`].",
+      "properties": {
+        "id": {
+          "description": "Conversation id.",
+          "type": "string"
+        },
+        "message_count": {
+          "description": "Persisted turn count.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "model": {
+          "description": "Model used on the most recent turn, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "description": "Owner of the conversation, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Title, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "description": "Tool that owns the native session, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "RFC 3339 timestamp of the most recent turn.",
+          "type": "string"
+        },
+        "visibility": {
+          "$ref": "#/$defs/Visibility",
+          "default": "private",
+          "description": "Visibility of the conversation."
+        }
+      },
+      "required": [
+        "id",
+        "message_count",
+        "updated_at"
+      ],
+      "title": "ConversationSummary",
+      "type": "object"
+    },
     "EnvRequirement": {
       "description": "One environment variable a plugin asks the host to forward at spawn time.\n\nThe host treats `name` as the source of truth: only matching variables are\npassed through the `env_clear()` boundary. `description` and `sensitive`\nare informational hints surfaced in `animus plugin info` and the install\nflow so operators can decide whether a plugin's secret requirements are\nreasonable before granting it access.\n\nWhen `required` is set, the host emits a warning at spawn time if the\nvariable isn't present in the daemon's own environment. The host never\nrefuses to spawn over a missing required var — that decision belongs to\nthe plugin itself, which sees the missing variable during its own startup.",
       "properties": {
@@ -540,6 +1056,21 @@
       },
       "title": "TriggerWatchParams",
       "type": "object"
+    },
+    "Visibility": {
+      "description": "Visibility of a conversation. Controls whether [`ConversationListRequest::as_user`]\nfiltering surfaces it to users other than its `owner`.",
+      "oneOf": [
+        {
+          "const": "private",
+          "description": "Visible only to the conversation's `owner` (and to unscoped/admin\nqueries that pass no `as_user`). The default.",
+          "type": "string"
+        },
+        {
+          "const": "shared",
+          "description": "Visible to every user, in addition to its owner.",
+          "type": "string"
+        }
+      ]
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Makes the chat conversation store pluggable via a new **optional** kernel `conversation_store` plugin role, mirroring `config_source`/`subject_backend`. Foundation for per-user + shared chat history served by an out-of-tree Postgres plugin (built next).

## What's in here
- **Contract** (`crates/animus-plugin-protocol`, module `conversation_store`): `conversation/{create,load_meta,save_meta,append_message,load_messages,list,delete}` with serde request/response types + exported JSON schemas. `try_lock_conversation` deliberately stays off the wire (store-internal). `seq` is client-authoritative; multi-host backends serialize via `UNIQUE(conversation_id, seq)` or per-conversation advisory lock.
- **Schema**: `ConversationMeta` gains `owner: Option<String>` (`None` = unowned/legacy) and `visibility: Visibility {Private, Shared}` (default Private). Serde-defaulted → existing on-disk `meta.json` still loads.
- **Client seam** (`runtime_chat/client.rs`): `ConversationStoreClient` routes to a discovered `conversation_store` plugin (host reaped each call per the v0.6.3 leak lesson) else falls back to the in-tree `FileConversationStore`. Optional role — chat works with zero plugins; NOT added to `daemon_default()` required roles.
- **CLI**: `animus chat --as-user <id>` (new/send/list/get/delete + rename/export/search) and `--visibility` on `new`. `list --as-user X` returns X's own + all Shared; no flag = all (legacy/admin). Client-side access enforcement; direct-id denials return uniform "not found" to avoid existence leaks.
- Docs: `docs/reference/chat.md`, `cli/index.md`, `configuration.md`.

## Verification (main loop)
- `cargo build -p orchestrator-cli` ✅, `cargo fmt --check` ✅, `cargo clippy -p orchestrator-cli` clean ✅
- `cargo test -p orchestrator-cli runtime_chat` → 45/45 ✅
- Sub-agent codex self-vet: 7 rounds, all P1 cleared, final round clean.
- 3 pre-existing `auto_resume::restart_resume_*` oai-runner test failures are environment-dependent and present on clean origin/main (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)