### PR TITLE
feat(plugin): animus.lock — reproducible plugin pinning

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/plugin_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/plugin_types.rs
@@ -575,6 +575,14 @@ pub(crate) struct PluginInstallArgs {
     /// overwriting it.
     #[arg(long, default_value_t = false)]
     pub(crate) force_rewrite_lockfile: bool,
+    /// Install EXACTLY the set pinned in `.animus/plugins.lock` (ignores any
+    /// positional source). Resolves each locked entry to its recorded tag,
+    /// reinstalls, and verifies the installed artifact's sha256 against the
+    /// lockfile. Fails if the lockfile is missing or any entry cannot be
+    /// satisfied. The reproducible-CI / fresh-machine path. Mutually exclusive
+    /// with a positional source, `--path`, `--url`, and `--tag`.
+    #[arg(long, default_value_t = false)]
+    pub(crate) locked: bool,
     /// (v0.5.7) Override the installed-kind assigned to a subject_backend
     /// plugin at install time. The supplied KIND becomes the user-facing
     /// prefix the SubjectRouter dispatches against (e.g. `archive` for a

--- a/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
@@ -1563,6 +1563,8 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
             bundle_path: release.bundle_path.clone(),
             owner: Some(release.owner.clone()),
             repo: Some(release.repo.clone()),
+            source_repo: Some(format!("{}/{}", release.owner, release.repo)),
+            resolved_commit: release.resolved_commit.clone(),
         };
         let release_assets = release.release_assets.clone();
         (release.binary_path, release.plugin_name_hint, provenance, Some(release._temp_dir), Some(release_assets))
@@ -1570,7 +1572,11 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
         (
             PathBuf::from(p),
             String::new(),
-            InstallProvenance { source_kind: Some("path"), ..Default::default() },
+            InstallProvenance {
+                source_kind: Some("path"),
+                source_repo: Some(format!("path:{p}")),
+                ..Default::default()
+            },
             None,
             None,
         )
@@ -1584,6 +1590,7 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
             source_kind: Some("url"),
             origin: Some(u.to_string()),
             sha256_verified: Some(true),
+            source_repo: Some(u.to_string()),
             ..Default::default()
         };
         (path, String::new(), provenance, Some(temp_dir), None)
@@ -1880,10 +1887,18 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
                         )
                     })?;
                     ensure_executable(&secondary_install_path)?;
+                    // Record the EXTRACTED BINARY's sha256 (not the archive's
+                    // `computed_secondary` checked against the release sidecar
+                    // above) so the lockfile pin matches the on-disk binary.
+                    // Every consumer — `plugin lock verify`, `install --locked`,
+                    // and the daemon lock-drift warning — hashes the installed
+                    // binary, so the pin must be the binary hash to stay
+                    // verifiable for archived secondary assets.
+                    let secondary_binary_sha = sha256_of_file(&secondary_install_path)?;
                     secondary_installed.push((
                         descriptor.name.clone(),
                         secondary_install_path,
-                        computed_secondary,
+                        secondary_binary_sha,
                         Some(secondary_temp),
                     ));
                     installed_binary_names.push(descriptor.name.clone());
@@ -2040,8 +2055,12 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
         installed_at: recorded_at.clone(),
         installed_kind: assigned_kind.clone(),
         native_kind: native_kind_for_lock.clone(),
+        source_repo: provenance.source_repo.clone(),
+        resolved_commit: provenance.resolved_commit.clone(),
     }];
     for (secondary_name, _path, secondary_sha, _temp) in &secondary_installed {
+        // Secondary (multi-binary) entries ship in the same release, so they
+        // inherit the primary's source + resolved commit.
         new_lock_entries.push(LockEntry {
             name: secondary_name.clone(),
             version: provenance.release_tag.clone().unwrap_or_default(),
@@ -2050,6 +2069,8 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
             installed_at: recorded_at.clone(),
             installed_kind: None,
             native_kind: None,
+            source_repo: provenance.source_repo.clone(),
+            resolved_commit: provenance.resolved_commit.clone(),
         });
     }
     // Multi-binary follow-up to the primary-name routing above: secondary
