### PR TITLE
test(drift): allowlist conversation_store in-tree-only surface

### DIFF
--- a/crates/orchestrator-plugin-host/tests/protocol_drift.rs
+++ b/crates/orchestrator-plugin-host/tests/protocol_drift.rs
@@ -372,6 +372,14 @@ fn protocol_public_surface_does_not_drift_against_standalone() {
         "PluginKind.WebUi",
         "PLUGIN_KIND_TRANSPORT_BACKEND",
         "PLUGIN_KIND_WEB_UI",
+        // v0.6.4 conversation_store plugin role (per-user + shared chat history).
+        // The in-tree crate added the role + wire contract; it is ALREADY
+        // published in the standalone repo at tag v0.1.20, but STANDALONE_TAG
+        // here is still pinned to v0.1.13. Drop these two entries once
+        // STANDALONE_TAG advances to >= v0.1.20 (the PluginKind.ConversationStore
+        // variant is already covered by the blanket "PluginKind" entry above).
+        "PLUGIN_KIND_CONVERSATION_STORE",
+        "conversation_store",
     ];
 
     let unexpected_findings: Vec<&DriftFinding> =


### PR DESCRIPTION
Fixes the Protocol Drift CI failure on main since #257/v0.6.4. The conversation_store role's `PLUGIN_KIND_CONVERSATION_STORE` + `conversation_store` module are in-tree but the drift check pins STANDALONE_TAG=v0.1.13 (they're published in the standalone repo at v0.1.20). Allowlisted with a tracking note, matching the existing pattern for every prior in-tree-leading addition. Verified locally: drift test passes against v0.1.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)