### PR TITLE
release: v0.6.7 — platform-aware lock + resident config_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-06-22
+
+**v0.6.7 — platform-aware plugin lock + resident config_source.**
+
+- **Platform-aware `plugins.lock`** (schema 1.0→2.0): each entry records integrity
+  per target triple (`targets: {triple → {archive_sha256, signature_bundle_sha256,
+  installed_binary_sha256}}`). Install fetches each release's `SHA256SUMS.txt` and
+  records the tarball sha for EVERY published platform, so a lock generated on one
+  machine drives a verified `--locked` install on another (macOS → linux container).
+  `--locked` verifies the current platform's tarball before extract; `lock verify`/
+  `list` are target-aware; 1.0 locks migrate to empty targets (re-install to upgrade).
+- **Resident config_source host**: the daemon spawns the `config_source` plugin
+  ONCE and reuses it (process-global cache, re-spawn only on ConnectionLost, reaped
+  at shutdown) instead of forking it per `config/load` (~50-60 forks/min → ~0). A
+  CacheToken short-circuit skips the pack-overlay merge + validate when the source
+  config is unchanged. Eliminates the fork churn amplified by v0.6.5's config/write.
+
 - **Resident config_source host.** The daemon no longer spawns + reaps a fresh
   `config_source` plugin process on every `config/load` / `config/write`
   (~4-5 forks per scheduler-loop pass under v0.6.3's leak fix). It now keeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Cuts v0.6.7. Bumps orchestrator-cli 0.6.6→0.6.7 + CHANGELOG. Ships the platform-aware lockfile (#266) + resident config_source host (#265). Merging fires auto-tag-release → v0.6.7 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)