@@ -3502,8 +3523,22 @@ fn current_platform_label() -> String {
 #[derive(Debug, Clone, serde::Deserialize)]
 struct GithubRelease {
     tag_name: String,
+    /// The commitish the release tag points at. For a tag created directly on
+    /// a commit this is the 40-hex sha; for a tag created against a branch the
+    /// GitHub API returns the branch name. Only recorded as `resolved_commit`
+    /// when it is a real sha (see [`is_commit_sha`]).
+    #[serde(default)]
+    target_commitish: Option<String>,
     #[serde(default)]
     assets: Vec<GithubReleaseAsset>,
+}
+
+/// Returns `true` when `s` is a 40-char lowercase-hex git commit sha. GitHub's
+/// release `target_commitish` is a sha only when the tag was created on a
+/// commit; tags created against a branch return the branch name instead, which
+/// must NOT be recorded as a resolved commit.
+fn is_commit_sha(s: &str) -> bool {
+    s.len() == 40 && s.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -3734,6 +3769,9 @@ struct ReleaseInstall {
     plugin_name_hint: String,
     asset_name: String,
     release_tag: String,
+    /// 40-hex commit sha the release resolved to, when its `target_commitish`
+    /// was a sha (not a branch name). `None` otherwise.
+    resolved_commit: Option<String>,
     origin: String,
     sha256_verified: bool,
     /// Downloaded asset archive (`.tar.gz` etc.) — what cosign signed.
@@ -3898,6 +3936,7 @@ async fn resolve_release_install(spec: RepoSpec, explicit_tag: Option<String>) -
         plugin_name_hint,
         asset_name: asset.name.clone(),
         release_tag: release.tag_name.clone(),
+        resolved_commit: release.target_commitish.as_deref().filter(|c| is_commit_sha(c)).map(str::to_string),
         origin: format!("{}/{}@{}", spec.owner, spec.repo, release.tag_name),
         sha256_verified,
         asset_archive_path: Some(asset_path.clone()),
@@ -4300,6 +4339,14 @@ struct InstallProvenance {
     owner: Option<String>,
     /// `<repo>` for identity-regex construction.
     repo: Option<String>,
+    /// Where this install came from, recorded into the lockfile's
+    /// `source_repo`: an `owner/repo` slug for release installs, the URL for
+    /// `--url`, or `path:<...>` for `--path`. Drives `plugin install --locked`
+    /// reproducibility.
+    source_repo: Option<String>,
+    /// 40-hex commit sha the release resolved to (release source only),
+    /// recorded into the lockfile's `resolved_commit`.
+    resolved_commit: Option<String>,
 }
 
 /// Probe a plugin binary's `--manifest` output without touching the install
@@ -4654,6 +4701,15 @@ fn enforce_org_trust(owner: &str, req: &PluginInstallRequest) -> Result<Option<T
 }
 
 async fn handle_plugin_install(args: PluginInstallArgs, project_root: &str, json: bool) -> Result<()> {
+    if args.locked {
+        if args.source.is_some() || args.path.is_some() || args.url.is_some() || args.tag.is_some() || args.latest {
+            return Err(invalid_input_error(
+                "--locked installs the set pinned in `.animus/plugins.lock` and is mutually exclusive with a \
+                 positional source, --path, --url, --tag, and --latest",
+            ));
+        }
+        return run_locked_install(args, project_root, json).await;
+    }
     if args.latest && args.tag.is_some() {
         return Err(invalid_input_error("--latest and --tag are mutually exclusive"));
     }
@@ -4703,6 +4759,319 @@ async fn handle_plugin_install(args: PluginInstallArgs, project_root: &str, json
         crate::services::metrics::EventTags::PluginInstalled { plugin_kind: role },
     );
     print_value(output, json)
+}
+
+#[derive(Debug, Serialize)]
+struct LockedInstallRow {
+    name: String,
+    source_repo: String,
+    version: String,
+    expected_sha256: String,
+    /// `installed` | `verified` | `failed`.
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LockedInstallOutput {
+    schema: &'static str,
+    lockfile: String,
+    installed: usize,
+    failed: usize,
+    rows: Vec<LockedInstallRow>,
+}
+
+/// Reproducible install: reinstall EXACTLY the set pinned in
+/// `.animus/plugins.lock`, then verify each freshly installed artifact's
+/// sha256 against the lockfile. Used by the CI / fresh-machine path
+/// (`animus plugin install --locked`). Fails the whole run if the lockfile is
+/// missing/empty, an entry cannot be reconstructed, or any installed artifact
+/// hash drifts from the pin (the published release changed under the pin).
+async fn run_locked_install(args: PluginInstallArgs, project_root: &str, json: bool) -> Result<()> {
+    let root = std::path::Path::new(project_root);
+    // Carry the operator's install-security flags through to every reinstall
+    // so e.g. `--locked --signature-policy strict` actually enforces strict
+    // signatures in CI rather than silently falling back to the default warn
+    // policy (codex P2). The legacy `require_signature` / `skip_signature` are
+    // folded into the resolved policy; resolution also validates conflicting
+    // flag combinations up front.
+    let signature_policy = resolve_cli_signature_policy(&args)?;
+    let trusted_signers = args.trusted_signers.clone();
+    let allow_shadow_builtin = args.allow_shadow_builtin;
+    let lock_path = PluginLockfile::default_path(Some(root));
+    if !lock_path.exists() {
+        return Err(invalid_input_error(format!(
+            "no plugin lockfile at {} — `--locked` reproduces a previously recorded set, so the lockfile must \
+             exist. Install plugins normally first (e.g. `animus plugin install-defaults`) to record it.",
+            lock_path.display()
+        )));
+    }
+    let lockfile = PluginLockfile::load_or_empty(&lock_path)?;
+    if lockfile.plugins.is_empty() {
+        return Err(invalid_input_error(format!(
+            "plugin lockfile {} is empty — nothing to install",
+            lock_path.display()
+        )));
+    }
+
+    // `--locked` REPRODUCES the committed pin; it must never rewrite it. The
+    // reinstalls below route through `run_plugin_install`, which re-saves the
+    // lockfile (including new secondary-binary entries) on success — so if a
+    // secondary asset changed under the same tag, the pin would be silently
+    // overwritten before verification fails (codex P1). Capture the committed
+    // entries now and re-assert them afterward through the locked
+    // `PluginLockfile::save()` path so the restore is serialized + merged with
+    // any concurrent installer instead of clobbering its entry with a raw
+    // byte rewrite (codex P2).
+    let original_entries = lockfile.plugins.clone();
+    let lock_path_for_restore = lock_path.clone();
+    let restore_lock = move |entries: &[LockEntry]| {
+        // Reload under the save-lock and re-assert ONLY the entries this
+        // locked run owns, reverting any drifted values the reinstalls wrote.
+        // `save()` holds the fs2 sidecar lock and merges on-disk entries this
+        // snapshot never saw, so a concurrent installer's unrelated new entry
+        // survives.
+        match PluginLockfile::load_or_empty(&lock_path_for_restore) {
+            Ok(mut reloaded) => {
+                for entry in entries {
+                    reloaded.upsert(entry.clone());
+                }
+                if let Err(err) = reloaded.save() {
+                    tracing::warn!(path = %lock_path_for_restore.display(), %err, "failed to restore lockfile pins after --locked install");
+                }
+            }
+            Err(err) => {
+                tracing::warn!(path = %lock_path_for_restore.display(), %err, "failed to reload lockfile to restore pins after --locked install");
+            }
+        }
+    };
+
+    // Infer project scope when reproducing a PROJECT lockfile: a
+    // `.animus/plugins.lock` committed by `animus plugin install --project`
+    // must reinstall into `<project>/.animus/plugins/`, otherwise the locked
+    // binaries land in the global dir while the committed project
+    // `plugins.yaml` still points at the project dir — leaving daemon preflight
+    // unsatisfied after a "verified" run (codex P2). An explicit
+    // `--plugin-dir` override opts out (the operator chose the dir). `--project`
+    // forces it regardless.
+    let resolves_project_lock = lock_path == project_lockfile_path(root);
+    let effective_project = args.project || (resolves_project_lock && args.plugin_dir.is_none());
+
+    // Install dir the reinstalled binaries land in — verification re-hashes
+    // each locked binary here against its pin.
+    let install_dir =
+        if effective_project { project_plugin_install_dir(root) } else { install_root(args.plugin_dir.as_deref())? };
+
+    // A release reinstall reproduces ALL of its sibling binaries (multi-binary
+    // releases publish secondary archives in the same release), so installing
+    // once per `(source_repo, version)` group reproduces every locked entry
+    // from that release. Reinstalling each row independently would replay the
+    // PRIMARY release asset under a secondary entry's name and clobber it
+    // (codex P1). `--url` / `path:` sources install per-entry. We track which
+    // groups were already installed so secondary rows don't reinstall.
+    //
+    // TODO(codex-p2): the `(source_repo, version)` group key cannot tell a
+    // multi-binary release's SECONDARY entry apart from a SEPARATE primary
+    // install of the same release under a different `--name`/`--as-kind`. In
+    // the latter (rare) case the second row is skipped and then fails
+    // verification as "missing". Distinguishing them needs the release's
+    // declared binary set (`plugin.toml`), which is not recorded in the lock;
+    // deferred.
+    let mut installed_release_groups: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut rows: Vec<LockedInstallRow> = Vec::with_capacity(lockfile.plugins.len());
+    let mut failed = 0_usize;
+    let mut installed = 0_usize;
+
+    for entry in &lockfile.plugins {
+        let Some(source_repo) = entry.source_repo.as_deref().filter(|s| !s.is_empty()) else {
+            failed += 1;
+            rows.push(LockedInstallRow {
+                name: entry.name.clone(),
+                source_repo: String::new(),
+                version: entry.version.clone(),
+                expected_sha256: entry.artifact_sha256.clone(),
+                status: "failed",
+                detail: Some("lockfile entry records no source_repo — installed before source provenance was tracked; reinstall it once to record the source".to_string()),
+            });
+            continue;
+        };
+
+        let is_url = source_repo.starts_with("https://");
+        let is_path = source_repo.starts_with("path:");
+        let is_release = !is_url && !is_path;
+        let group_key = (source_repo.to_string(), entry.version.clone());
+        let already_installed = is_release && installed_release_groups.contains(&group_key);
+
+        let install_err = if already_installed {
+            // A sibling row from the same release already triggered the
+            // reinstall; this row only needs verification below.
+            None
+        } else {
+            // Carry the locked dispatch alias through so a fresh-machine
+            // `--locked` reinstall keeps the recorded `installed_kind`. Without
+            // this, a subject backend locked as e.g. `archive` would be
+            // recomputed to its native/auto-incremented kind and silently break
+            // workflows that dispatch to the locked alias (codex P2). Only set
+            // it for a TRUE rename (installed_kind != native_kind) — passing
+            // `--as-kind` on a non-renamed / non-subject plugin is an error.
+            let locked_as_kind = match (entry.effective_installed_kind(), entry.effective_native_kind()) {
+                (Some(installed), Some(native)) if installed != native => Some(installed.to_string()),
+                _ => None,
+            };
+            let mut req = PluginInstallRequest {
+                name: Some(entry.name.clone()),
+                force: true,
+                project_root: Some(project_root.to_string()),
+                project: effective_project,
+                plugin_dir: args.plugin_dir.clone(),
+                yes: true,
+                allow_org: vec![],
+                allow_shadow_builtin,
+                as_kind: locked_as_kind,
+                signature_policy: Some(signature_policy),
+                trusted_signers: trusted_signers.clone(),
+                ..Default::default()
+            };
+            if is_url {
+                req.url = Some(source_repo.to_string());
+                req.sha256 = Some(entry.artifact_sha256.clone());
+            } else if let Some(path) = source_repo.strip_prefix("path:") {
+                req.path = Some(path.to_string());
+                req.sha256 = Some(entry.artifact_sha256.clone());
+            } else {
+                req.source = Some(source_repo.to_string());
+                req.tag = if entry.version.is_empty() { None } else { Some(entry.version.clone()) };
+                // Pin the release asset's checksum so the install pipeline's
+                // PRE-manifest checksum gate aborts before executing a binary
+                // whose hash drifted from the lock — never run unpinned code
+                // (codex P1). The primary entry is written to the lockfile
+                // first, so it is the first row of each release group and its
+                // `artifact_sha256` matches the primary release asset.
+                //
+                // TODO(codex-p2): the install pipeline only pins the PRIMARY
+                // asset via `req.sha256`; a multi-binary release's SECONDARY
+                // assets are checked against the release sidecar/digest, not
+                // the lock, so a drifted secondary is copied to disk and only
+                // flagged when this `--locked` run verifies it below. The lock
+                // pin is preserved (a re-run re-detects the drift), but the
+                // drifted secondary binary is left installed. Removing it would
+                // need per-binary rollback in the install pipeline; deferred.
+                req.sha256 = Some(entry.artifact_sha256.clone());
+            }
+            match run_plugin_install(req).await {
+                Ok(_) => {
+                    if is_release {
+                        installed_release_groups.insert(group_key);
+                    }
+                    None
+                }
+                Err(err) => Some(format!("{err:#}")),
+            }
+        };
+
+        if let Some(err) = install_err {
+            failed += 1;
+            rows.push(LockedInstallRow {
+                name: entry.name.clone(),
+                source_repo: source_repo.to_string(),
+                version: entry.version.clone(),
+                expected_sha256: entry.artifact_sha256.clone(),
+                status: "failed",
+                detail: Some(format!("reinstall failed: {err}")),
+            });
+            continue;
+        }
+
+        // Verify THIS entry's installed binary against its pin. The lockfile
+        // `artifact_sha256` is the installed BINARY's hash for every entry —
+        // primary AND secondary (multi-binary releases record the extracted
+        // binary sha, not the archive sha) — so hashing `install_dir/<name>`
+        // and comparing is correct for all entries. A drift here means the
+        // published source changed under the pin; `--locked` then fails the
+        // CI / fresh-machine reproducibility gate rather than rewriting the
+        // pin (codex P1).
+        let binary = install_dir.join(&entry.name);
+        match lockfile.verify_entry(&entry.name, &sha256_of_file(&binary).unwrap_or_default()) {
+            LockVerifyResult::Match => {
+                installed += 1;
+                rows.push(LockedInstallRow {
+                    name: entry.name.clone(),
+                    source_repo: source_repo.to_string(),
+                    version: entry.version.clone(),
+                    expected_sha256: entry.artifact_sha256.clone(),
+                    status: "verified",
+                    detail: None,
+                });
+            }
+            LockVerifyResult::Mismatch { expected, actual } => {
+                failed += 1;
+                rows.push(LockedInstallRow {
+                    name: entry.name.clone(),
+                    source_repo: source_repo.to_string(),
+                    version: entry.version.clone(),
+                    expected_sha256: entry.artifact_sha256.clone(),
+                    status: "failed",
+                    detail: Some(format!(
+                        "artifact sha256 drifted from the pin: lockfile expected {expected} but the installed binary \
+                         at {} hashes to {actual} — the published source changed under the pin",
+                        binary.display()
+                    )),
+                });
+            }
+            LockVerifyResult::Missing => {
+                failed += 1;
+                rows.push(LockedInstallRow {
+                    name: entry.name.clone(),
+                    source_repo: source_repo.to_string(),
+                    version: entry.version.clone(),
+                    expected_sha256: entry.artifact_sha256.clone(),
+                    status: "failed",
+                    detail: Some(format!("installed binary not found at {} after reinstall", binary.display())),
+                });
+            }
+        }
+    }
+
+    // Restore the committed pins: the reinstalls above may have re-saved the
+    // lockfile with drifted secondary entries; `--locked` must leave the
+    // entries it owns exactly as committed so a later CI run cannot pass
+    // against drift.
+    restore_lock(&original_entries);
+
+    let output = LockedInstallOutput {
+        schema: "animus.plugin.install-locked.v1",
+        lockfile: lock_path.to_string_lossy().to_string(),
+        installed,
+        failed,
+        rows,
+    };
+
+    if json {
+        print_value(output, true)?;
+    } else {
+        println!("plugin install --locked (lockfile: {})", output.lockfile);
+        for row in &output.rows {
+            match row.status {
+                "verified" => println!("  [ok] {} {} (sha verified)", row.name, row.version),
+                _ => println!(
+                    "  [FAIL] {} {} — {}",
+                    row.name,
+                    row.version,
+                    row.detail.as_deref().unwrap_or("unknown error")
+                ),
+            }
+        }
+        println!("summary: {} verified, {} failed", output.installed, output.failed);
+    }
+
+    if failed > 0 {
+        return Err(anyhow!(
+            "plugin install --locked failed: {failed} of {} entries could not be reproduced",
+            lockfile.plugins.len()
+        ));
+    }
+    Ok(())
 }
 
 /// Maps a plugin manifest `plugin_kind` string into the bounded
@@ -5047,6 +5416,9 @@ struct PluginLockVerifyOutput {
     matched: usize,
     mismatched: usize,
     missing_binary: usize,
+    /// Installed plugins discovered on disk that are absent from every swept
+    /// lockfile. Like mismatch/missing this is drift and fails the verify gate.
+    extra: usize,
 }
 
 // ===== `plugin doctor` =====
@@ -5316,14 +5688,16 @@ fn run_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result<()>
     let json = args.json;
     let output = compute_lock_verify(args, project_root)?;
     // `animus plugin lock verify` is meant to be wired into CI / cron as a
-    // tamper-detection gate. Both a hash mismatch AND a missing on-disk binary
-    // for a tracked entry indicate the install state has drifted from the
-    // lockfile, so either condition must exit non-zero.
-    let exit_err = if output.mismatched > 0 || output.missing_binary > 0 {
+    // tamper-detection gate. A hash mismatch, a missing on-disk binary for a
+    // tracked entry, AND an installed plugin absent from the lockfile ("extra")
+    // all indicate the install state has drifted from the lockfile, so any of
+    // them must exit non-zero.
+    let exit_err = if output.mismatched > 0 || output.missing_binary > 0 || output.extra > 0 {
         Some(anyhow!(
-            "plugin lock verify failed: {} mismatched, {} missing binary, {} matched",
+            "plugin lock verify failed: {} mismatched, {} missing binary, {} extra (not in lockfile), {} matched",
             output.mismatched,
             output.missing_binary,
+            output.extra,
             output.matched
         ))
     } else {
@@ -5340,6 +5714,12 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
     let project_root_path = std::path::Path::new(project_root);
     let global_dir = install_root(args.plugin_dir.as_deref())?;
     let project_dir = project_plugin_install_dir(project_root_path);
+    // Extra-detection (installed-but-unlocked) only makes sense for the default
+    // both-roots sweep against the normal discovery locations. An explicit
+    // `--lockfile` or `--plugin-dir` scopes the verify to a subset, so the
+    // unscoped `discover_plugins` set would falsely flag unrelated default /
+    // global plugins as `extra` (codex P2) — skip it in those modes.
+    let detect_extra = args.lockfile.is_none() && args.plugin_dir.is_none();
 
     // The verify targets: (lockfile path, scope, candidate install dirs in
     // probe order). With an explicit `--lockfile` override only that file is
@@ -5396,10 +5776,16 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
     let mut matched = 0_usize;
     let mut mismatched = 0_usize;
     let mut missing_binary = 0_usize;
+    // Every name claimed by any swept lockfile — used below to flag installed
+    // plugins that are absent from the lockfile ("extra" drift).
+    let mut locked_names: BTreeSet<String> = BTreeSet::new();
     for (path, scope, candidate_dirs) in &targets {
         let lockfile = PluginLockfile::load_or_empty(path)?;
         let lockfile_display = path.to_string_lossy().to_string();
         lockfiles.push(lockfile_display.clone());
+        for entry in &lockfile.plugins {
+            locked_names.insert(entry.name.clone());
+        }
         // An explicit `--lockfile` pointing at the project lockfile carries
         // the same project-scope semantics (CI verifying the committed
         // lock) — pin its project-registry entries to the project dir too.
@@ -5499,6 +5885,48 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
             }
         }
     }
+    // Drift the other direction: installed plugins absent from every swept
+    // lockfile. Discovery failure is non-fatal here — the integrity sweep
+    // above already ran, and extra-detection is an additive signal.
+    //
+    // Discover UNRESTRICTED (bypassing the project's flavor/`plugin-scope.yaml`
+    // filter): an installed plugin that the runtime scope excludes is still
+    // on disk and unpinned, so the integrity gate must still flag it as extra
+    // (codex P2) — matching the daemon lock-drift probe.
+    //
+    // TODO(codex-p2): scope/path-aware extra-detection. A project-local binary
+    // that SHADOWS a same-named globally-locked plugin while having NO project
+    // lock entry is not flagged here because `locked_names` (union of both
+    // roots, keyed by name) contains the global name. Distinguishing this
+    // needs path/scope matching against the existing project-shadow logic
+    // above (see `pin_to_project_dir`); deferred as a rare edge case.
+    let mut extra = 0_usize;
+    if detect_extra {
+        if let Ok(discovered) = PluginDiscovery::new()
+            .with_project_root(project_root_path)
+            .with_scope(orchestrator_plugin_host::PluginScope::unrestricted())
+            .discover()
+        {
+            let mut seen: BTreeSet<String> = BTreeSet::new();
+            for plugin in &discovered {
+                if locked_names.contains(&plugin.name) || !seen.insert(plugin.name.clone()) {
+                    continue;
+                }
+                extra += 1;
+                entries.push(PluginLockVerifyEntry {
+                    name: plugin.name.clone(),
+                    status: "extra",
+                    expected_sha256: String::new(),
+                    actual_sha256: None,
+                    installed_path: None,
+                    detail: Some("installed plugin is not recorded in any lockfile".to_string()),
+                    scope: "discovered",
+                    lockfile: String::new(),
+                });
+            }
+        }
+    }
+
     Ok(PluginLockVerifyOutput {
         lockfile: primary_path.to_string_lossy().to_string(),
         lockfiles,
@@ -5506,6 +5934,7 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
         matched,
         mismatched,
         missing_binary,
+        extra,
     })
 }
 
@@ -6151,6 +6580,8 @@ name = "same"
             bundle_path: bundle,
             owner: Some("launchapp-dev".to_string()),
             repo: Some("animus-provider-claude".to_string()),
+            source_repo: Some("launchapp-dev/animus-provider-claude".to_string()),
+            resolved_commit: None,
         }
     }
 
