### PR TITLE
release: v0.6.6 — cap plugin tokio runtimes (TOKIO_WORKER_THREADS=2 at spawn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.5] - 2026-06-22
+## [0.6.6] - 2026-06-22
+
+**v0.6.6 — cap plugin tokio runtimes to stop PID/thread exhaustion.**
+
+- **Plugin thread cap.** Every Animus stdio plugin uses a bare `#[tokio::main]`,
+  which sizes its worker pool to *all* CPU cores. With v0.6's resident-plugin fleet
+  (config_source + subject backends + queue + workflow_runner + providers +
+  transport) that is hundreds of threads on a many-core host, exhausting the
+  PID/thread budget — new forks (including the provider CLI an agent phase spawns)
+  fail with `EAGAIN` and the run hangs at the agent phase. The daemon now injects
+  `TOKIO_WORKER_THREADS=2` into every spawned plugin (`PluginHost::spawn_with_options`,
+  after `env_clear()`) and into the workflow-runner subprocess, honoring an operator
+  override set on the daemon env. Plugins are I/O-bound stdio RPC servers, so a small
+  pool is sufficient. Fixes agent phases stalling on PID-capped hosts (e.g. Railway).
+  Follow-up (tracked): make `config_source` resident to remove the per-tick respawn
+  churn, and switch the plugin scaffold to a `current_thread` runtime for new plugins.
 
 **v0.6.5 — config write-back + reproducible plugin pinning.**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
@@ -286,6 +286,13 @@ impl ProcessManager {
         // `replay_gap_from_spawn_record` falls back to scanning runs/ for
         // the most recent decisions.jsonl matching the spawn time.
         command.env(ANIMUS_AGENT_RUN_ID_ENV, &pending_session_id);
+        // Bound the workflow-runner's tokio pool for the same reason we cap plugins
+        // (orchestrator-plugin-host host.rs): a bare `#[tokio::main]` otherwise sizes
+        // the worker pool to all CPU cores, compounding the PID/thread pressure. This
+        // path inherits the daemon env, so only impose the default when unset.
+        if std::env::var_os("TOKIO_WORKER_THREADS").is_none() {
+            command.env("TOKIO_WORKER_THREADS", "2");
+        }
         // Phase skills pass-down: resolve the union of phase-level `skills:`
         // and the executing agent profile's `skills:` daemon-side (scoped
         // sources + trust stripping, identical to the ad-hoc `--skill`

--- a/crates/orchestrator-plugin-host/src/host.rs
+++ b/crates/orchestrator-plugin-host/src/host.rs
@@ -681,6 +681,22 @@ impl PluginHost {
             }
         }
 
+        // Bound each plugin's tokio runtime. A bare `#[tokio::main]` (every Animus
+        // stdio plugin) sizes its multi-thread worker pool to
+        // `available_parallelism()` — all CPU cores. With v0.6's resident-plugin
+        // fleet (config_source + subject backends + queue + workflow_runner +
+        // providers + transport) that is hundreds of threads on a many-core host,
+        // exhausting the PID/thread budget so new forks — including the provider CLI
+        // an agent phase spawns — fail with EAGAIN and the run hangs. Plugins are
+        // I/O-bound stdio RPC servers, so a tiny pool is sufficient. `env_clear()`
+        // above dropped any inherited value (TOKIO_WORKER_THREADS is not in the base
+        // allowlist), so set it explicitly here, honoring an operator override on the
+        // daemon env so a deploy can still tune it up or down.
+        command.env(
+            "TOKIO_WORKER_THREADS",
+            std::env::var_os("TOKIO_WORKER_THREADS").unwrap_or_else(|| std::ffi::OsString::from("2")),
+        );
+
         for missing in &options.missing_required_env {
             // Suppress the warning when the keychain already satisfied
             // the requirement during the snapshot merge above. The


### PR DESCRIPTION
Caps every spawned plugin's tokio runtime to 2 worker threads, injected by the daemon (`PluginHost::spawn_with_options` after `env_clear()`, honoring an operator override) + the workflow-runner subprocess.

**Why:** every Animus stdio plugin uses bare `#[tokio::main]` (worker pool = all CPU cores). v0.6's resident-plugin fleet (config_source + subjects + queue + workflow_runner + providers + transport) then spawns hundreds of threads on a many-core host, exhausting the PID/thread cap — the agent phase can't fork the provider CLI (EAGAIN) and runs hang at 'writing'. Caps collapse the ~480-thread floor to ~40.

**Gates:** cargo check + fmt + clippy clean; codex review clean; plugin env-scrubbing tests pass.

**Follow-up (tracked):** make config_source resident to remove the per-tick respawn churn; switch the plugin scaffold to a current_thread runtime for new plugins.