### PR TITLE
release: v0.6.4 — pluggable conversation_store + per-user chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-06-22
+
+**v0.6.4 — pluggable chat conversation store (per-user + shared history).**
+
+- New OPTIONAL kernel plugin role `conversation_store` (mirrors `config_source` /
+  `subject_backend`): when a `conversation_store` plugin is installed the CLI
+  routes chat persistence through it, else falls back to the in-tree
+  `FileConversationStore`. Not a required preflight role — chat works with zero
+  plugins installed.
+- `ConversationMeta` gains `owner: Option<String>` and `visibility {private,shared}`
+  (serde-defaulted, back-compatible with existing on-disk conversations).
+- `animus chat` gains `--as-user <id>` (new/send/list/get/delete/rename/export/
+  search) and `--visibility` (new). `list --as-user X` returns X's own + all
+  shared; direct-id denials return uniform "not found" to avoid existence leaks.
+- Wire contract in `animus-plugin-protocol::conversation_store`
+  (`conversation/{create,load_meta,save_meta,append_message,load_messages,list,delete}`);
+  `seq` is client-authoritative. Reference backend: `launchapp-dev/animus-chat-postgres`.
+
 ## [0.6.3] - 2026-06-22
 
 **v0.6.3 — fix the config_source plugin process/connection leak (fleet-wide).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Cuts v0.6.4. Bumps orchestrator-cli 0.6.3 → 0.6.4 + CHANGELOG. Ships the conversation_store plugin role merged in #257 (per-user + shared chat history, `animus chat --as-user`). Merging fires auto-tag-release → v0.6.4 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)