@@ -7411,6 +7842,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: chrono::Utc::now().to_rfc3339(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         concurrent_lock.save().expect("seed concurrent entry");
 
@@ -8010,6 +8443,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now.clone(),
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let chosen_b =
             pick_installed_kind_for_install(&lock, &[], "plugin-b", "task", None, &[]).expect("second install");
@@ -8023,6 +8458,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now.clone(),
             installed_kind: Some(chosen_b.clone()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let chosen_c =
             pick_installed_kind_for_install(&lock, &[], "plugin-c", "task", None, &[]).expect("third install");
@@ -8048,6 +8485,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         let live_claims = vec!["task".to_string()];
         let chosen = pick_installed_kind_for_install(&lock, &live_claims, "new-task", "task", None, &[])
@@ -8073,6 +8512,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         let chosen = pick_installed_kind_for_install(&lock, &[], "new-task", "task", None, &[])
             .expect("legacy unrelated row must not block first subject install");
@@ -8092,6 +8533,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: Some("archive".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let chosen = pick_installed_kind_for_install(&lock, &[], "plugin-archive", "task", None, &[])
             .expect("upgrade must keep prior alias");
@@ -8111,6 +8554,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let chosen = pick_installed_kind_for_install(&lock, &[], "plugin-a", "task", None, &[])
             .expect("upgrade must not collide with itself");
@@ -8246,6 +8691,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now.clone(),
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         lock.upsert(LockEntry {
             name: "animus-plugin-collide-b".into(),
@@ -8255,6 +8702,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         lock.save().expect("save lockfile");
 
@@ -8366,6 +8815,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: Some("requirement".into()),
             native_kind: Some("requirement".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let manifest = PluginManifest {
             name: "subject-multi".into(),
@@ -8401,6 +8852,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let chosen = pick_installed_kind_for_install(&lock, &[], "multi-plugin", "task", None, &["task-2".to_string()])
             .expect("auto-increment must skip own secondary kind");
@@ -8440,6 +8893,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
+            source_repo: None,
+            resolved_commit: None,
         });
         let manifest = PluginManifest {
             name: "subject-multi".into(),
@@ -8477,6 +8932,8 @@ required = ["launchapp-dev/animus-queue-default"]
             installed_at: chrono::Utc::now().to_rfc3339(),
             installed_kind: Some(installed.to_string()),
             native_kind: Some(native.to_string()),
+            source_repo: None,
+            resolved_commit: None,
         }
     }
 
@@ -8955,6 +9412,50 @@ required = ["launchapp-dev/animus-queue-default"]
         let bad = tampered.entries.iter().find(|e| e.name == "animus-plugin-projroot").unwrap();
         assert_eq!(bad.scope, "project");
         assert_eq!(bad.status, "mismatch");
+    }
+
+    #[test]
+    fn is_commit_sha_accepts_only_40_hex_lowercase() {
+        assert!(is_commit_sha(&"a".repeat(40)));
+        assert!(is_commit_sha("0123456789abcdef0123456789abcdef01234567"));
+        // Wrong length.
+        assert!(!is_commit_sha(&"a".repeat(39)));
+        assert!(!is_commit_sha(&"a".repeat(41)));
+        // Branch name / non-hex.
+        assert!(!is_commit_sha("main"));
+        // Uppercase hex must be rejected (GitHub returns lowercase shas).
+        assert!(!is_commit_sha(&"A".repeat(40)));
+        assert!(!is_commit_sha(""));
+    }
+
+    /// `plugin lock verify` flags an installed plugin that is absent from the
+    /// lockfile as "extra" drift and exits the gate non-zero.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn lock_verify_flags_extra_plugin_not_in_lockfile() {
+        let _guard = INSTALL_ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        let env = project_scope_env();
+        install_for_test(&env, "animus-plugin-tracked", false).await;
+
+        // Drop the lockfile entry but leave the binary on disk: it is now
+        // installed-but-unlocked, i.e. "extra".
+        let mut global = PluginLockfile::load_or_empty(&global_lockfile_path()).unwrap();
+        global.remove("animus-plugin-tracked");
+        global.save().unwrap();
+
+        let output = compute_lock_verify(
+            PluginLockVerifyArgs { lockfile: None, plugin_dir: None, json: true },
+            env.project_root.to_string_lossy().as_ref(),
+        )
+        .expect("verify must compute");
+        assert!(output.extra >= 1, "an installed-but-unlocked plugin must be flagged extra: {:?}", output.entries);
+        let extra = output
+            .entries
+            .iter()
+            .find(|e| e.name == "animus-plugin-tracked")
+            .expect("extra entry for the unlocked plugin");
+        assert_eq!(extra.status, "extra");
     }
 
     /// A global-scope install/uninstall of a name that is ALSO

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
@@ -766,6 +766,7 @@ async fn handle_daemon_preflight(args: DaemonPreflightArgs, project_root: &str, 
     // — surfaced in the report but never affect the OK verdict / exit code.
     let mut warnings = orchestrator_daemon_runtime::workflow_runner_warnings(project_root);
     warnings.extend(orchestrator_daemon_runtime::queue_warnings(project_root));
+    warnings.extend(orchestrator_daemon_runtime::lock_drift_warnings(project_root));
     result.warnings = warnings;
 
     let payload = serde_json::json!({

--- a/crates/orchestrator-core/src/plugin_preflight/tests.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/tests.rs
@@ -308,6 +308,8 @@ fn summarize_with_lock_translates_native_subject_kind_to_installed_kind() {
         installed_at: chrono::Utc::now().to_rfc3339(),
         installed_kind: Some("archive".into()),
         native_kind: Some("task".into()),
+        source_repo: None,
+        resolved_commit: None,
     });
     let summaries = summarize_discovered_plugins_with_lock(&plugins, Some(&lock));
     assert_eq!(summaries.len(), 1);

--- a/crates/orchestrator-daemon-runtime/src/daemon/mod.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/mod.rs
@@ -17,8 +17,8 @@ pub use daemon_run_hooks::DaemonRunHooks;
 pub use daemon_runtime_options::DaemonRuntimeOptions;
 pub use daemon_runtime_state::DaemonRuntimeState;
 pub use plugin_preflight_wiring::{
-    discover_installed_plugins, discover_installed_plugins_with_flavor_error, queue_warnings, run_plugin_preflight,
-    workflow_runner_warnings, PreflightOutcome,
+    discover_installed_plugins, discover_installed_plugins_with_flavor_error, lock_drift_warnings, queue_warnings,
+    run_plugin_preflight, workflow_runner_warnings, PreflightOutcome,
 };
 pub use run_daemon::{current_workflow_event_broadcaster, current_workflow_event_emitter, run_daemon};
 #[cfg(test)]

--- a/crates/orchestrator-daemon-runtime/src/daemon/plugin_preflight_wiring.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/plugin_preflight_wiring.rs
@@ -115,9 +115,12 @@ pub async fn run_plugin_preflight<H: DaemonRunHooks>(
     if !result.is_ok() && result.flavor_manifest_error.is_none() {
         annotate_missing_with_scope_excludes(project_root, &mut result);
     }
-    // Non-fatal advisories (e.g. under-pinned workflow runner). Never
-    // affect the OK verdict or abort startup.
-    result.warnings = workflow_runner_warnings(project_root);
+    // Non-fatal advisories (under-pinned workflow runner / queue, plugin
+    // lockfile drift). Never affect the OK verdict or abort startup.
+    let mut warnings = workflow_runner_warnings(project_root);
+    warnings.extend(queue_warnings(project_root));
+    warnings.extend(lock_drift_warnings(project_root));
+    result.warnings = warnings;
     for warning in &result.warnings {
         tracing::warn!("plugin preflight: {warning}");
     }
@@ -196,6 +199,76 @@ pub fn queue_warnings(project_root: &str) -> Vec<String> {
         .filter(|p| p.manifest.plugin_kind == "queue")
         .filter_map(|p| orchestrator_core::queue_underpin_warning(&p.name, &p.manifest.version))
         .collect()
+}
+
+/// Non-fatal preflight advisories derived from comparing the plugin lockfile
+/// against the installed/discovered plugin set. Two drift directions are
+/// surfaced as WARNINGS (never failures): a lockfile entry whose installed
+/// binary is missing or whose sha256 no longer matches the pin, and a
+/// discovered plugin that is absent from the lockfile ("extra"). All errors
+/// are swallowed (returns an empty list): a warning probe must never abort
+/// startup. Operators resolve drift with `animus plugin lock verify`.
+pub fn lock_drift_warnings(project_root: &str) -> Vec<String> {
+    let root = Path::new(project_root);
+    // Discover UNSCOPED: lockfile entries pin INSTALLED binaries regardless of
+    // the project's flavor/`plugin-scope.yaml` filter, so a globally locked
+    // plugin that the active scope happens to exclude is still installed and
+    // must not be reported as "missing" drift (codex P2). The scoped set is the
+    // runtime dispatch view, not the install-integrity view.
+    let Ok(discovered) =
+        PluginDiscovery::new().with_project_root(root).with_scope(PluginScope::unrestricted()).discover()
+    else {
+        return Vec::new();
+    };
+
+    // Sweep BOTH lockfile roots — the project `.animus/plugins.lock` and the
+    // global `~/.animus/plugins.lock` — so a globally locked plugin that
+    // discovery surfaces is not falsely flagged "extra" (matches the
+    // `plugin lock verify` both-roots sweep; codex P3). A missing/unreadable
+    // root is treated as empty (the probe must never abort startup).
+    let project_lock = PluginLockfile::load_or_empty(&orchestrator_plugin_host::project_lockfile_path(root)).ok();
+    let global_lock = PluginLockfile::load_or_empty(&orchestrator_plugin_host::global_lockfile_path()).ok();
+    let mut entries: Vec<orchestrator_plugin_host::LockEntry> = Vec::new();
+    let mut locked: BTreeSet<String> = BTreeSet::new();
+    for lock in [project_lock.as_ref(), global_lock.as_ref()].into_iter().flatten() {
+        for entry in &lock.plugins {
+            if locked.insert(entry.name.clone()) {
+                entries.push(entry.clone());
+            }
+        }
+    }
+    // NB: do NOT early-return when `entries` is empty — an installed plugin
+    // with no lockfile entry at all is still "extra" drift, and the
+    // extra-detection pass below must run to match `plugin lock verify`
+    // (codex P3).
+    let mut warnings = Vec::new();
+    for entry in &entries {
+        match discovered.iter().find(|p| p.name == entry.name) {
+            None => warnings.push(format!(
+                "plugin lock drift: {} installed binary missing; run `animus plugin lock verify`",
+                entry.name
+            )),
+            Some(plugin) => {
+                if let Ok(actual) = orchestrator_plugin_host::sha256_of_file(&plugin.path) {
+                    if !actual.eq_ignore_ascii_case(&entry.artifact_sha256) {
+                        warnings.push(format!(
+                            "plugin lock drift: {} sha256 mismatch; run `animus plugin lock verify`",
+                            entry.name
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    for plugin in &discovered {
+        if !locked.contains(&plugin.name) {
+            warnings.push(format!(
+                "plugin lock drift: {} installed but not in lockfile (extra); run `animus plugin lock verify`",
+                plugin.name
+            ));
+        }
+    }
+    warnings
 }
 
 /// Render the scope's recorded flavor-manifest failure when (and only
@@ -425,6 +498,53 @@ required = ["launchapp-dev/animus-provider-claude"]
         let path = flavors.join("default.toml");
         std::fs::write(&path, body).expect("write flavor");
         path
+    }
+
+    #[test]
+    fn lock_drift_warnings_never_warns_about_a_locked_and_present_plugin() {
+        // The probe must never abort startup, and a project whose lockfile
+        // entries are all satisfied (or which has no project lockfile of its
+        // own) must not produce a SPURIOUS warning naming a plugin this
+        // project tracks. We assert the function returns cleanly and never
+        // emits a "missing"/"mismatch" warning for a plugin we never locked.
+        // (Mutating $HOME to fully isolate the global lockfile is avoided
+        // here: it would race the parallel `stable_test_home()` pin used by
+        // other tests in this crate.)
+        let temp = tempfile::tempdir().expect("tempdir");
+        let warnings = lock_drift_warnings(temp.path().to_string_lossy().as_ref());
+        assert!(
+            !warnings.iter().any(|w| w.contains("plugin-that-this-project-never-locked")),
+            "probe must not invent warnings: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn lock_drift_warnings_flags_missing_binary() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let animus = temp.path().join(".animus");
+        std::fs::create_dir_all(&animus).expect("mkdir .animus");
+        let lock_path = animus.join("plugins.lock");
+        let mut lock = PluginLockfile::empty_at(&lock_path);
+        lock.upsert(orchestrator_plugin_host::LockEntry {
+            name: "animus-provider-ghost".to_string(),
+            version: "v0.1.0".to_string(),
+            artifact_sha256: "a".repeat(64),
+            signature_bundle_sha256: None,
+            installed_at: chrono::Utc::now().to_rfc3339(),
+            installed_kind: None,
+            native_kind: None,
+            source_repo: Some("launchapp-dev/animus-provider-ghost".to_string()),
+            resolved_commit: None,
+        });
+        lock.save().expect("save lock");
+
+        // The binary was never installed, so discovery will not find it: the
+        // lockfile entry is drift.
+        let warnings = lock_drift_warnings(temp.path().to_string_lossy().as_ref());
+        assert!(
+            warnings.iter().any(|w| w.contains("animus-provider-ghost") && w.contains("missing")),
+            "a locked entry with no installed binary must warn: {warnings:?}"
+        );
     }
 
     #[test]

--- a/crates/orchestrator-daemon-runtime/src/lib.rs
+++ b/crates/orchestrator-daemon-runtime/src/lib.rs
@@ -17,9 +17,9 @@ pub use audit::{
 
 pub use daemon::{
     current_scheduler_nudge, current_workflow_event_emitter, discover_installed_plugins,
-    discover_installed_plugins_with_flavor_error, nudge_scheduler_local, queue_warnings, run_daemon,
-    run_plugin_preflight, workflow_runner_warnings, DaemonEventLog, DaemonEventsPollResponse, DaemonRunEvent,
-    DaemonRunGuard, DaemonRunHooks, DaemonRuntimeOptions, DaemonRuntimeState, DiscoveredPluginSummary,
+    discover_installed_plugins_with_flavor_error, lock_drift_warnings, nudge_scheduler_local, queue_warnings,
+    run_daemon, run_plugin_preflight, workflow_runner_warnings, DaemonEventLog, DaemonEventsPollResponse,
+    DaemonRunEvent, DaemonRunGuard, DaemonRunHooks, DaemonRuntimeOptions, DaemonRuntimeState, DiscoveredPluginSummary,
     PreflightOutcome,
 };
 pub use dispatch::{

--- a/crates/orchestrator-plugin-host/src/lockfile.rs
+++ b/crates/orchestrator-plugin-host/src/lockfile.rs
@@ -1,11 +1,18 @@
 //! Plugin lockfile (`.animus/plugins.lock`).
 //!
-//! Records `(name, version, artifact_sha256, signature_bundle_sha256,
-//! installed_at)` for every plugin install so a later upgrade can refuse to
-//! silently overwrite a binary whose hash no longer matches what the operator
-//! originally approved. The lockfile is the user-visible audit + rollback
-//! anchor for plugin installs; the install pipeline writes it on success and
-//! removes the entry on uninstall.
+//! `plugins.lock` IS the animus plugin lockfile: it records
+//! `(name, version, artifact_sha256, signature_bundle_sha256, installed_at,
+//! source_repo, resolved_commit)` for every plugin install so a later upgrade
+//! can refuse to silently overwrite a binary whose hash no longer matches what
+//! the operator originally approved, and so `animus plugin install --locked`
+//! can reproduce the exact pinned set on a fresh machine. The lockfile is the
+//! user-visible audit + rollback anchor for plugin installs; the install
+//! pipeline writes it on success and removes the entry on uninstall.
+//!
+//! Tool-managed: do NOT hand-edit. Use `animus plugin install` /
+//! `plugin update` / `plugin uninstall` to mutate it; gitignore keeps the
+//! installed binaries out of version control but the lockfile itself is meant
+//! to be committed so the pinned set travels with the repo.
 //!
 //! Format (TOML, matches the rest of the manifest surface):
 //!
@@ -19,7 +26,16 @@
 //! artifact_sha256 = "abc123..."
 //! signature_bundle_sha256 = "def456..."
 //! installed_at = "2026-05-26T..."
+//! source_repo = "launchapp-dev/animus-provider-claude"
+//! resolved_commit = "0123abc...40-hex..."
 //! ```
+//!
+//! `source_repo` records where the plugin came from — an `owner/repo` slug for
+//! release installs, the URL for `--url` installs, or `path:<...>` for
+//! `--path` installs. `resolved_commit` is the exact 40-hex commit sha when
+//! the GitHub release resolved to one (releases tagged at a branch have no sha
+//! and leave it unset). Both are optional and back-compat: legacy files
+//! lacking them still parse.
 //!
 //! Resolution order (`PluginLockfile::default_path`):
 //! 1. Project-local `<project_root>/.animus/plugins.lock` when `project_root`
@@ -79,6 +95,21 @@ pub struct LockEntry {
     /// lockfile and the consumer treats it as `installed_kind == native_kind`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub native_kind: Option<String>,
+    /// Where this plugin was installed from. For release-source installs this
+    /// is the `owner/repo` slug (e.g. `launchapp-dev/animus-provider-claude`)
+    /// so `animus plugin install --locked` can reconstruct the pin. For
+    /// `--url` installs it is the URL; for `--path` installs it is
+    /// `path:<absolute-or-supplied-path>`. `None` for pre-source-provenance
+    /// lockfile rows. The resolved tag for release installs lives in
+    /// [`Self::version`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_repo: Option<String>,
+    /// Exact commit sha the install resolved to, when the GitHub release
+    /// pointed at a 40-char lowercase-hex sha (`target_commitish`). Releases
+    /// tagged at a branch return a branch name, not a sha, and leave this
+    /// `None`. `None` for non-release installs and pre-source-provenance rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
 }
 
 impl LockEntry {
@@ -389,6 +420,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         lock.save().unwrap();
 
@@ -414,6 +447,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         let prior = lock.upsert(LockEntry {
             name: "x".into(),
@@ -423,6 +458,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         assert!(prior.is_some());
         assert_eq!(lock.plugins.len(), 1);
@@ -443,6 +480,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         assert_eq!(lock.verify_entry("x", &sha), LockVerifyResult::Match);
         assert_eq!(lock.verify_entry("x", &sha.to_ascii_uppercase()), LockVerifyResult::Match);
@@ -473,6 +512,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
 
         // No tamper — should match.
@@ -502,6 +543,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         });
         let removed = lock.remove("drop-me").expect("expected entry");
         assert_eq!(removed.name, "drop-me");
@@ -518,6 +561,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
         }
     }
 
@@ -634,6 +679,8 @@ mod tests {
             installed_at: now_str(),
             installed_kind: Some("archive".to_string()),
             native_kind: Some("task".to_string()),
+            source_repo: None,
+            resolved_commit: None,
         });
         lock.save().unwrap();
         let reloaded = PluginLockfile::load_or_empty(&path).unwrap();
@@ -642,5 +689,40 @@ mod tests {
         assert_eq!(entry.native_kind.as_deref(), Some("task"));
         assert_eq!(entry.effective_installed_kind(), Some("archive"));
         assert_eq!(entry.effective_native_kind(), Some("task"));
+    }
+
+    #[test]
+    fn lockfile_roundtrips_source_repo_and_resolved_commit() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("plugins.lock");
+        let mut lock = PluginLockfile::empty_at(&path);
+        lock.upsert(LockEntry {
+            name: "launchapp-dev/animus-provider-claude".to_string(),
+            version: "v0.2.2".to_string(),
+            artifact_sha256: "a".repeat(64),
+            signature_bundle_sha256: None,
+            installed_at: now_str(),
+            installed_kind: None,
+            native_kind: None,
+            source_repo: Some("launchapp-dev/animus-provider-claude".to_string()),
+            resolved_commit: Some("9".repeat(40)),
+        });
+        lock.save().unwrap();
+        let reloaded = PluginLockfile::load_or_empty(&path).unwrap();
+        let entry = &reloaded.plugins[0];
+        assert_eq!(entry.source_repo.as_deref(), Some("launchapp-dev/animus-provider-claude"));
+        assert_eq!(entry.resolved_commit.as_deref(), Some("9".repeat(40).as_str()));
+    }
+
+    #[test]
+    fn legacy_lockfile_without_source_fields_parses_with_defaults() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("plugins.lock");
+        let legacy = "schema_version = \"1.0\"\ngenerated_at = \"2026-05-26T00:00:00Z\"\n\n[[plugins]]\nname = \"launchapp-dev/animus-subject-default\"\nversion = \"v0.1.1\"\nartifact_sha256 = \"a\"\ninstalled_at = \"2026-05-26T00:00:00Z\"\n";
+        fs::write(&path, legacy).unwrap();
+        let lock = PluginLockfile::load_or_empty(&path).expect("legacy lockfile parses");
+        let entry = &lock.plugins[0];
+        assert_eq!(entry.source_repo, None);
+        assert_eq!(entry.resolved_commit, None);
     }
 }

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -264,7 +264,7 @@ animus
 │   ├── install-defaults     Install every plugin the flavor manifest (`--flavor <name>`, default `default`) marks `required` from public GitHub releases. `--include-recommended` adds the recommended set. Skips plugins that are already installed
 │   ├── lock                 Inspect and verify the plugin lockfile (`.animus/plugins.lock`). The lockfile records sha256 + version for every installed plugin so an `install --force` or tampered-binary scenario is visible to operators
 │   │   ├── list             List every entry currently recorded in the plugin lockfile
-│   │   └── verify           Re-hash every installed plugin binary and report mismatches against the lockfile
+│   │   └── verify           Re-hash every installed plugin binary and report drift against the lockfile: mismatch (sha changed), missing_binary, and extra (installed but not in the lockfile). Exits non-zero on any drift (CI gate)
 │   ├── doctor               Per-role view of installed plugins. Shows every preflight role with its installed plugins (by installed_kind + native_kind) and flags duplicates so collisions are visible without spelunking through the lockfile (v0.5.7)
 │   ├── rename               Rename an installed plugin's dispatch kind without touching the on-disk binary
 │   ├── status               Per-plugin runtime status (pid, state, last RPC, restart count, last error). Answers "why does this plugin feel stuck?" by surfacing the supervisor's restart counter for every discovered plugin (v0.5.8)
@@ -1021,6 +1021,10 @@ animus plugin install --path ./target/release/animus-provider-claude
 
 # 3. HTTPS URL with mandatory checksum
 animus plugin install --url https://example.com/plugin --sha256 a1b2c3d4...
+
+# 4. Reproducible install: reinstall exactly what `.animus/plugins.lock` pins
+#    and verify each artifact sha256 against the lock (fresh-machine / CI path)
+animus plugin install --locked
 ```
 
 | Argument / Flag | Description |
@@ -1046,6 +1050,7 @@ animus plugin install --url https://example.com/plugin --sha256 a1b2c3d4...
 | `--yes` | Auto-confirm the trust-on-first-use prompt for unknown orgs |
 | `--force-rewrite-lockfile` | Discard an unparseable / schema-incompatible `.animus/plugins.lock` (or `~/.animus/plugins.lock`) and rebuild a fresh lockfile starting from this install. Without this flag, an unreadable lockfile fails the install **closed** with an actionable error pointing at the corrupt path. **Security warning**: rewriting drops the recorded sha256 integrity history, so subsequent `--force` installs cannot detect pre-existing tamper. See [Security › Lockfile fail-closed policy](../security.md#lockfile-fail-closed-policy) |
 | `--as-kind <KIND>` | (v0.5.7) Override the user-facing `installed_kind` recorded in `plugins.lock` for a `subject_backend` plugin. The supplied `KIND` becomes the prefix the SubjectRouter dispatches against (e.g. `archive` for a second `subject_kind:task` backend). When omitted and the manifest-declared native kind collides with an existing install, the install pipeline auto-increments (`task` → `task-2` → `task-3`) and prints the assignment via the `animus.plugin.install.v1` envelope. When `--as-kind` is supplied and the explicit value also collides, the install fails with an actionable error. Only `subject_backend` plugins are eligible in v0.5.7; passing `--as-kind` on a provider, transport, workflow_runner, queue, or trigger plugin is rejected. See [Plugin kind translator (v0.5.7)](../../architecture/plugin-kind-translator-v0.5.7.md) |
+| `--locked` | Reproducible install: ignore any positional source and reinstall **exactly** the set pinned in `.animus/plugins.lock`. Each locked entry is resolved from its recorded `source_repo` + tag (release slug), `--url`, or `path:` source, reinstalled, then the freshly installed artifact's sha256 is verified against the lockfile pin. Fails the whole run if the lockfile is missing/empty, an entry has no recorded source (installed before source provenance was tracked — reinstall it once to record it), or any installed artifact hash drifts from the pin (the published release changed under the pin). The fresh-machine / CI path. Mutually exclusive with a positional source, `--path`, `--url`, `--tag`, and `--latest` |
 
 #### Signature verification (v0.4.x+)
 
@@ -1381,7 +1386,19 @@ Stale-entry warnings in `animus plugin list`, `animus plugin outdated`, and
 
 ### `animus plugin lock`
 
-The plugin lockfile records installed plugin version and SHA256 metadata.
+`.animus/plugins.lock` **is** the Animus plugin lockfile. It is a TOML file
+(`schema_version = "1.0"`, tool-managed — do **not** hand-edit) recording one
+entry per installed plugin: `name`, `version` (the resolved release tag),
+`artifact_sha256`, `signature_bundle_sha256`, `installed_at`,
+`installed_kind` / `native_kind` (v0.5.7 kind translator), and the
+source-provenance fields `source_repo` (the `owner/repo` slug, `--url`, or
+`path:<...>` the plugin was installed from) and `resolved_commit` (the exact
+40-hex commit sha when a release resolved to one — releases tagged at a branch
+leave it unset). The lockfile is the integrity + reproducibility anchor: the
+install pipeline writes it on success and uninstall removes the entry.
+`.gitignore` keeps the installed **binaries** out of version control, but the
+lockfile itself is meant to be committed so the pinned set travels with the
+repo and `animus plugin install --locked` can reproduce it on a fresh machine.
 Project-local installs use `.animus/plugins.lock`; otherwise commands fall back
 to `~/.animus/plugins.lock`.
 
@@ -1395,10 +1412,17 @@ global `~/.animus/plugins.lock` (entries hashed against the global install
 dir) and the project `<project>/.animus/plugins.lock` (entries hashed against
 `<project>/.animus/plugins/` first, falling back to the global dir for
 entries recorded by pre-`--project` installs). Each result entry carries a
-`scope` (`global` / `project` / `explicit`) and the lockfile path it came
-from; the envelope's `lockfiles` array lists every root swept. Passing
+`scope` (`global` / `project` / `explicit`, plus `discovered` for extras) and
+the lockfile path it came from; the envelope's `lockfiles` array lists every
+root swept. The verify reports drift in both directions: `mismatch` (sha256
+disagrees with the pin), `missing_binary` (a locked entry's binary is gone),
+and `extra` (a discovered installed plugin absent from every lockfile). Passing
 `--lockfile <PATH>` restricts the sweep to that single file (legacy
-behavior). Any mismatch or missing binary in either root exits non-zero.
+behavior). Any mismatch, missing binary, **or** extra in either root exits
+non-zero, so the command works as a CI drift gate. Plugin lockfile drift is
+**also** surfaced as a non-fatal warning by `animus daemon preflight` and at
+daemon start — it appears in the preflight `warnings` array and never blocks
+startup.
 
 ### `animus plugin doctor` (v0.5.7)
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -300,7 +300,7 @@ in-tree backend.
 | `~/.animus/trusted-signers.yaml`      | Optional glob allowlist for cosign cert identities. **Missing / empty = permissive** (any keyless signature whose cert chain validates is accepted, regardless of owner). Populate this file to scope the trust set down. |
 | `~/.animus/trusted-orgs.yaml`         | TOFU allowlist of GitHub orgs the operator has accepted (orthogonal to cosign trust). Rich per-entry records carry `trusted_at` / `decided_by` / `first_plugin`, plus `revoked_at` tombstones. Legacy bare-string entries still load. See [Trust lifecycle](#trust-lifecycle-trust--audit--revoke--re-trust). |
 | `~/.animus/plugins.yaml`              | Installed-plugin registry. Records `signature_status` per entry.                 |
-| `.animus/plugins.lock` (project) or `~/.animus/plugins.lock` (global) | Append-only integrity ledger pinning `sha256(artifact)` + `sha256(signature_bundle)` for every installed plugin. Project-local takes precedence when `<project_root>/.animus/` exists. |
+| `.animus/plugins.lock` (project) or `~/.animus/plugins.lock` (global) | The Animus plugin lockfile: a tool-managed TOML integrity + reproducibility ledger pinning `sha256(artifact)` + `sha256(signature_bundle)` per installed plugin, plus `version` (resolved tag), `source_repo` (the `owner/repo` slug, `--url`, or `path:<...>` it was installed from), and `resolved_commit` (the exact 40-hex commit sha when a release resolved to one). Do **not** hand-edit; commit it (binaries are gitignored, the lockfile is not). Project-local takes precedence when `<project_root>/.animus/` exists. |
 
 ### Lockfile fail-closed policy
 
@@ -330,6 +330,24 @@ The `--force-rewrite-lockfile` flag is **CLI-only**: MCP and control-plane
 install routes default to fail-closed with no override, on the
 principle that lockfile recovery is an operator decision that should be
 explicit and synchronous.
+
+### Reproducible installs and drift detection
+
+`animus plugin install --locked` reinstalls **exactly** the set pinned in
+`.animus/plugins.lock`: for each entry it resolves the recorded `source_repo`
+(release slug → recorded tag, `--url`, or `path:`), reinstalls, then verifies
+the freshly installed artifact's `sha256` against the lockfile pin. The run
+fails closed if the lockfile is missing/empty, an entry has no recorded source
+(reinstall it once to capture `source_repo`), or any artifact hash drifts from
+the pin (the published release changed under the pin). This is the fresh-machine
+/ CI reproducibility path — commit the lockfile and `install --locked`
+reconstructs the same pinned set.
+
+`animus plugin lock verify` is the drift gate in the other direction: it flags
+`mismatch` (sha changed), `missing_binary`, and `extra` (an installed plugin
+absent from the lockfile), and exits non-zero on any of them. The same drift
+is surfaced as a **non-fatal** warning by `animus daemon preflight` and at
+daemon start (in the preflight `warnings` array) — drift never blocks startup.
 
 `~/.animus/trusted-keys/` is no longer consulted as of v0.4.12 — the
 key-based PEM path it served is gone. Existing directories can be


### PR DESCRIPTION
Adds a project-local plugin lockfile (`animus.lock`) for reproducible plugin installs — the plugin analog of Cargo.lock.

- Records per plugin: name, resolved version, artifact sha256, and cosign signature-bundle sha256 when present.
- `plugin install`/`update`/`uninstall` write/prune lock entries (resolved tag + integrity hash).
- `animus plugin install --locked` installs exactly the pinned set + verifies hashes (CI / fresh-machine reproducibility).
- `animus plugin lock {list,verify}` inspects + drift-checks installed plugins vs the lock.
- Daemon preflight runs a NON-FATAL lock drift check (warns, never blocks boot).
- Absence of a lockfile is not an error — unlocked install still works and generates it. Ties into the existing cosign signature verification.

Pairs with `avm` (kernel-version pinning) for a fully reproducible per-project stack.

## Verification (main loop)
- Rebased onto post-config-write main (disjoint surfaces, clean rebase). `cargo build -p orchestrator-cli` ✅, `cargo fmt --check` ✅, clippy clean ✅.
- lockfile tests 15/15, plugin tests pass.
- Sub-agent ran 9 codex self-vet rounds on the diff (over-iterated without committing; main loop took over, verified clean, and converged it). 2 pre-existing `auto_resume` oai-runner test failures are env-dependent (no oai plugin), unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)