### PR TITLE
feat(plugin-lock): platform-aware lockfile (schema 2.0) for cross-platform --locked

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/plugin_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/plugin_tools.rs
@@ -352,6 +352,8 @@ impl AoMcpServer {
             force_rewrite_lockfile: force_rewrite_lockfile.unwrap_or(false),
             as_kind: None,
             project: false,
+            expected_archive_sha256: None,
+            locked_secondary_archive_shas: std::collections::BTreeMap::new(),
         })
         .await
         .map_err(anyhow_to_mcp)?;

--- a/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
@@ -17,7 +17,7 @@ pub(crate) use signing::{
     GITHUB_OIDC_ISSUER,
 };
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -27,11 +27,11 @@ use anyhow::{anyhow, Context, Result};
 use orchestrator_daemon_runtime::{Audit, AuditActor, AuditEvent, AuditEventKind};
 use orchestrator_plugin_host::session::is_reserved_provider_tool;
 use orchestrator_plugin_host::{
-    discover_plugins, global_lockfile_path, legacy_plugins_registry_path, plugin_install_dir, plugins_registry_path,
-    project_lockfile_path, project_plugin_install_dir, project_plugins_registry_path,
+    current_target_triple, discover_plugins, global_lockfile_path, legacy_plugins_registry_path, plugin_install_dir,
+    plugins_registry_path, project_lockfile_path, project_plugin_install_dir, project_plugins_registry_path,
     registered_skip_manifest_check_at_install_scoped, sha256_of_file as plugin_host_sha256_of_file, DiscoveredPlugin,
     DiscoverySource, DiscoveryWarning, LockEntry, LockVerifyResult, PluginDiscovery, PluginHost, PluginLockfile,
-    PluginSpawnOptions, PolicyMode as PluginPolicyMode,
+    PluginSpawnOptions, PolicyMode as PluginPolicyMode, TargetIntegrity,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -313,6 +313,21 @@ pub(crate) struct PluginInstallRequest {
     /// is mutually exclusive with `plugin_dir` (the CLI enforces the
     /// conflict via clap; this pipeline re-validates for non-CLI callers).
     pub(crate) project: bool,
+    /// Internal: for RELEASE sources, the expected sha256 of the downloaded
+    /// **tarball** (not the extracted binary). When set, `resolve_release_install`
+    /// hard-fails before extracting if the tarball drifts from it. Used by
+    /// `--locked` to gate a release reinstall against the lockfile's portable
+    /// per-target `archive_sha256` (the `req.sha256` field gates the extracted
+    /// BINARY, which differs from the tarball hash). `None` for normal installs.
+    pub(crate) expected_archive_sha256: Option<String>,
+    /// Internal: for `--locked` RELEASE reinstalls of multi-binary plugins,
+    /// the lockfile's expected per-SECONDARY tarball sha for the current target
+    /// (`secondary binary name -> archive sha256`). The multi-binary install
+    /// loop verifies each downloaded secondary tarball against this BEFORE
+    /// extracting, so a drifted secondary asset fails the reproducibility gate
+    /// even when the release's own SHA256SUMS was regenerated to match. Empty
+    /// for normal installs.
+    pub(crate) locked_secondary_archive_shas: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1552,7 +1567,7 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
         Option<Vec<GithubReleaseAsset>>,
     ) = if let Some(slug) = req.source.as_deref() {
         let spec = parse_repo_spec(slug)?;
-        let release = resolve_release_install(spec, req.tag.clone()).await?;
+        let release = resolve_release_install(spec, req.tag.clone(), req.expected_archive_sha256.clone()).await?;
         let provenance = InstallProvenance {
             source_kind: Some("release"),
             origin: Some(release.origin.clone()),
@@ -1565,6 +1580,8 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
             repo: Some(release.repo.clone()),
             source_repo: Some(format!("{}/{}", release.owner, release.repo)),
             resolved_commit: release.resolved_commit.clone(),
+            sha256sums_targets: release.sha256sums_targets.clone(),
+            sha256sums_body: release.sha256sums_body.clone(),
         };
         let release_assets = release.release_assets.clone();
         (release.binary_path, release.plugin_name_hint, provenance, Some(release._temp_dir), Some(release_assets))
@@ -1703,38 +1720,41 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
         load_or_refuse_lockfile(project_root_for_lock, effective_lock_override.as_deref(), req.force_rewrite_lockfile)?;
     let lockfile_path_for_log = lockfile.path().to_path_buf();
     let is_upgrade = installed_path.exists();
-    if is_upgrade {
-        if let Some(existing_entry) = lockfile.find(&plugin_name).cloned() {
-            match lockfile.verify_installed(&plugin_name, &installed_path) {
-                Ok(LockVerifyResult::Match) | Ok(LockVerifyResult::Missing) => {}
-                Ok(LockVerifyResult::Mismatch { expected, actual }) => {
-                    if let Some(root) = project_root_for_lock {
-                        if let Some(scoped) = protocol::repository_scope::scoped_state_root(root) {
-                            Audit::at_scoped_root(&scoped).log_event(AuditEvent::new(
-                                AuditActor::User,
-                                AuditEventKind::LockfileMismatch,
-                                serde_json::json!({
-                                    "plugin": plugin_name,
-                                    "expected_sha256": expected,
-                                    "actual_sha256": actual,
-                                    "force": req.force,
-                                    "lockfile": lockfile_path_for_log.display().to_string(),
-                                }),
-                            ));
-                        }
+    if is_upgrade && lockfile.find(&plugin_name).is_some() {
+        match lockfile.verify_installed(&plugin_name, &installed_path) {
+            // `Missing` (no entry) and `MissingTarget` (no host-only
+            // binary claim for this platform — a 1.0-migrated entry or a
+            // lock generated elsewhere) both mean "nothing to compare
+            // against here", so the upgrade proceeds and re-records.
+            Ok(LockVerifyResult::Match)
+            | Ok(LockVerifyResult::Missing)
+            | Ok(LockVerifyResult::MissingTarget { .. }) => {}
+            Ok(LockVerifyResult::Mismatch { expected, actual }) => {
+                if let Some(root) = project_root_for_lock {
+                    if let Some(scoped) = protocol::repository_scope::scoped_state_root(root) {
+                        Audit::at_scoped_root(&scoped).log_event(AuditEvent::new(
+                            AuditActor::User,
+                            AuditEventKind::LockfileMismatch,
+                            serde_json::json!({
+                                "plugin": plugin_name,
+                                "expected_sha256": expected,
+                                "actual_sha256": actual,
+                                "force": req.force,
+                                "lockfile": lockfile_path_for_log.display().to_string(),
+                            }),
+                        ));
                     }
-                    if !req.force {
-                        return Err(invalid_input_error(format!(
-                            "lockfile mismatch for plugin '{plugin_name}': recorded sha256 {} but on-disk binary hashes to {}. \
+                }
+                if !req.force {
+                    return Err(invalid_input_error(format!(
+                            "lockfile mismatch for plugin '{plugin_name}': recorded sha256 {expected} but on-disk binary hashes to {actual}. \
                              The installed binary appears to have been modified or replaced out of band. \
                              Re-run with --force to overwrite (and update the lockfile), or `animus plugin lock verify` to inspect.",
-                            existing_entry.artifact_sha256, actual,
                         )));
-                    }
                 }
-                Err(err) => {
-                    tracing::warn!(plugin = %plugin_name, %err, "failed to hash existing installed plugin during lockfile pre-check");
-                }
+            }
+            Err(err) => {
+                tracing::warn!(plugin = %plugin_name, %err, "failed to hash existing installed plugin during lockfile pre-check");
             }
         }
     }
@@ -1857,6 +1877,20 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
                         }
                     }
                     let computed_secondary = sha256_of_file(&secondary_asset_path)?;
+                    // `--locked` cross-platform gate: when the lockfile pins this
+                    // secondary's tarball for the current target, the downloaded
+                    // archive MUST match the LOCK (not just the release's own
+                    // SHA256SUMS) — closes the drifted-secondary-with-regenerated-
+                    // SHA256SUMS hole before we extract/execute it (codex P1).
+                    if let Some(locked) = req.locked_secondary_archive_shas.get(&descriptor.name) {
+                        if !locked.eq_ignore_ascii_case(&computed_secondary) {
+                            return Err(invalid_input_error(format!(
+                                "lockfile mismatch for secondary asset '{}': lock pins {locked} but the downloaded \
+                                 tarball hashes to {computed_secondary} — the published release changed under the pin",
+                                asset.name
+                            )));
+                        }
+                    }
                     if let Some(expected) = expected_sha.as_ref() {
                         if !expected.eq_ignore_ascii_case(&computed_secondary) {
                             return Err(invalid_input_error(format!(
@@ -2047,30 +2081,94 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
     // ---- Lockfile: persist this install ----
     let bundle_sha = provenance.bundle_path.as_deref().and_then(|p| plugin_host_sha256_of_file(p).ok());
     let recorded_at = chrono::Utc::now().to_rfc3339();
+    let current_triple = current_target_triple();
+
+    // Build the PRIMARY entry's per-target claim. Start from the release
+    // `SHA256SUMS.txt` (every published platform's TARBALL sha → portable) and
+    // overlay the install platform with the cosign-bundle sha + the extracted
+    // BINARY sha (host-only tamper-check). For `--path`/`--url` sources the map
+    // is empty, so we record only the current target's verified archive sha.
+    let is_release_source = provenance.source_kind == Some("release");
+    let mut primary_targets: BTreeMap<String, TargetIntegrity> = BTreeMap::new();
+    for (triple, archive_sha) in &provenance.sha256sums_targets {
+        primary_targets
+            .insert(triple.clone(), TargetIntegrity { archive_sha256: archive_sha.clone(), ..Default::default() });
+    }
+    if let Some(triple) = current_triple {
+        // Attach the host-only fields (installed-binary sha + cosign bundle) to
+        // the current build target. For a RELEASE the archive sha for each
+        // target comes from `sha256sums_targets` (the TARBALL hash); `computed_sha`
+        // is the EXTRACTED-BINARY hash, so it must NOT seed a fresh
+        // `archive_sha256`. When the build triple has no recorded target —
+        // e.g. a `*-linux-musl` asset selected as a fallback on a `*-gnu` host —
+        // skip the host overlay rather than write a binary hash as a bogus
+        // tarball pin (codex P2); `lock verify` then reports MissingTarget for
+        // this platform until a native-asset reinstall.
+        let entry_for_target = if is_release_source {
+            primary_targets.get_mut(triple)
+        } else {
+            // `--path`/`--url`: the fetched artifact IS the archive, so its sha
+            // is both the archive and the installed-binary hash.
+            Some(
+                primary_targets
+                    .entry(triple.to_string())
+                    .or_insert_with(|| TargetIntegrity { archive_sha256: computed_sha.clone(), ..Default::default() }),
+            )
+        };
+        if let Some(integrity) = entry_for_target {
+            integrity.installed_binary_sha256 = Some(computed_sha.clone());
+            integrity.signature_bundle_sha256 = bundle_sha;
+        }
+    }
+
     let mut new_lock_entries: Vec<LockEntry> = vec![LockEntry {
         name: plugin_name.clone(),
         version: provenance.release_tag.clone().unwrap_or_default(),
-        artifact_sha256: computed_sha.clone(),
-        signature_bundle_sha256: bundle_sha,
+        targets: primary_targets,
         installed_at: recorded_at.clone(),
         installed_kind: assigned_kind.clone(),
         native_kind: native_kind_for_lock.clone(),
         source_repo: provenance.source_repo.clone(),
         resolved_commit: provenance.resolved_commit.clone(),
+        legacy_artifact_sha256: None,
+        legacy_signature_bundle_sha256: None,
     }];
     for (secondary_name, _path, secondary_sha, _temp) in &secondary_installed {
         // Secondary (multi-binary) entries ship in the same release, so they
-        // inherit the primary's source + resolved commit.
+        // inherit the primary's source + resolved commit. Derive their per-target
+        // TARBALL shas from the SAME `SHA256SUMS.txt` (keyed by the secondary's
+        // own `<name>-<triple>.tar.gz` archives) so the secondary entry is just
+        // as portable as the primary — `--locked` on a foreign platform can pin
+        // its tarball before extract. `secondary_sha` is the EXTRACTED-BINARY
+        // hash (NOT a tarball sha), so it only seeds the current target's
+        // host-only `installed_binary_sha256`.
+        let mut secondary_targets: BTreeMap<String, TargetIntegrity> = BTreeMap::new();
+        if let Some(body) = provenance.sha256sums_body.as_deref() {
+            for (triple, archive_sha) in parse_sha256sums_for_targets(body, secondary_name) {
+                secondary_targets.insert(triple, TargetIntegrity { archive_sha256: archive_sha, ..Default::default() });
+            }
+        }
+        if let Some(triple) = current_triple {
+            // Overlay the host-only binary hash on the current target. When the
+            // release has no SHA256SUMS, the secondary's archive sha is UNKNOWN
+            // (we only have the extracted-binary hash, which is NOT a tarball
+            // sha) — leave `archive_sha256` empty so the `--locked` secondary
+            // gate skips it rather than comparing a binary hash to a tarball
+            // and failing a valid reinstall (codex P2).
+            let integrity = secondary_targets.entry(triple.to_string()).or_default();
+            integrity.installed_binary_sha256 = Some(secondary_sha.clone());
+        }
         new_lock_entries.push(LockEntry {
             name: secondary_name.clone(),
             version: provenance.release_tag.clone().unwrap_or_default(),
-            artifact_sha256: secondary_sha.clone(),
-            signature_bundle_sha256: None,
+            targets: secondary_targets,
             installed_at: recorded_at.clone(),
             installed_kind: None,
             native_kind: None,
             source_repo: provenance.source_repo.clone(),
             resolved_commit: provenance.resolved_commit.clone(),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
         });
     }
     // Multi-binary follow-up to the primary-name routing above: secondary
@@ -3641,6 +3739,86 @@ fn parse_sha256_sidecar(body: &str) -> Option<String> {
     }
 }
 
+/// Every Rust target triple Animus releases publish assets for. Used to derive
+/// a per-asset target triple from a `SHA256SUMS.txt` filename so the lockfile
+/// can record a portable, per-platform integrity claim.
+const KNOWN_TARGET_TRIPLES: &[&str] = &[
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
+    "x86_64-pc-windows-msvc",
+    "x86_64-pc-windows-gnu",
+];
+
+/// Derive the target triple a release asset filename targets, by scanning for a
+/// known triple substring (case-insensitive). `None` for non-archive assets
+/// (e.g. `SHA256SUMS.txt`, `.bundle`, `.sha256` sidecars) and any name with no
+/// recognizable triple.
+fn target_triple_from_asset_name(name: &str) -> Option<&'static str> {
+    let lower = name.to_ascii_lowercase();
+    // `lower` is already ASCII-lowercased, so these `ends_with` checks are
+    // case-insensitive by construction; clippy's heuristic doesn't see it.
+    #[allow(clippy::case_sensitive_file_extension_comparisons)]
+    let is_archive = lower.ends_with(".tar.gz") || lower.ends_with(".tgz");
+    if !is_archive {
+        return None;
+    }
+    KNOWN_TARGET_TRIPLES.iter().copied().find(|triple| lower.contains(&triple.to_ascii_lowercase()))
+}
+
+/// Parse a release `SHA256SUMS.txt` body into per-target archive shas for the
+/// archives belonging to `plugin`. Each line is `<hex>␠␠<filename>`; only
+/// archive filenames carrying a recognizable target triple contribute. When
+/// several archives map to the same triple (e.g. multi-binary releases
+/// publishing several `<bin>-<triple>.tar.gz`), the EXACT
+/// `<plugin>-<triple>.{tar.gz,tgz}` archive is preferred — an exact base match,
+/// not a prefix test, so a sibling like `<plugin>-helper-<triple>.tar.gz` is
+/// not mistaken for `<plugin>`'s archive. Otherwise the first seen is kept.
+fn parse_sha256sums_for_targets(body: &str, plugin: &str) -> BTreeMap<String, String> {
+    let plugin_lower = plugin.to_ascii_lowercase();
+    let mut out: BTreeMap<String, (String, bool)> = BTreeMap::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let Some(hex) = parts.next() else { continue };
+        if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+        let Some(filename) = parts.next() else { continue };
+        // Strip a leading `*` (binary-mode marker some sha256sum tools emit).
+        let filename = filename.strip_prefix('*').unwrap_or(filename);
+        let Some(triple) = target_triple_from_asset_name(filename) else { continue };
+        // The archive belongs to `plugin` exactly when its name is
+        // `<plugin>-<triple>.<ext>`. Compared case-insensitively against the
+        // canonical archive names for this triple.
+        let lower = filename.to_ascii_lowercase();
+        let is_preferred =
+            lower == format!("{plugin_lower}-{triple}.tar.gz") || lower == format!("{plugin_lower}-{triple}.tgz");
+        match out.get(triple) {
+            Some((_, existing_preferred)) if *existing_preferred || !is_preferred => {}
+            _ => {
+                out.insert(triple.to_string(), (hex.to_ascii_lowercase(), is_preferred));
+            }
+        }
+    }
+    out.into_iter().map(|(triple, (hex, _))| (triple, hex)).collect()
+}
+
+/// Locate the release's `SHA256SUMS.txt` asset (case-insensitive; also accepts
+/// `SHA256SUMS`).
+fn find_sha256sums_asset(assets: &[GithubReleaseAsset]) -> Option<&GithubReleaseAsset> {
+    assets.iter().find(|a| {
+        let lower = a.name.to_ascii_lowercase();
+        lower == "sha256sums.txt" || lower == "sha256sums"
+    })
+}
+
 async fn download_to_path(url: &str, dest: &Path) -> Result<()> {
     let client =
         reqwest::Client::builder().user_agent(release_user_agent()).build().context("failed to build HTTP client")?;
@@ -3786,6 +3964,15 @@ struct ReleaseInstall {
     /// can pick sibling `<binary>-<target>.tar.gz` archives without a
     /// second API roundtrip. Populated only on the release source path.
     release_assets: Vec<GithubReleaseAsset>,
+    /// Per-target archive sha256, derived from the release `SHA256SUMS.txt`
+    /// (`triple -> tarball sha`). Records EVERY published platform so a lock
+    /// generated on one platform drives a verified `--locked` install on
+    /// another. Empty when the release publishes no `SHA256SUMS.txt`.
+    sha256sums_targets: BTreeMap<String, String>,
+    /// Raw `SHA256SUMS.txt` body, retained so secondary (multi-binary) installs
+    /// can derive THEIR per-target archive shas without a second fetch. `None`
+    /// when the release publishes no sums file.
+    sha256sums_body: Option<String>,
     /// RAII guard for the staging directory the asset was downloaded into.
     /// All paths above point inside this guard's directory; the caller
     /// must keep `_temp_dir` alive until the binary has been copied to
@@ -3794,7 +3981,11 @@ struct ReleaseInstall {
     _temp_dir: tempfile::TempDir,
 }
 
-async fn resolve_release_install(spec: RepoSpec, explicit_tag: Option<String>) -> Result<ReleaseInstall> {
+async fn resolve_release_install(
+    spec: RepoSpec,
+    explicit_tag: Option<String>,
+    expected_archive_sha256: Option<String>,
+) -> Result<ReleaseInstall> {
     let tag = match (spec.tag.clone(), explicit_tag) {
         (Some(spec_tag), Some(flag_tag)) => {
             if spec_tag != flag_tag {
@@ -3846,22 +4037,62 @@ async fn resolve_release_install(spec: RepoSpec, explicit_tag: Option<String>) -
     let asset_path = temp_path.join(&asset.name);
     download_to_path(&asset.browser_download_url, &asset_path).await?;
 
-    // Resolve expected SHA256: sidecar asset > release `digest` field.
-    let mut expected_sha: Option<String> = None;
-    if let Some(sidecar_asset) = find_sha256_sidecar(&release.assets, &asset.name) {
-        match download_text(&sidecar_asset.browser_download_url).await {
+    // Fetch the release `SHA256SUMS.txt` once and record the tarball sha for
+    // EVERY published platform. This is what makes the lockfile portable: a
+    // macOS install records the linux (etc.) tarball sha too, so `--locked`
+    // can verify on a fresh linux container before extracting. Best-effort: a
+    // release without `SHA256SUMS.txt` falls back to the per-asset
+    // sidecar/digest path below (and records only the current target).
+    let mut sha256sums_targets: BTreeMap<String, String> = BTreeMap::new();
+    let mut sha256sums_body: Option<String> = None;
+    if let Some(sums_asset) = find_sha256sums_asset(&release.assets) {
+        match download_text(&sums_asset.browser_download_url).await {
             Ok(body) => {
-                if let Some(hex) = parse_sha256_sidecar(&body) {
-                    expected_sha = Some(hex);
-                } else {
-                    eprintln!(
-                        "warning: sha256 sidecar '{}' had unexpected format; skipping verification",
-                        sidecar_asset.name
-                    );
-                }
+                sha256sums_targets = parse_sha256sums_for_targets(&body, &spec.repo);
+                sha256sums_body = Some(body);
             }
             Err(err) => {
-                eprintln!("warning: failed to download sha256 sidecar '{}': {}", sidecar_asset.name, err);
+                eprintln!(
+                    "warning: failed to download '{}': {}; recording only the current target",
+                    sums_asset.name, err
+                );
+            }
+        }
+    }
+
+    // The target triple the SELECTED asset actually targets. `current_platform_tokens`
+    // allows compatible fallbacks (e.g. a musl archive on a gnu host), so the
+    // selected asset's triple can differ from the build triple — key the
+    // SHA256SUMS lookup + the recorded claim off the asset that was downloaded,
+    // not the build triple, otherwise verification is skipped and the sha is
+    // recorded under the wrong target (codex P2).
+    let selected_target = target_triple_from_asset_name(&asset.name).or_else(current_target_triple);
+
+    // Resolve expected SHA256 for the CURRENT asset (the TARBALL):
+    // caller-pinned `expected_archive_sha256` (the `--locked` lock pin) >
+    // SHA256SUMS (selected target) > sidecar asset > release `digest` field.
+    // The caller pin wins so a `--locked` run aborts BEFORE extracting when
+    // the published tarball drifted from the committed archive sha — even if
+    // the release's own SHA256SUMS was regenerated to match the drift.
+    let mut expected_sha: Option<String> = expected_archive_sha256
+        .clone()
+        .or_else(|| selected_target.and_then(|triple| sha256sums_targets.get(triple).cloned()));
+    if expected_sha.is_none() {
+        if let Some(sidecar_asset) = find_sha256_sidecar(&release.assets, &asset.name) {
+            match download_text(&sidecar_asset.browser_download_url).await {
+                Ok(body) => {
+                    if let Some(hex) = parse_sha256_sidecar(&body) {
+                        expected_sha = Some(hex);
+                    } else {
+                        eprintln!(
+                            "warning: sha256 sidecar '{}' had unexpected format; skipping verification",
+                            sidecar_asset.name
+                        );
+                    }
+                }
+                Err(err) => {
+                    eprintln!("warning: failed to download sha256 sidecar '{}': {}", sidecar_asset.name, err);
+                }
             }
         }
     }
@@ -3888,6 +4119,16 @@ async fn resolve_release_install(spec: RepoSpec, explicit_tag: Option<String>) -
             "warning: no sha256 sidecar or digest for asset '{}'; install proceeding without checksum verification",
             asset.name
         );
+    }
+
+    // Guarantee the lockfile records at least the SELECTED asset's target
+    // archive sha, even for a release without a `SHA256SUMS.txt` (the
+    // per-target map is otherwise empty). The current asset is the tarball we
+    // just verified (or hashed), so its `computed` sha IS that target's
+    // archive sha. Keyed off the selected asset's triple so a fallback archive
+    // (e.g. musl on a gnu host) is recorded under the triple it actually is.
+    if let Some(triple) = selected_target {
+        sha256sums_targets.entry(triple.to_string()).or_insert_with(|| computed.clone());
     }
 
     // Extract if tarball; otherwise treat as a bare binary.
@@ -3944,6 +4185,8 @@ async fn resolve_release_install(spec: RepoSpec, explicit_tag: Option<String>) -
         owner: spec.owner.clone(),
         repo: spec.repo.clone(),
         release_assets: release.assets.clone(),
+        sha256sums_targets,
+        sha256sums_body,
         _temp_dir: temp_dir,
     })
 }
@@ -4347,6 +4590,14 @@ struct InstallProvenance {
     /// 40-hex commit sha the release resolved to (release source only),
     /// recorded into the lockfile's `resolved_commit`.
     resolved_commit: Option<String>,
+    /// Per-target archive sha256 from the release `SHA256SUMS.txt`
+    /// (`triple -> tarball sha`), for the PRIMARY asset. Populated only on the
+    /// release source path; drives the lockfile's portable `targets` claim.
+    sha256sums_targets: BTreeMap<String, String>,
+    /// Raw `SHA256SUMS.txt` body, so secondary (multi-binary) lock entries can
+    /// derive their OWN per-target archive shas (keeping them portable too).
+    /// `None` for non-release sources or releases without a sums file.
+    sha256sums_body: Option<String>,
 }
 
 /// Probe a plugin binary's `--manifest` output without touching the install
@@ -4747,6 +4998,8 @@ async fn handle_plugin_install(args: PluginInstallArgs, project_root: &str, json
         force_rewrite_lockfile: args.force_rewrite_lockfile,
         as_kind: args.as_kind,
         project: args.project,
+        expected_archive_sha256: None,
+        locked_secondary_archive_shas: BTreeMap::new(),
     })
     .await?;
     let role = output
@@ -4878,19 +5131,93 @@ async fn run_locked_install(args: PluginInstallArgs, project_root: &str, json: b
     // verification as "missing". Distinguishing them needs the release's
     // declared binary set (`plugin.toml`), which is not recorded in the lock;
     // deferred.
+    // The platform we are reproducing ON. Every entry's portable claim is
+    // keyed by triple; without a known triple there is nothing to verify
+    // against, so fail the whole run with an actionable message.
+    let Some(current_triple) = current_target_triple() else {
+        return Err(invalid_input_error(
+            "current platform has no known target triple, so `--locked` cannot verify any pinned archive sha. \
+             Install plugins normally on this platform instead.",
+        ));
+    };
+
+    // Release groups (`source_repo`, `version`) that have at least one entry
+    // with a current-target archive sha. A multi-binary release's SECONDARY
+    // entries only record the install platform (we never had their foreign
+    // tarball shas), so on a different platform they lack a current-target
+    // claim — but the group's PRIMARY does, and a single release reinstall
+    // reproduces every sibling binary. Such a covered secondary must NOT fail
+    // the missing-archive-sha guard; it is verified by its installed binary
+    // below instead (codex P2).
+    // A usable archive pin for the current target: a recorded `archive_sha256`
+    // that is non-empty (an empty one means "binary installed but tarball sha
+    // unknown" — e.g. a no-SHA256SUMS secondary — which can't gate a download).
+    let archive_pin = |e: &LockEntry| -> Option<String> {
+        e.target(current_triple).map(|t| t.archive_sha256.clone()).filter(|s| !s.is_empty())
+    };
+    let mut release_groups_with_current_target: BTreeSet<(String, String)> = BTreeSet::new();
+    for entry in &lockfile.plugins {
+        if let (Some(repo), true) = (entry.source_repo.as_deref(), archive_pin(entry).is_some()) {
+            if !repo.starts_with("https://") && !repo.starts_with("path:") {
+                release_groups_with_current_target.insert((repo.to_string(), entry.version.clone()));
+            }
+        }
+    }
+
     let mut installed_release_groups: BTreeSet<(String, String)> = BTreeSet::new();
     let mut rows: Vec<LockedInstallRow> = Vec::with_capacity(lockfile.plugins.len());
     let mut failed = 0_usize;
     let mut installed = 0_usize;
 
     for entry in &lockfile.plugins {
+        // Portable, cross-platform pin for THIS platform: the recorded
+        // TARBALL sha for the current target. Its absence means the lock was
+        // generated without this platform (or migrated from 1.0) — fail with
+        // a regenerate/reinstall hint rather than installing unverified.
+        // EXCEPTION: a release-group secondary covered by a primary that DOES
+        // pin the current target (see above) is reproduced via the group, so
+        // it carries no own archive sha and is verified by binary hash instead.
+        let expected_archive_sha = archive_pin(entry);
+        let covered_secondary = expected_archive_sha.is_none()
+            && entry.source_repo.as_deref().is_some_and(|repo| {
+                release_groups_with_current_target.contains(&(repo.to_string(), entry.version.clone()))
+            });
+        if expected_archive_sha.is_none() && !covered_secondary {
+            failed += 1;
+            let detail = if entry.is_legacy_unverifiable() {
+                format!(
+                    "lockfile entry has no per-target integrity claim (migrated from a 1.0 lockfile) — \
+                     run `animus plugin install {}` once on this platform to record portable shas",
+                    entry.source_repo.as_deref().unwrap_or(&entry.name)
+                )
+            } else {
+                format!(
+                    "lockfile records no archive sha for target '{current_triple}' (the lock was generated without this \
+                     platform) — regenerate the lock on this platform, or `animus plugin install {}` once here",
+                    entry.source_repo.as_deref().unwrap_or(&entry.name)
+                )
+            };
+            rows.push(LockedInstallRow {
+                name: entry.name.clone(),
+                source_repo: entry.source_repo.clone().unwrap_or_default(),
+                version: entry.version.clone(),
+                expected_sha256: String::new(),
+                status: "failed",
+                detail: Some(detail),
+            });
+            continue;
+        }
+        // Empty for a covered secondary (reproduced via its release group); the
+        // recorded tarball sha otherwise.
+        let expected_archive_sha = expected_archive_sha.unwrap_or_default();
+
         let Some(source_repo) = entry.source_repo.as_deref().filter(|s| !s.is_empty()) else {
             failed += 1;
             rows.push(LockedInstallRow {
                 name: entry.name.clone(),
                 source_repo: String::new(),
                 version: entry.version.clone(),
-                expected_sha256: entry.artifact_sha256.clone(),
+                expected_sha256: expected_archive_sha.clone(),
                 status: "failed",
                 detail: Some("lockfile entry records no source_repo — installed before source provenance was tracked; reinstall it once to record the source".to_string()),
             });
@@ -4919,6 +5246,31 @@ async fn run_locked_install(args: PluginInstallArgs, project_root: &str, json: b
                 (Some(installed), Some(native)) if installed != native => Some(installed.to_string()),
                 _ => None,
             };
+            // For a RELEASE reinstall, gather the lock's expected per-target
+            // tarball sha for every OTHER entry in the same release group (the
+            // multi-binary SECONDARIES) so the install loop pins each secondary
+            // tarball against the lock before extracting (codex P1). Keyed by
+            // the secondary's binary name (`entry.name`), matching the
+            // `descriptor.name` the multi-binary loop installs under.
+            let locked_secondary_archive_shas: BTreeMap<String, String> = if is_release {
+                lockfile
+                    .plugins
+                    .iter()
+                    .filter(|other| {
+                        other.name != entry.name
+                            && other.source_repo.as_deref() == Some(source_repo)
+                            && other.version == entry.version
+                    })
+                    .filter_map(|other| {
+                        other
+                            .target(current_triple)
+                            .filter(|t| !t.archive_sha256.is_empty())
+                            .map(|t| (other.name.clone(), t.archive_sha256.clone()))
+                    })
+                    .collect()
+            } else {
+                BTreeMap::new()
+            };
             let mut req = PluginInstallRequest {
                 name: Some(entry.name.clone()),
                 force: true,
@@ -4931,33 +5283,47 @@ async fn run_locked_install(args: PluginInstallArgs, project_root: &str, json: b
                 as_kind: locked_as_kind,
                 signature_policy: Some(signature_policy),
                 trusted_signers: trusted_signers.clone(),
+                locked_secondary_archive_shas,
                 ..Default::default()
             };
+            // Pin the TARBALL sha for the current target so the install
+            // pipeline aborts before extracting / executing a binary whose
+            // archive drifted from the lock — the cross-platform verification
+            // that makes a Mac-generated lock safe to reproduce on linux
+            // (codex P1). For a RELEASE source the pin gates the downloaded
+            // TARBALL via `expected_archive_sha256` (the extracted-binary hash
+            // differs from the tarball hash, so `req.sha256` — which gates the
+            // binary — would spuriously fail). For `--url`/`--path` the fetched
+            // artifact IS the archive, so `req.sha256` is correct.
             if is_url {
                 req.url = Some(source_repo.to_string());
-                req.sha256 = Some(entry.artifact_sha256.clone());
+                req.sha256 = Some(expected_archive_sha.clone());
             } else if let Some(path) = source_repo.strip_prefix("path:") {
                 req.path = Some(path.to_string());
-                req.sha256 = Some(entry.artifact_sha256.clone());
+                req.sha256 = Some(expected_archive_sha.clone());
             } else {
                 req.source = Some(source_repo.to_string());
                 req.tag = if entry.version.is_empty() { None } else { Some(entry.version.clone()) };
-                // Pin the release asset's checksum so the install pipeline's
-                // PRE-manifest checksum gate aborts before executing a binary
-                // whose hash drifted from the lock — never run unpinned code
-                // (codex P1). The primary entry is written to the lockfile
-                // first, so it is the first row of each release group and its
-                // `artifact_sha256` matches the primary release asset.
+                // The primary entry is written to the lockfile first, so it is
+                // the first row of each release group and its current-target
+                // archive sha matches the primary release tarball.
                 //
-                // TODO(codex-p2): the install pipeline only pins the PRIMARY
-                // asset via `req.sha256`; a multi-binary release's SECONDARY
-                // assets are checked against the release sidecar/digest, not
-                // the lock, so a drifted secondary is copied to disk and only
-                // flagged when this `--locked` run verifies it below. The lock
-                // pin is preserved (a re-run re-detects the drift), but the
-                // drifted secondary binary is left installed. Removing it would
-                // need per-binary rollback in the install pipeline; deferred.
-                req.sha256 = Some(entry.artifact_sha256.clone());
+                // TODO(codex-p2): only the PRIMARY tarball is pinned via
+                // `expected_archive_sha256`; a multi-binary release's SECONDARY
+                // tarballs are checked against the release SHA256SUMS/sidecar,
+                // not the lock, so a drifted secondary is copied to disk and
+                // only flagged when this `--locked` run verifies its installed
+                // binary below. The lock pin is preserved (a re-run re-detects
+                // the drift), but the drifted secondary binary is left
+                // installed. Removing it would need per-binary rollback in the
+                // install pipeline; deferred.
+                //
+                // Empty only for a covered secondary that somehow drives its
+                // own install (its primary did not precede it) — leave the pin
+                // unset and rely on the release's own SHA256SUMS check.
+                if !expected_archive_sha.is_empty() {
+                    req.expected_archive_sha256 = Some(expected_archive_sha.clone());
+                }
             }
             match run_plugin_install(req).await {
                 Ok(_) => {
@@ -4976,58 +5342,83 @@ async fn run_locked_install(args: PluginInstallArgs, project_root: &str, json: b
                 name: entry.name.clone(),
                 source_repo: source_repo.to_string(),
                 version: entry.version.clone(),
-                expected_sha256: entry.artifact_sha256.clone(),
+                expected_sha256: expected_archive_sha.clone(),
                 status: "failed",
                 detail: Some(format!("reinstall failed: {err}")),
             });
             continue;
         }
 
-        // Verify THIS entry's installed binary against its pin. The lockfile
-        // `artifact_sha256` is the installed BINARY's hash for every entry —
-        // primary AND secondary (multi-binary releases record the extracted
-        // binary sha, not the archive sha) — so hashing `install_dir/<name>`
-        // and comparing is correct for all entries. A drift here means the
-        // published source changed under the pin; `--locked` then fails the
-        // CI / fresh-machine reproducibility gate rather than rewriting the
-        // pin (codex P1).
+        // The TARBALL sha was already verified against `expected_archive_sha`
+        // by the install pipeline's pre-extract gate (cross-platform). Here we
+        // additionally confirm the EXTRACTED binary landed and matches the
+        // sha the just-completed reinstall recorded for this platform — a
+        // host-only tamper check. `verify_installed` reads the in-memory
+        // `lockfile` (the committed pin), whose current-target host hash may be
+        // absent for a foreign-generated lock; in that case `MissingTarget` is
+        // not a failure (the portable archive gate already passed), so treat it
+        // as verified.
         let binary = install_dir.join(&entry.name);
-        match lockfile.verify_entry(&entry.name, &sha256_of_file(&binary).unwrap_or_default()) {
-            LockVerifyResult::Match => {
+        if !binary.exists() {
+            failed += 1;
+            rows.push(LockedInstallRow {
+                name: entry.name.clone(),
+                source_repo: source_repo.to_string(),
+                version: entry.version.clone(),
+                expected_sha256: expected_archive_sha.clone(),
+                status: "failed",
+                detail: Some(format!("installed binary not found at {} after reinstall", binary.display())),
+            });
+            continue;
+        }
+        // Secondary entries now carry per-target `archive_sha256` from
+        // SHA256SUMS (see the lock-build path), and the multi-binary install
+        // gate (below, via `locked_secondary_archive_shas`) checks each
+        // secondary TARBALL against the LOCK's recorded archive sha before
+        // extracting — so a drifted secondary asset fails the gate even with a
+        // regenerated SHA256SUMS. A foreign-generated lock has no current-target
+        // `installed_binary_sha256` for secondaries (we never extracted their
+        // binary on this platform), so `verify_installed` here returns
+        // `MissingTarget`; that is not unpinned (the archive was gated above),
+        // so it counts as verified.
+        match lockfile.verify_installed(&entry.name, &binary) {
+            Ok(LockVerifyResult::Match)
+            | Ok(LockVerifyResult::MissingTarget { .. })
+            | Ok(LockVerifyResult::Missing) => {
                 installed += 1;
                 rows.push(LockedInstallRow {
                     name: entry.name.clone(),
                     source_repo: source_repo.to_string(),
                     version: entry.version.clone(),
-                    expected_sha256: entry.artifact_sha256.clone(),
+                    expected_sha256: expected_archive_sha.clone(),
                     status: "verified",
                     detail: None,
                 });
             }
-            LockVerifyResult::Mismatch { expected, actual } => {
+            Ok(LockVerifyResult::Mismatch { expected, actual }) => {
                 failed += 1;
                 rows.push(LockedInstallRow {
                     name: entry.name.clone(),
                     source_repo: source_repo.to_string(),
                     version: entry.version.clone(),
-                    expected_sha256: entry.artifact_sha256.clone(),
+                    expected_sha256: expected_archive_sha.clone(),
                     status: "failed",
                     detail: Some(format!(
-                        "artifact sha256 drifted from the pin: lockfile expected {expected} but the installed binary \
-                         at {} hashes to {actual} — the published source changed under the pin",
+                        "installed binary sha256 drifted from the pin: lockfile expected {expected} but the binary \
+                         at {} hashes to {actual}",
                         binary.display()
                     )),
                 });
             }
-            LockVerifyResult::Missing => {
+            Err(err) => {
                 failed += 1;
                 rows.push(LockedInstallRow {
                     name: entry.name.clone(),
                     source_repo: source_repo.to_string(),
                     version: entry.version.clone(),
-                    expected_sha256: entry.artifact_sha256.clone(),
+                    expected_sha256: expected_archive_sha.clone(),
                     status: "failed",
-                    detail: Some(format!("installed binary not found at {} after reinstall", binary.display())),
+                    detail: Some(format!("failed to hash installed binary at {}: {err}", binary.display())),
                 });
             }
         }
@@ -5381,10 +5772,21 @@ pub(crate) fn run_plugin_rename(req: PluginRenameRequest) -> Result<PluginRename
 // ===== `plugin lock` subcommands =====
 
 #[derive(Debug, Serialize)]
+struct PluginLockTargetCoverage {
+    name: String,
+    /// Target triples this entry has a recorded archive sha for.
+    targets: Vec<String>,
+    /// `true` for a 1.0-migrated entry with no usable per-target claim.
+    legacy_unverifiable: bool,
+}
+
+#[derive(Debug, Serialize)]
 struct PluginLockListOutput {
     lockfile: String,
     schema_version: String,
     generated_at: String,
+    /// Per-entry platform coverage summary (which targets each entry pins).
+    coverage: Vec<PluginLockTargetCoverage>,
     plugins: Vec<LockEntry>,
 }
 
@@ -5392,6 +5794,9 @@ struct PluginLockListOutput {
 struct PluginLockVerifyEntry {
     name: String,
     status: &'static str,
+    /// The current build target the entry was verified against (the host-only
+    /// `installed_binary_sha256` claim is keyed by it).
+    target: String,
     expected_sha256: String,
     actual_sha256: Option<String>,
     installed_path: Option<String>,
@@ -5409,6 +5814,8 @@ struct PluginLockVerifyOutput {
     /// Primary lockfile path (back-compat field). Equals the `--lockfile`
     /// override when supplied, otherwise the default-resolved path.
     lockfile: String,
+    /// The current build target triple all entries were verified against.
+    target: String,
     /// Every lockfile root the verify swept (global + project when both
     /// exist as distinct files).
     lockfiles: Vec<String>,
@@ -5416,6 +5823,11 @@ struct PluginLockVerifyOutput {
     matched: usize,
     mismatched: usize,
     missing_binary: usize,
+    /// Entries that exist but have no host-only integrity claim for the
+    /// current target (1.0-migrated, or a lock generated on another platform).
+    /// Reported distinctly from `mismatch`; it is drift the operator must fix
+    /// by reinstalling on this platform, so it fails the verify gate.
+    missing_target: usize,
     /// Installed plugins discovered on disk that are absent from every swept
     /// lockfile. Like mismatch/missing this is drift and fails the verify gate.
     extra: usize,
@@ -5675,10 +6087,23 @@ async fn handle_plugin_lock(cmd: PluginLockCommand, project_root: &str) -> Resul
 fn run_lock_list(args: PluginLockListArgs, project_root: &str) -> Result<()> {
     let path = args.lockfile.unwrap_or_else(|| PluginLockfile::default_path(Some(std::path::Path::new(project_root))));
     let lockfile = PluginLockfile::load_or_empty(&path)?;
+    // Per-entry platform coverage: which target triples each entry has a
+    // recorded archive sha for. Surfaces portability at a glance — an entry
+    // covering only the generating platform won't drive `--locked` elsewhere.
+    let coverage: Vec<PluginLockTargetCoverage> = lockfile
+        .plugins
+        .iter()
+        .map(|e| PluginLockTargetCoverage {
+            name: e.name.clone(),
+            targets: e.target_triples().into_iter().map(str::to_string).collect(),
+            legacy_unverifiable: e.is_legacy_unverifiable(),
+        })
+        .collect();
     let output = PluginLockListOutput {
         lockfile: path.to_string_lossy().to_string(),
         schema_version: lockfile.schema_version.clone(),
         generated_at: lockfile.generated_at.clone(),
+        coverage,
         plugins: lockfile.plugins.clone(),
     };
     print_value(output, args.json)
@@ -5688,15 +6113,21 @@ fn run_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result<()>
     let json = args.json;
     let output = compute_lock_verify(args, project_root)?;
     // `animus plugin lock verify` is meant to be wired into CI / cron as a
-    // tamper-detection gate. A hash mismatch, a missing on-disk binary for a
-    // tracked entry, AND an installed plugin absent from the lockfile ("extra")
-    // all indicate the install state has drifted from the lockfile, so any of
-    // them must exit non-zero.
-    let exit_err = if output.mismatched > 0 || output.missing_binary > 0 || output.extra > 0 {
+    // tamper-detection gate. A hash mismatch, a missing on-disk binary, a
+    // missing per-target claim for this platform, AND an installed plugin
+    // absent from the lockfile ("extra") all indicate the install state has
+    // drifted from the lockfile, so any of them must exit non-zero.
+    let exit_err = if output.mismatched > 0
+        || output.missing_binary > 0
+        || output.missing_target > 0
+        || output.extra > 0
+    {
         Some(anyhow!(
-            "plugin lock verify failed: {} mismatched, {} missing binary, {} extra (not in lockfile), {} matched",
+            "plugin lock verify failed: {} mismatched, {} missing binary, {} missing target ({}), {} extra (not in lockfile), {} matched",
             output.mismatched,
             output.missing_binary,
+            output.missing_target,
+            output.target,
             output.extra,
             output.matched
         ))
@@ -5771,11 +6202,16 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
     // never appear in the project registry.
     let project_registry_names: BTreeSet<String> = project_registry_claimed_names(project_root_path);
 
+    // The platform we verify host-only binary claims against. An unknown
+    // triple leaves every entry as `missing_target` (no claim can be matched).
+    let current_target = current_target_triple().unwrap_or("<unknown>");
+
     let mut lockfiles: Vec<String> = Vec::with_capacity(targets.len());
     let mut entries = Vec::new();
     let mut matched = 0_usize;
     let mut mismatched = 0_usize;
     let mut missing_binary = 0_usize;
+    let mut missing_target = 0_usize;
     // Every name claimed by any swept lockfile — used below to flag installed
     // plugins that are absent from the lockfile ("extra" drift).
     let mut locked_names: BTreeSet<String> = BTreeSet::new();
@@ -5804,12 +6240,16 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                 .map(|dir| dir.join(&entry.name))
                 .find(|candidate| candidate.exists())
                 .unwrap_or_else(|| entry_dirs[0].join(&entry.name));
+            // The host-only claim recorded for the current platform, if any.
+            let expected_for_target =
+                entry.target(current_target).and_then(|t| t.installed_binary_sha256.clone()).unwrap_or_default();
             if !installed_path.exists() {
                 missing_binary += 1;
                 entries.push(PluginLockVerifyEntry {
                     name: entry.name.clone(),
                     status: "missing_binary",
-                    expected_sha256: entry.artifact_sha256.clone(),
+                    target: current_target.to_string(),
+                    expected_sha256: expected_for_target,
                     actual_sha256: None,
                     installed_path: Some(installed_path.to_string_lossy().to_string()),
                     detail: Some("installed binary not found at expected path".to_string()),
@@ -5824,8 +6264,9 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                     entries.push(PluginLockVerifyEntry {
                         name: entry.name.clone(),
                         status: "ok",
-                        expected_sha256: entry.artifact_sha256.clone(),
-                        actual_sha256: Some(entry.artifact_sha256.clone()),
+                        target: current_target.to_string(),
+                        expected_sha256: expected_for_target.clone(),
+                        actual_sha256: Some(expected_for_target),
                         installed_path: Some(installed_path.to_string_lossy().to_string()),
                         detail: None,
                         scope,
@@ -5840,6 +6281,7 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                             AuditEventKind::LockfileMismatch,
                             serde_json::json!({
                                 "plugin": entry.name,
+                                "target": current_target,
                                 "expected_sha256": expected,
                                 "actual_sha256": actual,
                                 "lockfile": lockfile_display.clone(),
@@ -5849,10 +6291,32 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                     entries.push(PluginLockVerifyEntry {
                         name: entry.name.clone(),
                         status: "mismatch",
+                        target: current_target.to_string(),
                         expected_sha256: expected,
                         actual_sha256: Some(actual),
                         installed_path: Some(installed_path.to_string_lossy().to_string()),
                         detail: Some("sha256 of installed binary does not match lockfile".to_string()),
+                        scope,
+                        lockfile: lockfile_display.clone(),
+                    });
+                }
+                Ok(LockVerifyResult::MissingTarget { target }) => {
+                    // The plugin IS pinned, but there's no host-only binary
+                    // claim for THIS platform (1.0-migrated, or a lock made
+                    // elsewhere). Reported distinctly so the operator knows to
+                    // reinstall on this platform rather than chase a "mismatch".
+                    missing_target += 1;
+                    entries.push(PluginLockVerifyEntry {
+                        name: entry.name.clone(),
+                        status: "missing_target",
+                        target: target.clone(),
+                        expected_sha256: String::new(),
+                        actual_sha256: None,
+                        installed_path: Some(installed_path.to_string_lossy().to_string()),
+                        detail: Some(format!(
+                            "lockfile has no integrity claim for target '{target}' (migrated from 1.0, or generated on \
+                             another platform) — run `animus plugin install` on this platform to record it"
+                        )),
                         scope,
                         lockfile: lockfile_display.clone(),
                     });
@@ -5862,7 +6326,8 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                     entries.push(PluginLockVerifyEntry {
                         name: entry.name.clone(),
                         status: "missing_lock_entry",
-                        expected_sha256: entry.artifact_sha256.clone(),
+                        target: current_target.to_string(),
+                        expected_sha256: expected_for_target,
                         actual_sha256: None,
                         installed_path: Some(installed_path.to_string_lossy().to_string()),
                         detail: Some("entry vanished between read and verify".to_string()),
@@ -5874,7 +6339,8 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                     entries.push(PluginLockVerifyEntry {
                         name: entry.name.clone(),
                         status: "error",
-                        expected_sha256: entry.artifact_sha256.clone(),
+                        target: current_target.to_string(),
+                        expected_sha256: expected_for_target,
                         actual_sha256: None,
                         installed_path: Some(installed_path.to_string_lossy().to_string()),
                         detail: Some(err.to_string()),
@@ -5916,6 +6382,7 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
                 entries.push(PluginLockVerifyEntry {
                     name: plugin.name.clone(),
                     status: "extra",
+                    target: current_target.to_string(),
                     expected_sha256: String::new(),
                     actual_sha256: None,
                     installed_path: None,
@@ -5929,11 +6396,13 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
 
     Ok(PluginLockVerifyOutput {
         lockfile: primary_path.to_string_lossy().to_string(),
+        target: current_target.to_string(),
         lockfiles,
         entries,
         matched,
         mismatched,
         missing_binary,
+        missing_target,
         extra,
     })
 }
@@ -5942,12 +6411,78 @@ fn compute_lock_verify(args: PluginLockVerifyArgs, project_root: &str) -> Result
 mod tests {
     use super::*;
 
+    /// Build a single-target integrity map for the CURRENT build target whose
+    /// archive + installed-binary shas both equal `sha`. Mirrors how an install
+    /// on this platform records its own target; lets the existing lock tests
+    /// exercise `verify_installed` / drift against `install_dir/<name>`.
+    fn lock_targets(sha: impl Into<String>) -> BTreeMap<String, TargetIntegrity> {
+        let sha = sha.into();
+        let mut targets = BTreeMap::new();
+        if let Some(triple) = current_target_triple() {
+            targets.insert(
+                triple.to_string(),
+                TargetIntegrity {
+                    archive_sha256: sha.clone(),
+                    signature_bundle_sha256: None,
+                    installed_binary_sha256: Some(sha),
+                },
+            );
+        }
+        targets
+    }
+
     fn asset(name: &str) -> GithubReleaseAsset {
         GithubReleaseAsset {
             name: name.to_string(),
             browser_download_url: format!("https://example.test/{name}"),
             digest: None,
         }
+    }
+
+    #[test]
+    fn target_triple_from_asset_name_recognizes_archives_only() {
+        assert_eq!(
+            target_triple_from_asset_name("animus-provider-claude-x86_64-unknown-linux-gnu.tar.gz"),
+            Some("x86_64-unknown-linux-gnu")
+        );
+        assert_eq!(target_triple_from_asset_name("ao-v0.6.5-aarch64-apple-darwin.tgz"), Some("aarch64-apple-darwin"));
+        // Non-archive sidecars and the sums file itself contribute nothing.
+        assert_eq!(target_triple_from_asset_name("SHA256SUMS.txt"), None);
+        assert_eq!(target_triple_from_asset_name("foo-x86_64-unknown-linux-gnu.tar.gz.bundle"), None);
+        assert_eq!(target_triple_from_asset_name("README.md"), None);
+    }
+
+    #[test]
+    fn parse_sha256sums_populates_all_targets() {
+        let a = "a".repeat(64);
+        let b = "b".repeat(64);
+        let c = "c".repeat(64);
+        let body = format!(
+            "{a}  animus-provider-claude-x86_64-unknown-linux-gnu.tar.gz\n\
+             {b}  animus-provider-claude-aarch64-apple-darwin.tar.gz\n\
+             {c} *animus-provider-claude-x86_64-pc-windows-msvc.tar.gz\n\
+             deadbeef  not-a-valid-line\n"
+        );
+        let targets = parse_sha256sums_for_targets(&body, "animus-provider-claude");
+        assert_eq!(targets.len(), 3);
+        assert_eq!(targets.get("x86_64-unknown-linux-gnu"), Some(&a));
+        assert_eq!(targets.get("aarch64-apple-darwin"), Some(&b));
+        // The `*` binary-mode marker is stripped.
+        assert_eq!(targets.get("x86_64-pc-windows-msvc"), Some(&c));
+    }
+
+    #[test]
+    fn parse_sha256sums_prefers_plugin_prefixed_archive_per_target() {
+        // A multi-binary release publishes a secondary archive for the SAME
+        // target; the plugin-prefixed primary must win.
+        let primary = "1".repeat(64);
+        let secondary = "2".repeat(64);
+        let body = format!(
+            "{secondary}  other-bin-x86_64-unknown-linux-gnu.tar.gz\n\
+             {primary}  animus-provider-claude-x86_64-unknown-linux-gnu.tar.gz\n"
+        );
+        let targets = parse_sha256sums_for_targets(&body, "animus-provider-claude");
+        assert_eq!(targets.get("x86_64-unknown-linux-gnu"), Some(&primary));
     }
 
     fn warning_row(name: &str, source: &'static str) -> PluginWarningRow {
@@ -6582,6 +7117,8 @@ name = "same"
             repo: Some("animus-provider-claude".to_string()),
             source_repo: Some("launchapp-dev/animus-provider-claude".to_string()),
             resolved_commit: None,
+            sha256sums_targets: BTreeMap::new(),
+            sha256sums_body: None,
         }
     }
 
@@ -7837,8 +8374,9 @@ required = ["launchapp-dev/animus-queue-default"]
         concurrent_lock.upsert(LockEntry {
             name: "animus-plugin-other".to_string(),
             version: "v0.1.0".to_string(),
-            artifact_sha256: "c".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("c".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: chrono::Utc::now().to_rfc3339(),
             installed_kind: None,
             native_kind: None,
@@ -8086,7 +8624,13 @@ required = ["launchapp-dev/animus-queue-default"]
         assert!(lock_path.exists(), "lockfile should exist at {}", lock_path.display());
         let lock = PluginLockfile::load_or_empty(&lock_path).unwrap();
         let entry = lock.find(&output.name).expect("lockfile entry must be present");
-        assert_eq!(entry.artifact_sha256, output.sha256);
+        // `--path` install records a single-target claim for the current
+        // platform; both the archive and installed-binary shas equal the
+        // installed-binary hash (no tarball involved).
+        let triple = current_target_triple().expect("known triple");
+        let integrity = entry.target(triple).expect("current-target claim recorded");
+        assert_eq!(integrity.archive_sha256, output.sha256);
+        assert_eq!(integrity.installed_binary_sha256.as_deref(), Some(output.sha256.as_str()));
         assert!(!entry.installed_at.is_empty());
     }
 
@@ -8438,8 +8982,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "plugin-a".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now.clone(),
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
@@ -8453,8 +8998,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "plugin-b".into(),
             version: "v0.1".into(),
-            artifact_sha256: "b".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("b".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now.clone(),
             installed_kind: Some(chosen_b.clone()),
             native_kind: Some("task".into()),
@@ -8480,8 +9026,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "legacy-task".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: None,
             native_kind: None,
@@ -8507,8 +9054,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "legacy-provider".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: None,
             native_kind: None,
@@ -8528,8 +9076,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "plugin-archive".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: Some("archive".into()),
             native_kind: Some("task".into()),
@@ -8549,8 +9098,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "plugin-a".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
@@ -8686,8 +9236,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "animus-plugin-collide-a".into(),
             version: "v0".into(),
-            artifact_sha256: "1".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("1".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now.clone(),
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
@@ -8697,8 +9248,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "animus-plugin-collide-b".into(),
             version: "v0".into(),
-            artifact_sha256: "2".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("2".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
@@ -8810,8 +9362,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "existing-requirement".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: Some("requirement".into()),
             native_kind: Some("requirement".into()),
@@ -8847,8 +9400,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "other-task".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
@@ -8888,8 +9442,9 @@ required = ["launchapp-dev/animus-queue-default"]
         lock.upsert(LockEntry {
             name: "existing-task".into(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: now,
             installed_kind: Some("task".into()),
             native_kind: Some("task".into()),
@@ -8927,8 +9482,9 @@ required = ["launchapp-dev/animus-queue-default"]
         LockEntry {
             name: name.to_string(),
             version: "v0.1".into(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets: lock_targets("a".repeat(64)),
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
             installed_at: chrono::Utc::now().to_rfc3339(),
             installed_kind: Some(installed.to_string()),
             native_kind: Some(native.to_string()),
@@ -9470,7 +10026,7 @@ required = ["launchapp-dev/animus-queue-default"]
         let env = project_scope_env();
         install_for_test(&env, "animus-plugin-bothscopes", true).await;
         let project_lock = || PluginLockfile::load_or_empty(&project_lockfile_path(&env.project_root)).unwrap();
-        let project_sha = project_lock().find("animus-plugin-bothscopes").unwrap().artifact_sha256.clone();
+        let project_sha = project_lock().find("animus-plugin-bothscopes").unwrap().targets.clone();
 
         // Global install of the SAME name, with the project root supplied
         // (as the CLI always does). The lock entry must land in the global
@@ -9490,7 +10046,7 @@ required = ["launchapp-dev/animus-queue-default"]
         let global_lock = PluginLockfile::load_or_empty(&global_lockfile_path()).unwrap();
         assert!(global_lock.find("animus-plugin-bothscopes").is_some(), "global op must write the global lockfile");
         assert_eq!(
-            project_lock().find("animus-plugin-bothscopes").unwrap().artifact_sha256,
+            project_lock().find("animus-plugin-bothscopes").unwrap().targets,
             project_sha,
             "project lock entry must be untouched by the global install"
         );

--- a/crates/orchestrator-cli/src/services/operations/ops_plugin/control_routing.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin/control_routing.rs
@@ -157,6 +157,8 @@ impl PluginRouting for PluginRoutingImpl {
             force_rewrite_lockfile: false,
             as_kind: None,
             project: false,
+            expected_archive_sha256: None,
+            locked_secondary_archive_shas: std::collections::BTreeMap::new(),
         };
         let output = run_plugin_install(install_req).await.map_err(internal)?;
         let plugin_kind = output.manifest.as_ref().map(|m| m.plugin_kind.clone()).unwrap_or_default();

--- a/crates/orchestrator-core/src/plugin_preflight/tests.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/tests.rs
@@ -303,13 +303,14 @@ fn summarize_with_lock_translates_native_subject_kind_to_installed_kind() {
     lock.upsert(LockEntry {
         name: "animus-plugin-archive".into(),
         version: "v0.1".into(),
-        artifact_sha256: "a".repeat(64),
-        signature_bundle_sha256: None,
+        targets: std::collections::BTreeMap::new(),
         installed_at: chrono::Utc::now().to_rfc3339(),
         installed_kind: Some("archive".into()),
         native_kind: Some("task".into()),
         source_repo: None,
         resolved_commit: None,
+        legacy_artifact_sha256: None,
+        legacy_signature_bundle_sha256: None,
     });
     let summaries = summarize_discovered_plugins_with_lock(&plugins, Some(&lock));
     assert_eq!(summaries.len(), 1);

--- a/crates/orchestrator-daemon-runtime/src/daemon/plugin_preflight_wiring.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/plugin_preflight_wiring.rs
@@ -249,13 +249,22 @@ pub fn lock_drift_warnings(project_root: &str) -> Vec<String> {
                 entry.name
             )),
             Some(plugin) => {
-                if let Ok(actual) = orchestrator_plugin_host::sha256_of_file(&plugin.path) {
-                    if !actual.eq_ignore_ascii_case(&entry.artifact_sha256) {
-                        warnings.push(format!(
-                            "plugin lock drift: {} sha256 mismatch; run `animus plugin lock verify`",
-                            entry.name
-                        ));
-                    }
+                // Target-aware (schema 2.0): compare the on-disk binary against
+                // the host-only `installed_binary_sha256` recorded for the
+                // CURRENT target. Only a `Mismatch` is drift; `MissingTarget` /
+                // `Missing` (1.0-migrated entry, or a lock generated on another
+                // platform) carries no comparable claim here, so it is left to
+                // `plugin lock verify` to report distinctly and not warned on.
+                let drift = [project_lock.as_ref(), global_lock.as_ref()]
+                    .into_iter()
+                    .flatten()
+                    .find(|lock| lock.find(&entry.name).is_some())
+                    .map(|lock| lock.verify_installed(&entry.name, &plugin.path));
+                if let Some(Ok(orchestrator_plugin_host::LockVerifyResult::Mismatch { .. })) = drift {
+                    warnings.push(format!(
+                        "plugin lock drift: {} sha256 mismatch; run `animus plugin lock verify`",
+                        entry.name
+                    ));
                 }
             }
         }
@@ -525,16 +534,28 @@ required = ["launchapp-dev/animus-provider-claude"]
         std::fs::create_dir_all(&animus).expect("mkdir .animus");
         let lock_path = animus.join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&lock_path);
+        let mut targets = std::collections::BTreeMap::new();
+        if let Some(triple) = orchestrator_plugin_host::current_target_triple() {
+            targets.insert(
+                triple.to_string(),
+                orchestrator_plugin_host::TargetIntegrity {
+                    archive_sha256: "a".repeat(64),
+                    signature_bundle_sha256: None,
+                    installed_binary_sha256: Some("a".repeat(64)),
+                },
+            );
+        }
         lock.upsert(orchestrator_plugin_host::LockEntry {
             name: "animus-provider-ghost".to_string(),
             version: "v0.1.0".to_string(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
+            targets,
             installed_at: chrono::Utc::now().to_rfc3339(),
             installed_kind: None,
             native_kind: None,
             source_repo: Some("launchapp-dev/animus-provider-ghost".to_string()),
             resolved_commit: None,
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
         });
         lock.save().expect("save lock");
 

--- a/crates/orchestrator-plugin-host/src/lib.rs
+++ b/crates/orchestrator-plugin-host/src/lib.rs
@@ -31,8 +31,8 @@ pub use host::{
     install_process_slot_factory_for_test, install_secret_snapshot_provider_for_test,
 };
 pub use lockfile::{
-    global_lockfile_path, project_lockfile_path, sha256_of_file, LockEntry, LockVerifyResult, PluginLockfile,
-    LOCKFILE_SCHEMA_VERSION,
+    current_target_triple, global_lockfile_path, project_lockfile_path, sha256_of_file, LockEntry, LockVerifyResult,
+    PluginLockfile, TargetIntegrity, LOCKFILE_SCHEMA_VERSION,
 };
 pub use manifest_cache::{CachedEntry, ManifestCache};
 

--- a/crates/orchestrator-plugin-host/src/lockfile.rs
+++ b/crates/orchestrator-plugin-host/src/lockfile.rs
@@ -1,13 +1,32 @@
 //! Plugin lockfile (`.animus/plugins.lock`).
 //!
-//! `plugins.lock` IS the animus plugin lockfile: it records
-//! `(name, version, artifact_sha256, signature_bundle_sha256, installed_at,
-//! source_repo, resolved_commit)` for every plugin install so a later upgrade
-//! can refuse to silently overwrite a binary whose hash no longer matches what
-//! the operator originally approved, and so `animus plugin install --locked`
-//! can reproduce the exact pinned set on a fresh machine. The lockfile is the
-//! user-visible audit + rollback anchor for plugin installs; the install
-//! pipeline writes it on success and removes the entry on uninstall.
+//! `plugins.lock` IS the animus plugin lockfile: it records, per plugin
+//! install, the source provenance plus a PER-TARGET integrity claim so a
+//! later upgrade can refuse to silently overwrite a binary whose hash no
+//! longer matches what the operator originally approved, and so
+//! `animus plugin install --locked` can reproduce the exact pinned set on a
+//! fresh machine — including a DIFFERENT platform than the one the lock was
+//! generated on. The lockfile is the user-visible audit + rollback anchor for
+//! plugin installs; the install pipeline writes it on success and removes the
+//! entry on uninstall.
+//!
+//! ## Platform-aware integrity (schema 2.0)
+//!
+//! Each entry's integrity claim is keyed by target triple in
+//! [`LockEntry::targets`]. The portable claim is
+//! [`TargetIntegrity::archive_sha256`] — the sha256 of the release TARBALL
+//! (`ao-<ver>-<target>.tar.gz`), exactly what a GitHub release's
+//! `SHA256SUMS.txt` lists. A release install fetches `SHA256SUMS.txt` and
+//! records the tarball sha for EVERY published platform, so a lock generated
+//! on macOS carries the linux tarball sha too and `--locked` can verify it on
+//! a linux container BEFORE extracting/executing anything.
+//!
+//! [`TargetIntegrity::installed_binary_sha256`] is a SECONDARY, host-only
+//! field: the sha256 of the extracted binary on the machine that performed
+//! this install. It is only meaningful for the install platform, so it is
+//! recorded only for the current target and used solely for fast on-disk
+//! tamper detection by `plugin lock verify` and the daemon lock-drift probe.
+//! Cross-platform verification (`--locked`) always uses `archive_sha256`.
 //!
 //! Tool-managed: do NOT hand-edit. Use `animus plugin install` /
 //! `plugin update` / `plugin uninstall` to mutate it; gitignore keeps the
@@ -17,32 +36,48 @@
 //! Format (TOML, matches the rest of the manifest surface):
 //!
 //! ```toml
-//! schema_version = "1.0"
+//! schema_version = "2.0"
 //! generated_at = "2026-05-26T..."
 //!
 //! [[plugins]]
 //! name = "launchapp-dev/animus-provider-claude"
 //! version = "v0.2.2"
-//! artifact_sha256 = "abc123..."
-//! signature_bundle_sha256 = "def456..."
 //! installed_at = "2026-05-26T..."
 //! source_repo = "launchapp-dev/animus-provider-claude"
 //! resolved_commit = "0123abc...40-hex..."
+//!
+//! [plugins.targets.x86_64-unknown-linux-gnu]
+//! archive_sha256 = "abc123..."
+//! signature_bundle_sha256 = "def456..."
+//!
+//! [plugins.targets.aarch64-apple-darwin]
+//! archive_sha256 = "789fed..."
+//! installed_binary_sha256 = "0011..."
 //! ```
 //!
 //! `source_repo` records where the plugin came from — an `owner/repo` slug for
 //! release installs, the URL for `--url` installs, or `path:<...>` for
 //! `--path` installs. `resolved_commit` is the exact 40-hex commit sha when
 //! the GitHub release resolved to one (releases tagged at a branch have no sha
-//! and leave it unset). Both are optional and back-compat: legacy files
-//! lacking them still parse.
+//! and leave it unset). Both are optional and back-compat.
+//!
+//! ## 1.0 → 2.0 migration
+//!
+//! A 1.0 entry's flat `artifact_sha256` was the installed BINARY hash on the
+//! generating machine, NOT a tarball sha — so it cannot be reused as a 2.0
+//! `archive_sha256`. A 1.0 entry therefore migrates to a 2.0 entry with an
+//! EMPTY `targets` map: it parses (no hard-fail), but carries no usable
+//! integrity claim until it is re-`install`ed. Consumers treat such an entry
+//! as "no recorded target" and `--locked` reports it as a missing target with
+//! an actionable reinstall hint. On the next write the entry serializes as
+//! 2.0.
 //!
 //! Resolution order (`PluginLockfile::default_path`):
 //! 1. Project-local `<project_root>/.animus/plugins.lock` when `project_root`
 //!    is supplied AND the file exists OR the parent `.animus/` exists.
 //! 2. Global `~/.animus/plugins.lock` fallback.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -55,11 +90,38 @@ use sha2::{Digest, Sha256};
 
 /// Current lockfile schema version. Bump when the on-disk shape changes in
 /// a non-backward-compatible way.
-pub const LOCKFILE_SCHEMA_VERSION: &str = "1.0";
+pub const LOCKFILE_SCHEMA_VERSION: &str = "2.0";
 
-/// One install entry inside the lockfile. The tuple
-/// `(name, version, artifact_sha256)` is the integrity claim the install
-/// pipeline checks on every subsequent upgrade.
+/// Per-target integrity claim for a single platform of a lock entry, keyed in
+/// [`LockEntry::targets`] by target triple (e.g. `x86_64-unknown-linux-gnu`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TargetIntegrity {
+    /// Lowercase hex sha256 of the release TARBALL for this target
+    /// (`<plugin>-<target>.tar.gz`) — exactly what the release
+    /// `SHA256SUMS.txt` lists. This is the PORTABLE claim: it can be verified
+    /// on any machine before extracting, so a lock generated on one platform
+    /// drives a verified `--locked` install on another. For `--path`/`--url`
+    /// sources (no tarball / no SHA256SUMS) this is the sha of the fetched
+    /// artifact itself; such entries carry only the install platform's target.
+    pub archive_sha256: String,
+    /// Lowercase hex sha256 of the cosign signature bundle published alongside
+    /// this target's tarball, if any. `None` when no bundle was present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_bundle_sha256: Option<String>,
+    /// Lowercase hex sha256 of the EXTRACTED binary as installed on disk.
+    /// SECONDARY + host-only: only meaningful for the platform that performed
+    /// the install, so it is populated solely for the current target and used
+    /// only for fast on-disk tamper detection (`plugin lock verify`, daemon
+    /// lock-drift probe). Cross-platform verification uses
+    /// [`Self::archive_sha256`]. `None` for targets recorded from a foreign
+    /// platform's SHA256SUMS (where no binary was extracted locally).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installed_binary_sha256: Option<String>,
+}
+
+/// One install entry inside the lockfile. `(name, version, targets)` is the
+/// integrity claim the install pipeline checks on every subsequent upgrade and
+/// reproduces under `--locked`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LockEntry {
     /// Canonical install identifier — typically `owner/repo` for release-source
@@ -71,13 +133,14 @@ pub struct LockEntry {
     /// sources without a tag is allowed but discouraged.
     #[serde(default)]
     pub version: String,
-    /// Lowercase hex sha256 of the installed binary (the on-disk artifact).
-    pub artifact_sha256: String,
-    /// Lowercase hex sha256 of the cosign signature bundle that accompanied
-    /// this install, if any. `None` when the install proceeded under
-    /// `warn`/`disabled` without a bundle present.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub signature_bundle_sha256: Option<String>,
+    /// Per-target integrity claims, keyed by target triple. Populated for
+    /// EVERY published platform on a release install (from `SHA256SUMS.txt`),
+    /// or only the install platform's target for `--path`/`--url` sources. An
+    /// EMPTY map marks an entry migrated from a 1.0 lockfile (whose flat
+    /// binary hash is unusable as a tarball sha): such an entry needs a
+    /// re-`install` to gain a usable claim.
+    #[serde(default)]
+    pub targets: BTreeMap<String, TargetIntegrity>,
     /// RFC 3339 timestamp captured at install time.
     pub installed_at: String,
     /// User-facing kind assigned at install time. For subject_backend
@@ -110,6 +173,20 @@ pub struct LockEntry {
     /// `None`. `None` for non-release installs and pre-source-provenance rows.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_commit: Option<String>,
+    /// Legacy 1.0 flat binary hash, captured only to detect a 1.0 row on read.
+    /// Never re-serialized (2.0 writes `targets` instead). A 1.0 row's
+    /// `artifact_sha256` was the install machine's BINARY hash, which is not a
+    /// tarball sha and cannot seed a portable `targets` claim, so it is read
+    /// then dropped — the migrated entry has an empty `targets` map until a
+    /// re-`install`. See module docs. Always `None` for in-memory-constructed
+    /// entries; consumers should never set it.
+    #[serde(default, skip_serializing, rename = "artifact_sha256")]
+    pub legacy_artifact_sha256: Option<String>,
+    /// Legacy 1.0 flat signature-bundle hash; captured only for read-back
+    /// (never re-serialized). Dropped on migration for the same reason as
+    /// [`Self::legacy_artifact_sha256`].
+    #[serde(default, skip_serializing, rename = "signature_bundle_sha256")]
+    pub legacy_signature_bundle_sha256: Option<String>,
 }
 
 impl LockEntry {
@@ -123,6 +200,23 @@ impl LockEntry {
     /// for pre-v0.5.7 entries where the rename surface did not yet exist.
     pub fn effective_native_kind(&self) -> Option<&str> {
         self.native_kind.as_deref().or(self.installed_kind.as_deref())
+    }
+
+    /// The integrity claim for `target` (target triple), if recorded.
+    pub fn target(&self, target: &str) -> Option<&TargetIntegrity> {
+        self.targets.get(target)
+    }
+
+    /// `true` when this entry carries no usable integrity claim — i.e. it was
+    /// migrated from a 1.0 lockfile and needs a re-`install` before
+    /// `--locked` / `lock verify` can validate it.
+    pub fn is_legacy_unverifiable(&self) -> bool {
+        self.targets.is_empty()
+    }
+
+    /// Sorted list of target triples this entry has a recorded claim for.
+    pub fn target_triples(&self) -> Vec<&str> {
+        self.targets.keys().map(String::as_str).collect()
     }
 }
 
@@ -163,11 +257,60 @@ pub enum LockVerifyResult {
     /// No entry for this name in the lockfile. Caller decides whether that's
     /// fine (fresh install) or an error (upgrade without prior install).
     Missing,
+    /// An entry exists but has no recorded integrity claim for the requested
+    /// target triple. Distinct from [`Self::Missing`]: the plugin IS pinned,
+    /// but the lock was generated without this platform (or migrated from a
+    /// 1.0 lockfile). `--locked` must hard-fail with a "regenerate / reinstall
+    /// on this platform" hint rather than verify against the wrong hash.
+    MissingTarget { target: String },
     /// The stored hash matches the supplied artifact.
     Match,
     /// The stored hash disagrees with the supplied artifact. The caller MUST
     /// refuse the upgrade unless `--force` was passed.
     Mismatch { expected: String, actual: String },
+}
+
+/// The Rust target triple this binary was built for, used to key per-target
+/// integrity claims. Built from `cfg!` so it matches the published asset
+/// naming (`<plugin>-<triple>.tar.gz`). Returns `None` on a target with no
+/// known triple mapping (mirrors the empty asset-selector case in the CLI).
+///
+// TODO(codex-p2): keyed on `target_os`/`target_arch` only, so a `*-linux-musl`
+// build reports the `-gnu` triple (and a Windows `-gnu` build reports `-msvc`).
+// Animus releases are gnu/msvc, so this is correct for them; a musl-built CLI
+// would record/look up the wrong target. Distinguishing needs a `target_env`
+// cfg arm; deferred until a musl build target is actually shipped.
+pub fn current_target_triple() -> Option<&'static str> {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        Some("aarch64-apple-darwin")
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        Some("x86_64-apple-darwin")
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        Some("x86_64-unknown-linux-gnu")
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        Some("aarch64-unknown-linux-gnu")
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        Some("x86_64-pc-windows-msvc")
+    }
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+    )))]
+    {
+        None
+    }
 }
 
 impl PluginLockfile {
@@ -203,13 +346,34 @@ impl PluginLockfile {
         let raw = fs::read_to_string(path).with_context(|| format!("failed to read lockfile {}", path.display()))?;
         let mut parsed: Self =
             toml::from_str(&raw).with_context(|| format!("failed to parse lockfile {}", path.display()))?;
-        if !schema_compatible(&parsed.schema_version) {
+        if !schema_readable(&parsed.schema_version) {
             anyhow::bail!(
-                "lockfile {} has incompatible schema_version '{}' (this build supports '{}')",
+                "lockfile {} has incompatible schema_version '{}' (this build reads 1.x and {})",
                 path.display(),
                 parsed.schema_version,
                 LOCKFILE_SCHEMA_VERSION
             );
+        }
+        // 1.0 → 2.0 migration: a 1.0 row's flat `artifact_sha256` was the
+        // install machine's BINARY hash (not a tarball sha), so it cannot seed
+        // a portable `targets` claim. Drop the legacy fields and leave
+        // `targets` empty — the entry parses but is `is_legacy_unverifiable()`
+        // until a re-`install`. The next write emits 2.0.
+        if major_of(&parsed.schema_version) == "1" {
+            let migrated_legacy = parsed.plugins.iter().filter(|e| e.legacy_artifact_sha256.is_some()).count();
+            if migrated_legacy > 0 {
+                tracing::warn!(
+                    path = %path.display(),
+                    count = migrated_legacy,
+                    "migrating 1.0 plugin lockfile to 2.0: legacy entries carry no portable (per-target) integrity claim \
+                     and must be reinstalled before `--locked` / `lock verify` can validate them"
+                );
+            }
+            for entry in &mut parsed.plugins {
+                entry.legacy_artifact_sha256 = None;
+                entry.legacy_signature_bundle_sha256 = None;
+            }
+            parsed.schema_version = LOCKFILE_SCHEMA_VERSION.to_string();
         }
         parsed.path = path.to_path_buf();
         Ok(parsed)
@@ -263,23 +427,68 @@ impl PluginLockfile {
         Some(self.plugins.remove(idx))
     }
 
-    /// Re-check whether the supplied `artifact_sha256` matches the recorded
-    /// hash for `name`. Returns [`LockVerifyResult::Missing`] when no entry
-    /// is present.
-    pub fn verify_entry(&self, name: &str, artifact_sha256: &str) -> LockVerifyResult {
+    /// Verify the supplied EXTRACTED-BINARY sha256 for `name` against the
+    /// recorded `installed_binary_sha256` for the current build target.
+    ///
+    /// Returns [`LockVerifyResult::Missing`] when no entry exists,
+    /// [`LockVerifyResult::MissingTarget`] when the entry has no claim for the
+    /// current target OR the current target's claim records no installed-binary
+    /// hash (e.g. the target was populated from a foreign platform's
+    /// SHA256SUMS, or the entry was migrated from a 1.0 lockfile). This is the
+    /// HOST-ONLY tamper check used by `plugin lock verify` and the daemon
+    /// drift probe; cross-platform reproducibility uses
+    /// [`Self::verify_archive`].
+    pub fn verify_entry(&self, name: &str, installed_binary_sha256: &str) -> LockVerifyResult {
+        let Some(triple) = current_target_triple() else {
+            return LockVerifyResult::MissingTarget { target: "<unknown>".to_string() };
+        };
+        self.verify_entry_for_target(name, triple, installed_binary_sha256)
+    }
+
+    /// Target-explicit form of [`Self::verify_entry`] — verifies the supplied
+    /// extracted-binary sha against `targets[target].installed_binary_sha256`.
+    pub fn verify_entry_for_target(&self, name: &str, target: &str, installed_binary_sha256: &str) -> LockVerifyResult {
         let Some(entry) = self.find(name) else {
             return LockVerifyResult::Missing;
         };
-        if entry.artifact_sha256.eq_ignore_ascii_case(artifact_sha256) {
+        let Some(integrity) = entry.target(target) else {
+            return LockVerifyResult::MissingTarget { target: target.to_string() };
+        };
+        let Some(expected) = integrity.installed_binary_sha256.as_deref() else {
+            return LockVerifyResult::MissingTarget { target: target.to_string() };
+        };
+        if expected.eq_ignore_ascii_case(installed_binary_sha256) {
             LockVerifyResult::Match
         } else {
-            LockVerifyResult::Mismatch { expected: entry.artifact_sha256.clone(), actual: artifact_sha256.to_string() }
+            LockVerifyResult::Mismatch { expected: expected.to_string(), actual: installed_binary_sha256.to_string() }
         }
     }
 
-    /// Hash the file at `path` against the entry recorded for `name`.
-    /// Combines [`sha256_of_file`] + [`Self::verify_entry`] into one call so
-    /// CLI subcommands can implement `plugin lock verify` directly.
+    /// Verify a downloaded release TARBALL's sha256 for `name` against the
+    /// recorded `archive_sha256` for `target`. This is the PORTABLE,
+    /// cross-platform claim `animus plugin install --locked` checks before
+    /// extracting/executing anything.
+    pub fn verify_archive(&self, name: &str, target: &str, archive_sha256: &str) -> LockVerifyResult {
+        let Some(entry) = self.find(name) else {
+            return LockVerifyResult::Missing;
+        };
+        let Some(integrity) = entry.target(target) else {
+            return LockVerifyResult::MissingTarget { target: target.to_string() };
+        };
+        if integrity.archive_sha256.eq_ignore_ascii_case(archive_sha256) {
+            LockVerifyResult::Match
+        } else {
+            LockVerifyResult::Mismatch {
+                expected: integrity.archive_sha256.clone(),
+                actual: archive_sha256.to_string(),
+            }
+        }
+    }
+
+    /// Hash the file at `path` against the installed-binary claim recorded for
+    /// `name` on the current target. Combines [`sha256_of_file`] +
+    /// [`Self::verify_entry`] into one call so CLI subcommands can implement
+    /// `plugin lock verify` directly.
     pub fn verify_installed(&self, name: &str, installed_path: &Path) -> Result<LockVerifyResult> {
         let actual = sha256_of_file(installed_path)?;
         Ok(self.verify_entry(name, &actual))
@@ -357,9 +566,17 @@ fn acquire_save_lock(path: &Path) -> Result<fs::File> {
     Ok(file)
 }
 
-fn schema_compatible(version: &str) -> bool {
-    let major = |s: &str| s.split('.').next().unwrap_or("").to_string();
-    major(version) == major(LOCKFILE_SCHEMA_VERSION)
+fn major_of(version: &str) -> &str {
+    version.split('.').next().unwrap_or("")
+}
+
+/// A lockfile is readable when its major version is the current one (2) — the
+/// native shape — OR `1` (the legacy shape, migrated in-memory on load). A
+/// future major (3+) is refused so a newer file is not silently truncated by
+/// this writer.
+fn schema_readable(version: &str) -> bool {
+    let major = major_of(version);
+    major == major_of(LOCKFILE_SCHEMA_VERSION) || major == "1"
 }
 
 /// Returns the project-local lockfile path
@@ -397,6 +614,36 @@ mod tests {
         Utc::now().to_rfc3339()
     }
 
+    /// Build a 2.0 entry with a single target claim for the CURRENT build
+    /// target whose `archive_sha256` and `installed_binary_sha256` are both the
+    /// repeated `sha_char`. Mirrors how an install on this platform records its
+    /// own target.
+    fn entry_with_local_target(name: &str, version: &str, sha_char: char) -> LockEntry {
+        let triple = current_target_triple().expect("test target has a known triple");
+        let sha = sha_char.to_string().repeat(64);
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            triple.to_string(),
+            TargetIntegrity {
+                archive_sha256: sha.clone(),
+                signature_bundle_sha256: None,
+                installed_binary_sha256: Some(sha),
+            },
+        );
+        LockEntry {
+            name: name.to_string(),
+            version: version.to_string(),
+            targets,
+            installed_at: now_str(),
+            installed_kind: None,
+            native_kind: None,
+            source_repo: None,
+            resolved_commit: None,
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
+        }
+    }
+
     #[test]
     fn load_or_empty_returns_empty_when_missing() {
         let dir = tempdir().unwrap();
@@ -408,20 +655,38 @@ mod tests {
     }
 
     #[test]
-    fn upsert_then_save_then_reload_roundtrips() {
+    fn upsert_then_save_then_reload_roundtrips_targets() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&path);
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            "x86_64-unknown-linux-gnu".to_string(),
+            TargetIntegrity {
+                archive_sha256: "a".repeat(64),
+                signature_bundle_sha256: Some("b".repeat(64)),
+                installed_binary_sha256: None,
+            },
+        );
+        targets.insert(
+            "aarch64-apple-darwin".to_string(),
+            TargetIntegrity {
+                archive_sha256: "c".repeat(64),
+                signature_bundle_sha256: None,
+                installed_binary_sha256: Some("d".repeat(64)),
+            },
+        );
         lock.upsert(LockEntry {
             name: "launchapp-dev/animus-provider-claude".to_string(),
             version: "v0.2.2".to_string(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: Some("b".repeat(64)),
+            targets,
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
             source_repo: None,
             resolved_commit: None,
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
         });
         lock.save().unwrap();
 
@@ -430,8 +695,13 @@ mod tests {
         let entry = &reloaded.plugins[0];
         assert_eq!(entry.name, "launchapp-dev/animus-provider-claude");
         assert_eq!(entry.version, "v0.2.2");
-        assert_eq!(entry.artifact_sha256, "a".repeat(64));
-        assert_eq!(entry.signature_bundle_sha256.as_deref(), Some("b".repeat(64).as_str()));
+        assert_eq!(entry.target_triples(), vec!["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]);
+        let linux = entry.target("x86_64-unknown-linux-gnu").unwrap();
+        assert_eq!(linux.archive_sha256, "a".repeat(64));
+        assert_eq!(linux.signature_bundle_sha256.as_deref(), Some("b".repeat(64).as_str()));
+        let mac = entry.target("aarch64-apple-darwin").unwrap();
+        assert_eq!(mac.archive_sha256, "c".repeat(64));
+        assert_eq!(mac.installed_binary_sha256.as_deref(), Some("d".repeat(64).as_str()));
     }
 
     #[test]
@@ -439,60 +709,56 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&path);
-        lock.upsert(LockEntry {
-            name: "x".into(),
-            version: "v1".into(),
-            artifact_sha256: "1".repeat(64),
-            signature_bundle_sha256: None,
-            installed_at: now_str(),
-            installed_kind: None,
-            native_kind: None,
-            source_repo: None,
-            resolved_commit: None,
-        });
-        let prior = lock.upsert(LockEntry {
-            name: "x".into(),
-            version: "v2".into(),
-            artifact_sha256: "2".repeat(64),
-            signature_bundle_sha256: None,
-            installed_at: now_str(),
-            installed_kind: None,
-            native_kind: None,
-            source_repo: None,
-            resolved_commit: None,
-        });
+        lock.upsert(entry_with_local_target("x", "v1", '1'));
+        let prior = lock.upsert(entry_with_local_target("x", "v2", '2'));
         assert!(prior.is_some());
         assert_eq!(lock.plugins.len(), 1);
         assert_eq!(lock.plugins[0].version, "v2");
     }
 
     #[test]
-    fn verify_entry_reports_match_missing_and_mismatch() {
+    fn verify_archive_reports_match_missing_mismatch_and_missing_target() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&path);
         let sha = "f".repeat(64);
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            "x86_64-unknown-linux-gnu".to_string(),
+            TargetIntegrity {
+                archive_sha256: sha.clone(),
+                signature_bundle_sha256: None,
+                installed_binary_sha256: None,
+            },
+        );
         lock.upsert(LockEntry {
             name: "x".into(),
             version: "v1".into(),
-            artifact_sha256: sha.clone(),
-            signature_bundle_sha256: None,
+            targets,
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
             source_repo: None,
             resolved_commit: None,
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
         });
-        assert_eq!(lock.verify_entry("x", &sha), LockVerifyResult::Match);
-        assert_eq!(lock.verify_entry("x", &sha.to_ascii_uppercase()), LockVerifyResult::Match);
-        match lock.verify_entry("x", &"0".repeat(64)) {
+        let tgt = "x86_64-unknown-linux-gnu";
+        assert_eq!(lock.verify_archive("x", tgt, &sha), LockVerifyResult::Match);
+        assert_eq!(lock.verify_archive("x", tgt, &sha.to_ascii_uppercase()), LockVerifyResult::Match);
+        match lock.verify_archive("x", tgt, &"0".repeat(64)) {
             LockVerifyResult::Mismatch { expected, actual } => {
                 assert_eq!(expected, sha);
                 assert_eq!(actual, "0".repeat(64));
             }
             other => panic!("expected Mismatch, got {other:?}"),
         }
-        assert_eq!(lock.verify_entry("missing", &sha), LockVerifyResult::Missing);
+        // Entry exists but no claim for a foreign target → MissingTarget.
+        match lock.verify_archive("x", "aarch64-apple-darwin", &sha) {
+            LockVerifyResult::MissingTarget { target } => assert_eq!(target, "aarch64-apple-darwin"),
+            other => panic!("expected MissingTarget, got {other:?}"),
+        }
+        assert_eq!(lock.verify_archive("missing", tgt, &sha), LockVerifyResult::Missing);
     }
 
     #[test]
@@ -501,22 +767,33 @@ mod tests {
         let bin_path = dir.path().join("plugin-bin");
         fs::write(&bin_path, b"original-binary-content").unwrap();
         let original_sha = sha256_of_file(&bin_path).unwrap();
+        let triple = current_target_triple().expect("test target has a known triple");
 
         let lock_path = dir.path().join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&lock_path);
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            triple.to_string(),
+            TargetIntegrity {
+                archive_sha256: "a".repeat(64),
+                signature_bundle_sha256: None,
+                installed_binary_sha256: Some(original_sha.clone()),
+            },
+        );
         lock.upsert(LockEntry {
             name: "myplugin".into(),
             version: "v1".into(),
-            artifact_sha256: original_sha.clone(),
-            signature_bundle_sha256: None,
+            targets,
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
             source_repo: None,
             resolved_commit: None,
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
         });
 
-        // No tamper — should match.
+        // No tamper — should match the recorded installed-binary hash.
         assert_eq!(lock.verify_installed("myplugin", &bin_path).unwrap(), LockVerifyResult::Match);
 
         // Mutate the binary on disk and re-check.
@@ -531,21 +808,47 @@ mod tests {
     }
 
     #[test]
-    fn remove_returns_entry_and_drops_it() {
+    fn verify_entry_missing_target_when_no_installed_binary_hash() {
+        // A target populated from a foreign platform's SHA256SUMS has an
+        // archive sha but no installed_binary_sha256 — the host-only
+        // verify_entry must report MissingTarget, not match against nothing.
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
+        let triple = current_target_triple().expect("known triple");
         let mut lock = PluginLockfile::empty_at(&path);
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            triple.to_string(),
+            TargetIntegrity {
+                archive_sha256: "a".repeat(64),
+                signature_bundle_sha256: None,
+                installed_binary_sha256: None,
+            },
+        );
         lock.upsert(LockEntry {
-            name: "drop-me".into(),
-            version: String::new(),
-            artifact_sha256: "9".repeat(64),
-            signature_bundle_sha256: None,
+            name: "x".into(),
+            version: "v1".into(),
+            targets,
             installed_at: now_str(),
             installed_kind: None,
             native_kind: None,
             source_repo: None,
             resolved_commit: None,
+            legacy_artifact_sha256: None,
+            legacy_signature_bundle_sha256: None,
         });
+        match lock.verify_entry("x", &"a".repeat(64)) {
+            LockVerifyResult::MissingTarget { target } => assert_eq!(target, triple),
+            other => panic!("expected MissingTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remove_returns_entry_and_drops_it() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("plugins.lock");
+        let mut lock = PluginLockfile::empty_at(&path);
+        lock.upsert(entry_with_local_target("drop-me", "", '9'));
         let removed = lock.remove("drop-me").expect("expected entry");
         assert_eq!(removed.name, "drop-me");
         assert!(lock.find("drop-me").is_none());
@@ -553,17 +856,7 @@ mod tests {
     }
 
     fn entry(name: &str, sha_char: char) -> LockEntry {
-        LockEntry {
-            name: name.to_string(),
-            version: "v1".to_string(),
-            artifact_sha256: sha_char.to_string().repeat(64),
-            signature_bundle_sha256: None,
-            installed_at: now_str(),
-            installed_kind: None,
-            native_kind: None,
-            source_repo: None,
-            resolved_commit: None,
-        }
+        entry_with_local_target(name, "v1", sha_char)
     }
 
     /// Two concurrent read-modify-write cycles (two `animus plugin install`
@@ -627,7 +920,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_mismatch_is_rejected() {
+    fn future_major_schema_is_rejected() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
         fs::write(&path, "schema_version = \"99.0\"\ngenerated_at = \"2026-05-26T00:00:00Z\"\nplugins = []\n").unwrap();
@@ -652,36 +945,14 @@ mod tests {
     }
 
     #[test]
-    fn legacy_lockfile_without_kind_fields_parses_with_defaults() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("plugins.lock");
-        let legacy = "schema_version = \"1.0\"\ngenerated_at = \"2026-05-26T00:00:00Z\"\n\n[[plugins]]\nname = \"launchapp-dev/animus-subject-default\"\nversion = \"v0.1.1\"\nartifact_sha256 = \"a\"\ninstalled_at = \"2026-05-26T00:00:00Z\"\n";
-        fs::write(&path, legacy).unwrap();
-        let lock = PluginLockfile::load_or_empty(&path).expect("legacy lockfile parses");
-        assert_eq!(lock.plugins.len(), 1);
-        let entry = &lock.plugins[0];
-        assert_eq!(entry.installed_kind, None);
-        assert_eq!(entry.native_kind, None);
-        assert_eq!(entry.effective_installed_kind(), None);
-        assert_eq!(entry.effective_native_kind(), None);
-    }
-
-    #[test]
     fn lockfile_roundtrips_installed_and_native_kind() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&path);
-        lock.upsert(LockEntry {
-            name: "launchapp-dev/animus-subject-default-archive".to_string(),
-            version: "v0.1.0".to_string(),
-            artifact_sha256: "c".repeat(64),
-            signature_bundle_sha256: None,
-            installed_at: now_str(),
-            installed_kind: Some("archive".to_string()),
-            native_kind: Some("task".to_string()),
-            source_repo: None,
-            resolved_commit: None,
-        });
+        let mut e = entry_with_local_target("launchapp-dev/animus-subject-default-archive", "v0.1.0", 'c');
+        e.installed_kind = Some("archive".to_string());
+        e.native_kind = Some("task".to_string());
+        lock.upsert(e);
         lock.save().unwrap();
         let reloaded = PluginLockfile::load_or_empty(&path).unwrap();
         let entry = &reloaded.plugins[0];
@@ -696,17 +967,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
         let mut lock = PluginLockfile::empty_at(&path);
-        lock.upsert(LockEntry {
-            name: "launchapp-dev/animus-provider-claude".to_string(),
-            version: "v0.2.2".to_string(),
-            artifact_sha256: "a".repeat(64),
-            signature_bundle_sha256: None,
-            installed_at: now_str(),
-            installed_kind: None,
-            native_kind: None,
-            source_repo: Some("launchapp-dev/animus-provider-claude".to_string()),
-            resolved_commit: Some("9".repeat(40)),
-        });
+        let mut e = entry_with_local_target("launchapp-dev/animus-provider-claude", "v0.2.2", 'a');
+        e.source_repo = Some("launchapp-dev/animus-provider-claude".to_string());
+        e.resolved_commit = Some("9".repeat(40));
+        lock.upsert(e);
         lock.save().unwrap();
         let reloaded = PluginLockfile::load_or_empty(&path).unwrap();
         let entry = &reloaded.plugins[0];
@@ -714,15 +978,31 @@ mod tests {
         assert_eq!(entry.resolved_commit.as_deref(), Some("9".repeat(40).as_str()));
     }
 
+    /// A 1.0 lockfile (flat `artifact_sha256`) must NOT hard-fail. It migrates
+    /// to a 2.0 entry with an EMPTY `targets` map (the legacy binary hash is
+    /// not a tarball sha) and is flagged `is_legacy_unverifiable()`. The next
+    /// write emits 2.0.
     #[test]
-    fn legacy_lockfile_without_source_fields_parses_with_defaults() {
+    fn legacy_1_0_lockfile_migrates_to_empty_targets() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("plugins.lock");
-        let legacy = "schema_version = \"1.0\"\ngenerated_at = \"2026-05-26T00:00:00Z\"\n\n[[plugins]]\nname = \"launchapp-dev/animus-subject-default\"\nversion = \"v0.1.1\"\nartifact_sha256 = \"a\"\ninstalled_at = \"2026-05-26T00:00:00Z\"\n";
+        let legacy = "schema_version = \"1.0\"\ngenerated_at = \"2026-05-26T00:00:00Z\"\n\n[[plugins]]\nname = \"launchapp-dev/animus-subject-default\"\nversion = \"v0.1.1\"\nartifact_sha256 = \"abc123\"\nsignature_bundle_sha256 = \"def456\"\ninstalled_at = \"2026-05-26T00:00:00Z\"\nsource_repo = \"launchapp-dev/animus-subject-default\"\n";
         fs::write(&path, legacy).unwrap();
-        let lock = PluginLockfile::load_or_empty(&path).expect("legacy lockfile parses");
+        let mut lock = PluginLockfile::load_or_empty(&path).expect("legacy 1.0 lockfile parses");
+        assert_eq!(lock.schema_version, LOCKFILE_SCHEMA_VERSION, "migrated in-memory to 2.0");
+        assert_eq!(lock.plugins.len(), 1);
         let entry = &lock.plugins[0];
-        assert_eq!(entry.source_repo, None);
-        assert_eq!(entry.resolved_commit, None);
+        assert!(entry.targets.is_empty(), "legacy binary hash is not reusable as a tarball sha");
+        assert!(entry.is_legacy_unverifiable());
+        // Source provenance survives the migration (still needed to reinstall).
+        assert_eq!(entry.source_repo.as_deref(), Some("launchapp-dev/animus-subject-default"));
+        assert_eq!(entry.installed_kind, None);
+        assert_eq!(entry.native_kind, None);
+
+        // Next write emits 2.0 with no legacy fields.
+        lock.save().unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("schema_version = \"2.0\""));
+        assert!(!raw.contains("artifact_sha256"), "2.0 write drops the flat legacy field: {raw}");
     }
 }

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1050,7 +1050,7 @@ animus plugin install --locked
 | `--yes` | Auto-confirm the trust-on-first-use prompt for unknown orgs |
 | `--force-rewrite-lockfile` | Discard an unparseable / schema-incompatible `.animus/plugins.lock` (or `~/.animus/plugins.lock`) and rebuild a fresh lockfile starting from this install. Without this flag, an unreadable lockfile fails the install **closed** with an actionable error pointing at the corrupt path. **Security warning**: rewriting drops the recorded sha256 integrity history, so subsequent `--force` installs cannot detect pre-existing tamper. See [Security › Lockfile fail-closed policy](../security.md#lockfile-fail-closed-policy) |
 | `--as-kind <KIND>` | (v0.5.7) Override the user-facing `installed_kind` recorded in `plugins.lock` for a `subject_backend` plugin. The supplied `KIND` becomes the prefix the SubjectRouter dispatches against (e.g. `archive` for a second `subject_kind:task` backend). When omitted and the manifest-declared native kind collides with an existing install, the install pipeline auto-increments (`task` → `task-2` → `task-3`) and prints the assignment via the `animus.plugin.install.v1` envelope. When `--as-kind` is supplied and the explicit value also collides, the install fails with an actionable error. Only `subject_backend` plugins are eligible in v0.5.7; passing `--as-kind` on a provider, transport, workflow_runner, queue, or trigger plugin is rejected. See [Plugin kind translator (v0.5.7)](../../architecture/plugin-kind-translator-v0.5.7.md) |
-| `--locked` | Reproducible install: ignore any positional source and reinstall **exactly** the set pinned in `.animus/plugins.lock`. Each locked entry is resolved from its recorded `source_repo` + tag (release slug), `--url`, or `path:` source, reinstalled, then the freshly installed artifact's sha256 is verified against the lockfile pin. Fails the whole run if the lockfile is missing/empty, an entry has no recorded source (installed before source provenance was tracked — reinstall it once to record it), or any installed artifact hash drifts from the pin (the published release changed under the pin). The fresh-machine / CI path. Mutually exclusive with a positional source, `--path`, `--url`, `--tag`, and `--latest` |
+| `--locked` | Reproducible, **cross-platform** install: ignore any positional source and reinstall **exactly** the set pinned in `.animus/plugins.lock`. For each entry it resolves the recorded `source_repo` + tag (release slug), `--url`, or `path:` source, downloads the **current platform's** tarball, and verifies it against `targets[<current-triple>].archive_sha256` **before** extracting/executing (this is what lets a lock generated on macOS reproduce verified on a Linux container). Fails the whole run if the lockfile is missing/empty, an entry has no recorded source, or — for the current platform — has no recorded archive sha (a 1.0-migrated entry, or a lock generated without this platform: regenerate the lock here, or `plugin install` once on this platform), or any downloaded tarball drifts from the pin. The fresh-machine / CI path. Mutually exclusive with a positional source, `--path`, `--url`, `--tag`, and `--latest` |
 
 #### Signature verification (v0.4.x+)
 
@@ -1387,20 +1387,45 @@ Stale-entry warnings in `animus plugin list`, `animus plugin outdated`, and
 ### `animus plugin lock`
 
 `.animus/plugins.lock` **is** the Animus plugin lockfile. It is a TOML file
-(`schema_version = "1.0"`, tool-managed — do **not** hand-edit) recording one
+(`schema_version = "2.0"`, tool-managed — do **not** hand-edit) recording one
 entry per installed plugin: `name`, `version` (the resolved release tag),
-`artifact_sha256`, `signature_bundle_sha256`, `installed_at`,
-`installed_kind` / `native_kind` (v0.5.7 kind translator), and the
+`installed_at`, `installed_kind` / `native_kind` (v0.5.7 kind translator), the
 source-provenance fields `source_repo` (the `owner/repo` slug, `--url`, or
 `path:<...>` the plugin was installed from) and `resolved_commit` (the exact
 40-hex commit sha when a release resolved to one — releases tagged at a branch
-leave it unset). The lockfile is the integrity + reproducibility anchor: the
-install pipeline writes it on success and uninstall removes the entry.
-`.gitignore` keeps the installed **binaries** out of version control, but the
-lockfile itself is meant to be committed so the pinned set travels with the
-repo and `animus plugin install --locked` can reproduce it on a fresh machine.
-Project-local installs use `.animus/plugins.lock`; otherwise commands fall back
-to `~/.animus/plugins.lock`.
+leave it unset), and a **per-target** `targets` map.
+
+**Platform-aware integrity (v2.0).** Each entry's integrity claim is keyed by
+target triple under `[plugins.targets.<triple>]`, with `archive_sha256` (the
+sha256 of the release **tarball** for that platform, exactly what a GitHub
+release's `SHA256SUMS.txt` lists), an optional `signature_bundle_sha256`, and
+an optional host-only `installed_binary_sha256` (the extracted-binary sha,
+recorded only for the platform that performed the install — used for fast
+on-disk tamper detection). A release install fetches `SHA256SUMS.txt` and
+records the tarball sha for **every published platform**, so a lock generated
+on macOS carries the Linux (and every other platform's) tarball sha too. That
+is what makes the committed lock portable: `animus plugin install --locked` can
+download the current platform's tarball and verify it against
+`targets[<current-triple>].archive_sha256` **before** extracting/executing, on
+a platform different from the one that generated the lock. `--path` / `--url`
+sources have no `SHA256SUMS.txt`, so they record only the install platform's
+target (non-portable by nature).
+
+**1.0 → 2.0 migration.** A 1.0 lockfile's flat `artifact_sha256` was the
+install machine's binary hash, not a tarball sha, so it cannot be reused as a
+2.0 `archive_sha256`. Reading a 1.0 file does **not** fail: each entry migrates
+to a 2.0 entry with an **empty** `targets` map and must be re-`install`ed once
+on the current platform to gain a usable claim (`lock verify` reports it as
+`missing_target` and `--locked` fails it with a reinstall hint). The next write
+emits 2.0.
+
+The lockfile is the integrity + reproducibility anchor: the install pipeline
+writes it on success and uninstall removes the entry. `.gitignore` keeps the
+installed **binaries** out of version control, but the lockfile itself is meant
+to be committed so the pinned set travels with the repo and `animus plugin
+install --locked` can reproduce it on a fresh machine — or a different
+platform. Project-local installs use `.animus/plugins.lock`; otherwise commands
+fall back to `~/.animus/plugins.lock`.
 
 | Command | Flags |
 |---|---|
@@ -1414,9 +1439,15 @@ dir) and the project `<project>/.animus/plugins.lock` (entries hashed against
 entries recorded by pre-`--project` installs). Each result entry carries a
 `scope` (`global` / `project` / `explicit`, plus `discovered` for extras) and
 the lockfile path it came from; the envelope's `lockfiles` array lists every
-root swept. The verify reports drift in both directions: `mismatch` (sha256
-disagrees with the pin), `missing_binary` (a locked entry's binary is gone),
-and `extra` (a discovered installed plugin absent from every lockfile). Passing
+root swept and its top-level `target` names the current build triple every
+entry was checked against. The verify is **target-aware**: each entry is
+compared against its host-only `installed_binary_sha256` for the current
+target. It reports drift in several directions: `mismatch` (sha256 disagrees
+with the pin), `missing_binary` (a locked entry's binary is gone),
+`missing_target` (the entry has no integrity claim for this platform — a
+1.0-migrated entry, or a lock generated on another platform; reinstall here to
+record it), and `extra` (a discovered installed plugin absent from every
+lockfile). Passing
 `--lockfile <PATH>` restricts the sweep to that single file (legacy
 behavior). Any mismatch, missing binary, **or** extra in either root exits
 non-zero, so the command works as a CI drift gate. Plugin lockfile drift is


### PR DESCRIPTION
Makes `.animus/plugins.lock` platform-aware so a single committed lock generated on any machine drives a verified `--locked` install on a different platform (the macOS-dev → linux-container case).

- `LockEntry.targets: BTreeMap<triple, TargetIntegrity { archive_sha256, signature_bundle_sha256, installed_binary_sha256 }>` (schema 1.0→2.0). `archive_sha256` = the release TARBALL sha (the portable claim, verifiable before extract); `installed_binary_sha256` = host-only, for local tamper checks.
- Install fetches the release `SHA256SUMS.txt` and records the tarball sha for EVERY published platform — one install on macOS records the linux sha too.
- `--locked` downloads the current platform's tarball and verifies it against `targets[current].archive_sha256` before extracting (fails closed with an actionable hint if the target is unrecorded).
- `lock verify` is target-aware (`missing_target` vs `mismatch`); `lock list` shows per-platform coverage; daemon drift probe target-aware. 1.0→2.0 migration parses (empty targets, re-install to upgrade), never crashes.

## Verification (main loop)
- fmt ✅, clippy clean ✅, lockfile tests 15/15 ✅, ops_plugin 228/228 ✅
- Codex self-vet: 5 rounds, P1-clear (round-4 P1 on cross-platform multi-binary secondaries fixed). One deferred P2 (musl triple — TODO; animus ships gnu/msvc).
- Pre-existing `auto_resume` oai-runner failures on clean main (unrelated).

Second of two **v0.6.7** changes (with the already-merged resident config_source). Live cross-platform round-trip against a real release worth confirming before CI relies on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)