### PR TITLE
feat(skill): import GitHub-hosted Agent Skills via skill install

### DIFF
--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -62,7 +62,7 @@ webbrowser = "1"
 termimad = "0.34"
 libc = "0.2"
 fs2 = "0.4"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 colored = "3.0"
 tracing = "0.1"
 tempfile = "3"

--- a/crates/orchestrator-cli/src/cli_types/skill_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/skill_types.rs
@@ -101,6 +101,19 @@ pub(crate) struct SkillSearchArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct SkillInstallArgs {
+    #[arg(
+        value_name = "SOURCE",
+        conflicts_with_all = ["path", "name", "github_flag"],
+        help = "GitHub-hosted skill to import and install: OWNER/REPO[@ref], a repo/tree URL, or a raw SKILL.md URL."
+    )]
+    pub(crate) github: Option<String>,
+    #[arg(
+        long = "github",
+        value_name = "SOURCE",
+        conflicts_with_all = ["path", "name"],
+        help = "Same as the positional SOURCE: a GitHub-hosted skill to import and install."
+    )]
+    pub(crate) github_flag: Option<String>,
     #[arg(long, help = "Skill name to resolve and install; optional with --path.")]
     pub(crate) name: Option<String>,
     #[arg(long, help = "Install a local Markdown skill file, skill folder, or directory of skill folders.")]

--- a/crates/orchestrator-cli/src/services/operations/ops_skill.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_skill.rs
@@ -22,6 +22,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+mod github;
 mod model;
 mod resolver;
 mod store;
@@ -35,6 +36,13 @@ use self::store::{
     load_skill_lock_state, load_skill_registry_state, save_skill_lock_state_if_changed,
     save_skill_registry_state_if_changed,
 };
+
+/// Reserved `source` value for skills imported via `animus skill install
+/// <github source>`. Distinct from any user/catalog source named `github` so an
+/// import never collides with a registry-resolved install, and so the
+/// registry-update sweep can recognize and skip imports (they refresh via
+/// re-install, not catalog resolution).
+const GITHUB_IMPORT_SOURCE: &str = "github-import";
 
 fn compare_semver_desc(left: &str, right: &str) -> std::cmp::Ordering {
     match (Version::parse(left), Version::parse(right)) {
@@ -141,6 +149,8 @@ fn upsert_installed(state: &mut SkillRegistryStateV1, selected: &SkillVersionRec
         integrity: selected.integrity.clone(),
         artifact: selected.artifact.clone(),
         definition: selected.definition.clone(),
+        origin: None,
+        format: None,
     };
     state.installed.retain(|item| !(item.name == entry.name && item.source == entry.source));
     state.installed.push(entry);
@@ -489,7 +499,11 @@ fn handle_search(args: SkillSearchArgs, project_root: &str, json: bool) -> Resul
     print_value(combined, json)
 }
 
-fn handle_install(args: SkillInstallArgs, project_root: &str, json: bool) -> Result<()> {
+async fn handle_install(args: SkillInstallArgs, project_root: &str, json: bool) -> Result<()> {
+    if let Some(source) = args.github.as_deref().or(args.github_flag.as_deref()) {
+        return handle_install_github(source, project_root, json).await;
+    }
+
     if let Some(path) = args.path.as_deref() {
         let installed = install_local_markdown_skills(path, args.name.as_deref(), project_root)?;
         return print_value(
@@ -551,6 +565,83 @@ fn handle_install(args: SkillInstallArgs, project_root: &str, json: bool) -> Res
             "registry_changed": registry_changed,
             "lock_changed": lock_changed,
             "skill_file_changed": skill_file_changed,
+        }),
+        json,
+    )
+}
+
+async fn handle_install_github(source: &str, project_root: &str, json: bool) -> Result<()> {
+    use self::github::{discover_and_import, materialize_to_dir, parse_github_skill_source, HttpRepoFetcher};
+
+    let parsed = parse_github_skill_source(source)?;
+    let origin = format!(
+        "{}/{}{}",
+        parsed.owner,
+        parsed.repo,
+        parsed.git_ref.as_deref().map(|r| format!("@{r}")).unwrap_or_default()
+    );
+
+    // Fetch + normalize off the async runtime: the GitHub client is blocking.
+    let parsed_for_fetch = parsed.clone();
+    let discovered = tokio::task::spawn_blocking(move || -> Result<Vec<github::DiscoveredSkill>> {
+        let fetcher = HttpRepoFetcher::new()?;
+        discover_and_import(&parsed_for_fetch, &fetcher)
+    })
+    .await
+    .context("github skill fetch task panicked")??;
+
+    // Stage the normalized skills, then install through the SAME local
+    // path-install pipeline `--path` uses (scoping, materialization identical).
+    let staging = tempfile::tempdir().context("failed to create staging directory")?;
+    materialize_to_dir(&discovered, staging.path())?;
+    let installed = install_local_markdown_skills(staging.path(), None, project_root)?;
+
+    // Record provenance (github origin + detected source format) into the
+    // registry so `skill list` / `skill info` surface where each skill came
+    // from. Mirrors the path install's file materialization, plus a registry
+    // snapshot keyed by `source = GITHUB_IMPORT_SOURCE`.
+    //
+    // NOTE: deliberately no skill-LOCK entry is written. The lockfile drives
+    // registry version resolution (`find_lock_pin` / `resolve_skill_version`),
+    // and an import lock with no catalog record would hijack a later
+    // `animus skill install --name <same>` registry resolve. GitHub provenance
+    // lives only in the `installed` registry snapshot, keyed by the reserved
+    // `GITHUB_IMPORT_SOURCE` so it never collides with a catalog `github` source.
+    let mut registry_state = load_skill_registry_state(project_root)?;
+    let mut provenance = Vec::new();
+    for skill in &discovered {
+        let version = skill.definition.version.clone().unwrap_or_else(|| "0.0.0".to_string());
+        let artifact = skill.skill_md_repo_path.clone();
+        let integrity = build_integrity(&skill.name, &version, GITHUB_IMPORT_SOURCE, &artifact);
+        ensure_registry_registered(&mut registry_state, GITHUB_IMPORT_SOURCE);
+        registry_state.installed.retain(|entry| !(entry.name == skill.name && entry.source == GITHUB_IMPORT_SOURCE));
+        registry_state.installed.push(ResolvedSkillEntry {
+            name: skill.name.clone(),
+            version,
+            source: GITHUB_IMPORT_SOURCE.to_string(),
+            registry: GITHUB_IMPORT_SOURCE.to_string(),
+            integrity,
+            artifact,
+            definition: Some(skill.definition.clone()),
+            origin: Some(origin.clone()),
+            format: Some(skill.format.as_str().to_string()),
+        });
+        provenance.push(serde_json::json!({
+            "name": skill.name,
+            "format": skill.format.as_str(),
+            "origin": origin,
+            "repo_path": skill.skill_md_repo_path,
+        }));
+    }
+    let registry_changed = save_skill_registry_state_if_changed(project_root, &registry_state)?;
+
+    print_value(
+        serde_json::json!({
+            "installed": installed,
+            "provenance": provenance,
+            "origin": origin,
+            "install_root": skill_install_root(project_root),
+            "registry_changed": registry_changed,
         }),
         json,
     )
@@ -719,6 +810,8 @@ fn handle_list(args: SkillListArgs, project_root: &str, json: bool) -> Result<()
                 "registry": entry.registry,
                 "integrity": entry.integrity,
                 "artifact": entry.artifact,
+                "origin": entry.origin,
+                "format": entry.format,
                 "definition_snapshot": entry.definition.is_some(),
                 "lock_status": lock_status_for(entry, &lock_state),
                 "type": "installed",
@@ -781,6 +874,12 @@ fn resolve_update_targets(
             if entry.source != source {
                 continue;
             }
+        } else if entry.source == GITHUB_IMPORT_SOURCE {
+            // GitHub imports are not registry-resolvable (no catalog record).
+            // A bare update-all sweep skips them rather than failing at
+            // resolution; an explicit `--name` target is handled separately in
+            // `handle_update` with a "re-run install" error.
+            continue;
         }
         targets.insert((entry.name.clone(), entry.source.clone()));
     }
@@ -796,8 +895,20 @@ fn handle_update(args: SkillUpdateArgs, project_root: &str, json: bool) -> Resul
     let target_source = args.source.as_deref().map(str::trim).filter(|value| !value.is_empty());
     let targets = resolve_update_targets(&registry_state, target_name, target_source);
 
-    if target_name.is_some() && targets.is_empty() {
-        return Err(not_found_error(format!("skill not found: {}", target_name.unwrap_or_default())));
+    if let Some(name) = target_name {
+        if targets.is_empty() {
+            // A named target that exists only as a GitHub import gets an
+            // actionable error rather than a misleading "not found": imports
+            // refresh by re-running the install, not via registry resolution.
+            let is_github_import =
+                registry_state.installed.iter().any(|entry| entry.name == name && entry.source == GITHUB_IMPORT_SOURCE);
+            if is_github_import {
+                return Err(invalid_input_error(format!(
+                    "'{name}' was imported from GitHub and is not registry-updatable; re-run `animus skill install <github source>` to refresh it"
+                )));
+            }
+            return Err(not_found_error(format!("skill not found: {name}")));
+        }
     }
 
     let mut updated_entries = Vec::new();
@@ -979,6 +1090,18 @@ fn handle_show(args: SkillShowArgs, project_root: &str, json: bool) -> Result<()
             if !warnings.is_empty() {
                 payload.as_object_mut().unwrap().insert("warnings".to_string(), serde_json::json!(warnings));
             }
+            // A resolved skill that is also a registry-tracked install (e.g. a
+            // GitHub import materialized into the project) carries provenance
+            // the resolved definition alone does not; surface it here.
+            if let Ok(state) = load_skill_registry_state(project_root) {
+                if let Some(entry) =
+                    state.installed.iter().find(|e| e.name == args.name && (e.origin.is_some() || e.format.is_some()))
+                {
+                    let object = payload.as_object_mut().unwrap();
+                    object.insert("origin".to_string(), serde_json::json!(entry.origin));
+                    object.insert("format".to_string(), serde_json::json!(entry.format));
+                }
+            }
             print_value(payload, json)
         }
         Err(_) => {
@@ -993,6 +1116,8 @@ fn handle_show(args: SkillShowArgs, project_root: &str, json: bool) -> Result<()
                         "registry": entry.registry,
                         "integrity": entry.integrity,
                         "artifact": entry.artifact,
+                        "origin": entry.origin,
+                        "format": entry.format,
                         "definition_snapshot": entry.definition.is_some(),
                         "definition": entry.definition.clone(),
                         "type": "installed",
@@ -1092,6 +1217,8 @@ mod tests {
             integrity: "sha256:abc".to_string(),
             artifact: format!("{name}-1.0.0.tgz"),
             definition: None,
+            origin: None,
+            format: None,
         });
         registry.defaults.push(SkillProjectConstraint {
             name: name.to_string(),
@@ -1326,6 +1453,8 @@ mod tests {
             integrity: "sha256:def".to_string(),
             artifact: "alpha-1.1.0.tgz".to_string(),
             definition: None,
+            origin: None,
+            format: None,
         });
         save_skill_registry_state_if_changed(root, &registry).expect("save registry state");
 
@@ -1363,6 +1492,8 @@ mod tests {
             integrity: "sha256:def".to_string(),
             artifact: "alpha-1.1.0.tgz".to_string(),
             definition: Some(definition),
+            origin: None,
+            format: None,
         });
         save_skill_registry_state_if_changed(root, &registry).expect("save registry state");
 
@@ -1411,7 +1542,7 @@ pub(crate) async fn handle_skill(command: SkillCommand, project_root: &str, json
     match command {
         SkillCommand::Create(args) => handle_create(args, project_root, json),
         SkillCommand::Search(args) => handle_search(args, project_root, json),
-        SkillCommand::Install(args) => handle_install(args, project_root, json),
+        SkillCommand::Install(args) => handle_install(args, project_root, json).await,
         SkillCommand::List(args) => handle_list(args, project_root, json),
         SkillCommand::Info(args) => handle_show(args, project_root, json),
         SkillCommand::Update(args) => handle_update(args, project_root, json),

--- a/crates/orchestrator-cli/src/services/operations/ops_skill/github.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_skill/github.rs
@@ -1,0 +1,919 @@
+use crate::{invalid_input_error, not_found_error, unavailable_error};
+use anyhow::{Context, Result};
+use orchestrator_config::skill_scoping::{import_skill_definition, DetectedSkillFormat};
+use orchestrator_config::SkillDefinition;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// A parsed GitHub skill source: owner/repo, an optional git ref (branch, tag,
+/// or sha), and an optional in-repo subpath (a directory of skills, a single
+/// skill folder, or a `SKILL.md` file).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GithubSkillSource {
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) git_ref: Option<String>,
+    pub(crate) subpath: Option<String>,
+}
+
+fn clean_segment(value: &str) -> &str {
+    value.trim().trim_matches('/')
+}
+
+fn strip_dot_git(repo: &str) -> &str {
+    repo.strip_suffix(".git").unwrap_or(repo)
+}
+
+fn normalize_subpath(raw: &str) -> Option<String> {
+    let trimmed = clean_segment(raw);
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Parse the many accepted GitHub source shapes into a [`GithubSkillSource`]:
+///
+/// - `OWNER/REPO` and `OWNER/REPO@REF`
+/// - `https://github.com/OWNER/REPO[.git]` (optionally `@REF`)
+/// - `https://github.com/OWNER/REPO/tree/REF[/SUBPATH]`
+/// - `https://github.com/OWNER/REPO/blob/REF/PATH/SKILL.md`
+/// - raw `https://raw.githubusercontent.com/OWNER/REPO/REF/PATH/SKILL.md`
+pub(crate) fn parse_github_skill_source(raw: &str) -> Result<GithubSkillSource> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(invalid_input_error("GitHub skill source must not be empty"));
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("http://") || lower.starts_with("https://") {
+        return parse_github_url(trimmed);
+    }
+
+    parse_owner_repo_slug(trimmed)
+}
+
+/// Parse `OWNER/REPO` or `OWNER/REPO@REF` (no scheme).
+fn parse_owner_repo_slug(trimmed: &str) -> Result<GithubSkillSource> {
+    let (slug, git_ref) = split_ref(trimmed);
+    let mut parts = slug.split('/');
+    let owner = parts.next().map(clean_segment).unwrap_or_default();
+    let repo = parts.next().map(clean_segment).map(strip_dot_git).unwrap_or_default();
+    if owner.is_empty() || repo.is_empty() || parts.next().is_some() {
+        return Err(invalid_input_error(format!(
+            "GitHub skill source '{trimmed}' must be 'OWNER/REPO[@ref]' or a github.com URL"
+        )));
+    }
+    Ok(GithubSkillSource { owner: owner.to_string(), repo: repo.to_string(), git_ref, subpath: None })
+}
+
+/// Split a trailing `@ref` off a slug (URLs use path components for the ref, so
+/// this only applies to the bare-slug form).
+fn split_ref(value: &str) -> (&str, Option<String>) {
+    match value.rsplit_once('@') {
+        Some((slug, git_ref)) => {
+            let git_ref = git_ref.trim();
+            if git_ref.is_empty() {
+                (value, None)
+            } else {
+                (slug.trim(), Some(git_ref.to_string()))
+            }
+        }
+        None => (value, None),
+    }
+}
+
+fn parse_github_url(url: &str) -> Result<GithubSkillSource> {
+    let (url, slug_ref) = match url.rsplit_once('@') {
+        // Only treat a trailing `@ref` as a ref when the remainder still looks
+        // like a github URL (so emails inside a path do not trip this).
+        Some((head, git_ref)) if !git_ref.contains('/') && !git_ref.is_empty() => (head, Some(git_ref.to_string())),
+        _ => (url, None),
+    };
+
+    let without_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let (host, path) = without_scheme
+        .split_once('/')
+        .ok_or_else(|| invalid_input_error(format!("GitHub skill source URL '{url}' has no path")))?;
+    let host = host.to_ascii_lowercase();
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    if host == "raw.githubusercontent.com" {
+        // raw.githubusercontent.com/OWNER/REPO/REF/PATH...
+        if segments.len() < 3 {
+            return Err(invalid_input_error(format!("raw GitHub URL '{url}' must include OWNER/REPO/REF/PATH")));
+        }
+        let owner = clean_segment(segments[0]);
+        let repo = strip_dot_git(clean_segment(segments[1]));
+        let git_ref = clean_segment(segments[2]);
+        let subpath = normalize_subpath(&segments[3..].join("/"));
+        return Ok(GithubSkillSource {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            git_ref: Some(git_ref.to_string()),
+            subpath,
+        });
+    }
+
+    if host != "github.com" && host != "www.github.com" {
+        return Err(invalid_input_error(format!(
+            "unsupported host '{host}' (expected github.com or raw.githubusercontent.com)"
+        )));
+    }
+
+    if segments.len() < 2 {
+        return Err(invalid_input_error(format!("GitHub URL '{url}' must include OWNER/REPO")));
+    }
+    let owner = clean_segment(segments[0]).to_string();
+    let repo = strip_dot_git(clean_segment(segments[1])).to_string();
+
+    // github.com/OWNER/REPO[/tree|/blob/REF[/SUBPATH]]
+    //
+    // A `/tree/<ref>/<path>` URL is inherently ambiguous when the branch name
+    // itself contains `/` (e.g. `feature/foo`): the URL string alone cannot
+    // tell where the ref ends and the path begins. We treat the first segment
+    // after `tree`/`blob` as the ref; users with slash-bearing branches should
+    // use the unambiguous `OWNER/REPO@feature/foo` slug form (handled by
+    // `split_ref`, which splits on the last `@`).
+    let (git_ref, subpath) = match segments.get(2).copied() {
+        Some("tree") | Some("blob") => {
+            let git_ref = segments.get(3).map(|s| clean_segment(s).to_string());
+            let subpath = normalize_subpath(&segments[4.min(segments.len())..].join("/"));
+            (git_ref, subpath)
+        }
+        Some(_) => {
+            return Err(invalid_input_error(format!(
+                "GitHub URL '{url}' is not understood (use /tree/<ref>/<path> or /blob/<ref>/<path>)"
+            )));
+        }
+        None => (slug_ref.clone(), None),
+    };
+
+    let git_ref = git_ref.or(slug_ref);
+    Ok(GithubSkillSource { owner, repo, git_ref, subpath })
+}
+
+fn release_user_agent() -> String {
+    format!("animus-cli/{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Abstraction over GitHub content access so the discovery + import logic is
+/// unit-testable without the network. The real implementation talks to the
+/// GitHub git-trees + raw-content endpoints; tests inject a fake.
+pub(crate) trait RepoFetcher {
+    /// Resolve the default branch when no ref was supplied.
+    fn default_branch(&self, owner: &str, repo: &str) -> Result<String>;
+    /// Resolve a branch/tag/sha to a commit sha. Resolving up front lets the
+    /// tree + raw-content URLs use an unambiguous single-segment sha, so refs
+    /// that contain `/` (e.g. `feature/foo`) work correctly.
+    fn resolve_ref_to_sha(&self, owner: &str, repo: &str, git_ref: &str) -> Result<String>;
+    /// List every file path under the repo at `commit_sha` (recursive tree).
+    fn list_tree(&self, owner: &str, repo: &str, commit_sha: &str) -> Result<Vec<String>>;
+    /// Download a single repo-relative file's raw bytes at `commit_sha`.
+    fn fetch_file(&self, owner: &str, repo: &str, commit_sha: &str, path: &str) -> Result<Vec<u8>>;
+}
+
+/// One discovered, normalized skill ready to be materialized: its assets keyed
+/// by the path relative to the skill's own root directory.
+#[derive(Debug, Clone)]
+pub(crate) struct DiscoveredSkill {
+    pub(crate) name: String,
+    pub(crate) format: DetectedSkillFormat,
+    /// The normalized animus skill definition (for the registry snapshot).
+    pub(crate) definition: SkillDefinition,
+    /// Repo-relative path of the SKILL.md, for provenance/errors.
+    pub(crate) skill_md_repo_path: String,
+    /// Files keyed by path relative to the skill's root (the dir holding
+    /// SKILL.md). Always includes `SKILL.md`.
+    pub(crate) files: BTreeMap<String, Vec<u8>>,
+}
+
+/// Identify every `SKILL.md` in `tree` that lives at or under `subpath`
+/// (`None` = whole repo). Returns repo-relative SKILL.md paths, sorted.
+pub(crate) fn discover_skill_md_paths(tree: &[String], subpath: Option<&str>) -> Vec<String> {
+    let prefix = subpath.map(clean_segment).filter(|s| !s.is_empty());
+
+    // A subpath that points directly at a SKILL.md selects exactly that file.
+    if let Some(prefix) = prefix {
+        if prefix.eq_ignore_ascii_case("SKILL.md") || prefix.to_ascii_lowercase().ends_with("/skill.md") {
+            return tree.iter().filter(|p| p.as_str() == prefix).cloned().collect();
+        }
+    }
+
+    let mut found: Vec<String> = tree
+        .iter()
+        .filter(|path| {
+            let is_skill_md =
+                path.rsplit('/').next().map(|name| name.eq_ignore_ascii_case("SKILL.md")).unwrap_or(false);
+            if !is_skill_md {
+                return false;
+            }
+            match prefix {
+                None => true,
+                Some(prefix) => path.as_str() == prefix || path.starts_with(&format!("{prefix}/")),
+            }
+        })
+        .cloned()
+        .collect();
+    found.sort();
+    found.dedup();
+    found
+}
+
+/// The repo-relative directory that holds a SKILL.md (`""` when at repo root).
+fn skill_root_dir(skill_md_path: &str) -> &str {
+    match skill_md_path.rsplit_once('/') {
+        Some((dir, _)) => dir,
+        None => "",
+    }
+}
+
+/// Fetch + normalize all skills selected by `source` using `fetcher`. Pure
+/// orchestration over the fetcher trait — no direct network calls — so it is
+/// fully unit-testable.
+pub(crate) fn discover_and_import(
+    source: &GithubSkillSource,
+    fetcher: &dyn RepoFetcher,
+) -> Result<Vec<DiscoveredSkill>> {
+    let git_ref = match &source.git_ref {
+        Some(git_ref) => git_ref.clone(),
+        None => fetcher.default_branch(&source.owner, &source.repo)?,
+    };
+    // Resolve to a commit sha so slash-bearing branch refs (e.g.
+    // `feature/foo`) survive URL interpolation unambiguously.
+    let commit_sha = fetcher.resolve_ref_to_sha(&source.owner, &source.repo, &git_ref)?;
+
+    // Fast path: a source that points directly at a SKILL.md (e.g. a raw or
+    // blob URL) fetches that one file without enumerating the whole repo tree,
+    // so it works even in large monorepos where the recursive tree is
+    // truncated. Bundled assets are not enumerable without a tree, so a direct
+    // file import installs the SKILL.md alone.
+    if let Some(skill_md_path) = source.subpath.as_deref().filter(|p| points_at_skill_md(p)) {
+        let bytes = fetcher.fetch_file(&source.owner, &source.repo, &commit_sha, skill_md_path)?;
+        let content =
+            String::from_utf8(bytes).with_context(|| format!("SKILL.md at {skill_md_path} is not valid UTF-8"))?;
+        return Ok(vec![import_one(&content, skill_md_path)?]);
+    }
+
+    // TODO(codex-p2): for a `/tree/<ref>/<subpath>` source in a very large
+    // monorepo, GitHub may mark the recursive tree `truncated` and the install
+    // fails before the subpath filter narrows it. A scoped (non-recursive,
+    // per-directory) tree walk rooted at `subpath` would let narrow installs
+    // succeed where the whole-repo tree is truncated. Deferred: needs a new
+    // per-directory enumeration path on the fetcher.
+    let tree = fetcher.list_tree(&source.owner, &source.repo, &commit_sha)?;
+    let skill_md_paths = discover_skill_md_paths(&tree, source.subpath.as_deref());
+
+    if skill_md_paths.is_empty() {
+        return Err(not_found_error(format!(
+            "no SKILL.md found in {}/{}@{}{}",
+            source.owner,
+            source.repo,
+            git_ref,
+            source.subpath.as_deref().map(|p| format!(" under '{p}'")).unwrap_or_default()
+        )));
+    }
+
+    // When several skills are discovered, a root-level SKILL.md must not vacuum
+    // the sibling skill folders. Collect the non-root skill directories so a
+    // root skill can exclude them from its asset sweep.
+    let other_skill_roots: Vec<String> =
+        skill_md_paths.iter().map(|path| skill_root_dir(path).to_string()).filter(|root| !root.is_empty()).collect();
+
+    let mut discovered = Vec::new();
+    for skill_md_path in &skill_md_paths {
+        let root = skill_root_dir(skill_md_path).to_string();
+        // Every tree entry under the skill's root is a bundled asset
+        // (scripts/, references/, ...). Preserve the layout relative to root.
+        // A root-level SKILL.md treats the whole repo as its bundle, minus any
+        // sibling skill directories.
+        let asset_paths: Vec<String> = tree
+            .iter()
+            .filter(|path| {
+                if root.is_empty() {
+                    path.as_str() == skill_md_path.as_str()
+                        || !other_skill_roots.iter().any(|other| path.starts_with(&format!("{other}/")))
+                } else {
+                    path.as_str() == skill_md_path.as_str() || path.starts_with(&format!("{root}/"))
+                }
+            })
+            .cloned()
+            .collect();
+
+        let mut asset_bytes: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        let mut skill_md_bytes: Option<Vec<u8>> = None;
+        for asset in &asset_paths {
+            let bytes = fetcher.fetch_file(&source.owner, &source.repo, &commit_sha, asset)?;
+            if asset == skill_md_path {
+                skill_md_bytes = Some(bytes.clone());
+                continue;
+            }
+            let relative = if root.is_empty() {
+                asset.clone()
+            } else {
+                asset.strip_prefix(&format!("{root}/")).unwrap_or(asset).to_string()
+            };
+            asset_bytes.insert(relative, bytes);
+        }
+
+        let skill_md_bytes = skill_md_bytes.context("internal: SKILL.md was discovered but not fetched")?;
+        let content = String::from_utf8(skill_md_bytes)
+            .with_context(|| format!("SKILL.md at {skill_md_path} is not valid UTF-8"))?;
+        let mut skill = import_one(&content, skill_md_path)?;
+        skill.files.extend(asset_bytes);
+        discovered.push(skill);
+    }
+
+    // Two skills in the same repo whose names normalize to the same slug would
+    // materialize into the same staging folder and collapse under one registry
+    // entry — silently dropping one. Detect and report instead of corrupting.
+    let mut seen: BTreeMap<&str, &str> = BTreeMap::new();
+    for skill in &discovered {
+        if let Some(prior) = seen.insert(skill.name.as_str(), skill.skill_md_repo_path.as_str()) {
+            return Err(invalid_input_error(format!(
+                "skill name collision: '{}' and '{}' both normalize to '{}'; install one at a time with a narrower /tree/<ref>/<path> source",
+                prior, skill.skill_md_repo_path, skill.name
+            )));
+        }
+    }
+
+    Ok(discovered)
+}
+
+/// Does `subpath` point directly at a `SKILL.md` file (case-insensitive)?
+fn points_at_skill_md(subpath: &str) -> bool {
+    subpath.rsplit('/').next().map(|name| name.eq_ignore_ascii_case("SKILL.md")).unwrap_or(false)
+}
+
+/// Import one SKILL.md's content into a [`DiscoveredSkill`] with only its
+/// (name-normalized) SKILL.md staged. The skill name comes from untrusted
+/// frontmatter, so it is forced to a safe single-segment slug AND the staged
+/// SKILL.md's `name:` is rewritten to match, so the reparse on install yields
+/// the same slug and the install destination can never escape the skills dir.
+fn import_one(content: &str, skill_md_path: &str) -> Result<DiscoveredSkill> {
+    let default_name = default_name_for(skill_md_path);
+    let (mut definition, format) =
+        import_skill_definition(content, &default_name).with_context(|| format!("failed to import {skill_md_path}"))?;
+    let slug = slugify_skill_name(&definition.name);
+    definition.name = slug.clone();
+    let rewritten = rewrite_skill_md_name(content, &slug);
+    let mut files = BTreeMap::new();
+    files.insert("SKILL.md".to_string(), rewritten.into_bytes());
+    Ok(DiscoveredSkill { name: slug, format, definition, skill_md_repo_path: skill_md_path.to_string(), files })
+}
+
+/// Reduce an imported skill name to a safe single-segment slug (lowercase ASCII
+/// alphanumerics plus `-`/`_`). Shared by the staging-folder name and the
+/// rewritten `name:` frontmatter so the install destination can never escape
+/// the skills directory.
+fn slugify_skill_name(name: &str) -> String {
+    let lowered: String = name
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .collect();
+    let collapsed = lowered.trim_matches('-').to_string();
+    if collapsed.is_empty() {
+        "skill".to_string()
+    } else {
+        collapsed
+    }
+}
+
+/// Rewrite (or insert) the `name:` field in a SKILL.md's YAML frontmatter so it
+/// equals `slug`. Preserves the body verbatim. When the file has no
+/// frontmatter, one is prepended.
+fn rewrite_skill_md_name(content: &str, slug: &str) -> String {
+    let normalized = content.replace("\r\n", "\n");
+    let trimmed = normalized.trim_start_matches('\u{feff}');
+    let name_line = format!("name: {slug}");
+
+    let Some(rest) = trimmed.strip_prefix("---\n") else {
+        return format!("---\n{name_line}\n---\n\n{}", trimmed.trim_start());
+    };
+    let Some(end) = rest.find("\n---\n") else {
+        // Frontmatter-only document; rewrite within the block.
+        let block = rest.strip_suffix("\n---").unwrap_or(rest);
+        let new_block = replace_or_prepend_name(block, &name_line);
+        return format!("---\n{new_block}\n---\n");
+    };
+    let block = &rest[..end];
+    let body = &rest[end + 5..];
+    let new_block = replace_or_prepend_name(block, &name_line);
+    format!("---\n{new_block}\n---\n{body}")
+}
+
+fn replace_or_prepend_name(block: &str, name_line: &str) -> String {
+    let mut replaced = false;
+    let mut lines: Vec<String> = block
+        .lines()
+        .map(|line| {
+            // Only rewrite a top-level (non-indented) `name:` key.
+            if !replaced && !line.starts_with(char::is_whitespace) {
+                let key = line.split(':').next().unwrap_or("").trim();
+                if key == "name" {
+                    replaced = true;
+                    return name_line.to_string();
+                }
+            }
+            line.to_string()
+        })
+        .collect();
+    if !replaced {
+        lines.insert(0, name_line.to_string());
+    }
+    lines.join("\n")
+}
+
+/// Derive a fallback skill name from a SKILL.md repo path: the holding
+/// directory name, or the repo root marker otherwise.
+fn default_name_for(skill_md_path: &str) -> String {
+    let root = skill_root_dir(skill_md_path);
+    let candidate = root.rsplit('/').next().unwrap_or("");
+    if candidate.trim().is_empty() {
+        "skill".to_string()
+    } else {
+        candidate.to_string()
+    }
+}
+
+/// Materialize `skills` into `dest_dir` as `<name>/SKILL.md` (+ assets),
+/// producing one folder per skill that `install_local_markdown_skills` can
+/// then install through the same path that `--path` uses.
+pub(crate) fn materialize_to_dir(skills: &[DiscoveredSkill], dest_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    for skill in skills {
+        let safe_name = sanitize_dir_name(&skill.name);
+        let root = dest_dir.join(&safe_name);
+        for (relative, bytes) in &skill.files {
+            let target = root.join(relative);
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+            }
+            std::fs::write(&target, bytes).with_context(|| format!("failed to write {}", target.display()))?;
+        }
+        roots.push(root);
+    }
+    Ok(roots)
+}
+
+/// Reduce an imported skill name to a single safe path segment so a malicious
+/// `name:` frontmatter can never escape the staging directory.
+fn sanitize_dir_name(name: &str) -> String {
+    let cleaned: String =
+        name.trim().chars().map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' }).collect();
+    let cleaned = cleaned.trim_matches('-').to_string();
+    if cleaned.is_empty() {
+        "skill".to_string()
+    } else {
+        cleaned
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Real network fetcher (GitHub git-trees + raw content).
+// ---------------------------------------------------------------------------
+
+pub(crate) struct HttpRepoFetcher {
+    client: reqwest::blocking::Client,
+    token: Option<String>,
+}
+
+impl HttpRepoFetcher {
+    pub(crate) fn new() -> Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(release_user_agent())
+            .build()
+            .context("failed to build HTTP client")?;
+        let token = std::env::var("GITHUB_TOKEN").ok().filter(|value| !value.trim().is_empty());
+        Ok(Self { client, token })
+    }
+
+    fn get(&self, url: &str, accept: &str) -> Result<reqwest::blocking::Response> {
+        let mut request = self.client.get(url).header("Accept", accept);
+        if let Some(token) = &self.token {
+            request = request.header("Authorization", format!("Bearer {token}"));
+        }
+        let response = request.send().map_err(|err| unavailable_error(format!("failed to GET {url}: {err}")))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(not_found_error(format!("not found: {url}")));
+        }
+        response
+            .error_for_status()
+            .map_err(|err| unavailable_error(format!("GET {url} returned non-success status: {err}")))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct RepoInfo {
+    default_branch: String,
+}
+
+#[derive(serde::Deserialize)]
+struct GitTree {
+    tree: Vec<GitTreeEntry>,
+    #[serde(default)]
+    truncated: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct GitTreeEntry {
+    path: String,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+#[derive(serde::Deserialize)]
+struct CommitRef {
+    sha: String,
+}
+
+impl RepoFetcher for HttpRepoFetcher {
+    fn default_branch(&self, owner: &str, repo: &str) -> Result<String> {
+        let url = format!("https://api.github.com/repos/{owner}/{repo}");
+        let info: RepoInfo = self
+            .get(&url, "application/vnd.github+json")?
+            .json()
+            .with_context(|| format!("failed to parse repo info from {url}"))?;
+        Ok(info.default_branch)
+    }
+
+    fn resolve_ref_to_sha(&self, owner: &str, repo: &str, git_ref: &str) -> Result<String> {
+        // The commits endpoint resolves a branch, tag, or sha to its commit and
+        // takes the ref as a single path segment, so a slash-bearing branch
+        // must be percent-encoded.
+        let encoded = encode_path_segment(git_ref);
+        let url = format!("https://api.github.com/repos/{owner}/{repo}/commits/{encoded}");
+        let commit: CommitRef = self
+            .get(&url, "application/vnd.github+json")?
+            .json()
+            .with_context(|| format!("failed to resolve ref '{git_ref}' via {url}"))?;
+        Ok(commit.sha)
+    }
+
+    fn list_tree(&self, owner: &str, repo: &str, commit_sha: &str) -> Result<Vec<String>> {
+        let url = format!("https://api.github.com/repos/{owner}/{repo}/git/trees/{commit_sha}?recursive=1");
+        let tree: GitTree = self
+            .get(&url, "application/vnd.github+json")?
+            .json()
+            .with_context(|| format!("failed to parse git tree from {url}"))?;
+        if tree.truncated {
+            return Err(unavailable_error(format!(
+                "repo tree at {owner}/{repo}@{commit_sha} is too large to enumerate (GitHub truncated the response); pass a narrower /tree/<ref>/<path> URL"
+            )));
+        }
+        Ok(tree.tree.into_iter().filter(|entry| entry.kind == "blob").map(|entry| entry.path).collect())
+    }
+
+    fn fetch_file(&self, owner: &str, repo: &str, commit_sha: &str, path: &str) -> Result<Vec<u8>> {
+        // `commit_sha` is a resolved 40-hex sha (single path segment); the file
+        // path's `/` separators are intended path structure, not encoded.
+        let url = format!("https://raw.githubusercontent.com/{owner}/{repo}/{commit_sha}/{path}");
+        let bytes = self
+            .get(&url, "application/octet-stream")?
+            .bytes()
+            .with_context(|| format!("failed to read body from {url}"))?;
+        Ok(bytes.to_vec())
+    }
+}
+
+/// Percent-encode a single URL path segment (encodes `/` and other reserved
+/// characters) so a slash-bearing git ref stays one segment.
+fn encode_path_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => out.push(byte as char),
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_owner_repo_slug_forms() {
+        let s = parse_github_skill_source("anthropics/skills").unwrap();
+        assert_eq!(
+            s,
+            GithubSkillSource { owner: "anthropics".into(), repo: "skills".into(), git_ref: None, subpath: None }
+        );
+
+        let s = parse_github_skill_source("anthropics/skills@v1.2.0").unwrap();
+        assert_eq!(s.git_ref.as_deref(), Some("v1.2.0"));
+        assert_eq!(s.subpath, None);
+    }
+
+    #[test]
+    fn parse_slug_with_slash_bearing_ref() {
+        // The slug `@` form unambiguously delimits a slash-bearing branch ref.
+        let s = parse_github_skill_source("owner/repo@feature/foo").unwrap();
+        assert_eq!(s.owner, "owner");
+        assert_eq!(s.repo, "repo");
+        assert_eq!(s.git_ref.as_deref(), Some("feature/foo"));
+        assert_eq!(s.subpath, None);
+    }
+
+    #[test]
+    fn parse_repo_url_with_and_without_dot_git() {
+        let s = parse_github_skill_source("https://github.com/anthropics/skills.git").unwrap();
+        assert_eq!(s.owner, "anthropics");
+        assert_eq!(s.repo, "skills");
+        assert_eq!(s.subpath, None);
+
+        let s = parse_github_skill_source("https://github.com/anthropics/skills").unwrap();
+        assert_eq!(s.repo, "skills");
+    }
+
+    #[test]
+    fn parse_tree_url_with_ref_and_subpath() {
+        let s =
+            parse_github_skill_source("https://github.com/anthropics/skills/tree/main/document-skills/pdf").unwrap();
+        assert_eq!(s.owner, "anthropics");
+        assert_eq!(s.repo, "skills");
+        assert_eq!(s.git_ref.as_deref(), Some("main"));
+        assert_eq!(s.subpath.as_deref(), Some("document-skills/pdf"));
+    }
+
+    #[test]
+    fn parse_blob_url_to_skill_md() {
+        let s = parse_github_skill_source("https://github.com/owner/repo/blob/abc123/skills/foo/SKILL.md").unwrap();
+        assert_eq!(s.git_ref.as_deref(), Some("abc123"));
+        assert_eq!(s.subpath.as_deref(), Some("skills/foo/SKILL.md"));
+    }
+
+    #[test]
+    fn parse_raw_skill_md_url() {
+        let s =
+            parse_github_skill_source("https://raw.githubusercontent.com/owner/repo/main/skills/foo/SKILL.md").unwrap();
+        assert_eq!(s.owner, "owner");
+        assert_eq!(s.repo, "repo");
+        assert_eq!(s.git_ref.as_deref(), Some("main"));
+        assert_eq!(s.subpath.as_deref(), Some("skills/foo/SKILL.md"));
+    }
+
+    #[test]
+    fn parse_rejects_garbage_and_non_github_hosts() {
+        assert!(parse_github_skill_source("").is_err());
+        assert!(parse_github_skill_source("not-a-slug").is_err());
+        assert!(parse_github_skill_source("a/b/c").is_err());
+        assert!(parse_github_skill_source("https://gitlab.com/a/b").is_err());
+    }
+
+    #[test]
+    fn discover_finds_single_skill_md_at_subpath() {
+        let tree = vec![
+            "README.md".to_string(),
+            "skills/foo/SKILL.md".to_string(),
+            "skills/foo/scripts/run.sh".to_string(),
+            "skills/bar/SKILL.md".to_string(),
+        ];
+        let found = discover_skill_md_paths(&tree, Some("skills/foo"));
+        assert_eq!(found, vec!["skills/foo/SKILL.md".to_string()]);
+    }
+
+    #[test]
+    fn discover_finds_all_skill_md_in_repo() {
+        let tree =
+            vec!["skills/foo/SKILL.md".to_string(), "skills/bar/SKILL.md".to_string(), "docs/guide.md".to_string()];
+        let mut found = discover_skill_md_paths(&tree, None);
+        found.sort();
+        assert_eq!(found, vec!["skills/bar/SKILL.md".to_string(), "skills/foo/SKILL.md".to_string()]);
+    }
+
+    #[test]
+    fn discover_subpath_directly_to_skill_md() {
+        let tree = vec!["skills/foo/SKILL.md".to_string()];
+        let found = discover_skill_md_paths(&tree, Some("skills/foo/SKILL.md"));
+        assert_eq!(found, vec!["skills/foo/SKILL.md".to_string()]);
+    }
+
+    struct FakeFetcher {
+        files: BTreeMap<String, Vec<u8>>,
+        default_branch: String,
+    }
+
+    impl RepoFetcher for FakeFetcher {
+        fn default_branch(&self, _owner: &str, _repo: &str) -> Result<String> {
+            Ok(self.default_branch.clone())
+        }
+        fn resolve_ref_to_sha(&self, _owner: &str, _repo: &str, git_ref: &str) -> Result<String> {
+            Ok(format!("sha-for-{git_ref}"))
+        }
+        fn list_tree(&self, _owner: &str, _repo: &str, _git_ref: &str) -> Result<Vec<String>> {
+            Ok(self.files.keys().cloned().collect())
+        }
+        fn fetch_file(&self, _owner: &str, _repo: &str, _git_ref: &str, path: &str) -> Result<Vec<u8>> {
+            self.files.get(path).cloned().ok_or_else(|| not_found_error(format!("fake: {path}")))
+        }
+    }
+
+    #[test]
+    fn discover_and_import_maps_anthropic_skill_with_assets() {
+        let mut files = BTreeMap::new();
+        files.insert(
+            "skills/pdf/SKILL.md".to_string(),
+            b"---\nname: pdf\ndescription: Work with PDFs\nallowed-tools:\n  - Read\n---\n\nExtract text.\n".to_vec(),
+        );
+        files.insert("skills/pdf/scripts/run.sh".to_string(), b"echo hi\n".to_vec());
+        files.insert("README.md".to_string(), b"ignore me\n".to_vec());
+        let fetcher = FakeFetcher { files, default_branch: "main".to_string() };
+
+        let source = GithubSkillSource {
+            owner: "o".into(),
+            repo: "r".into(),
+            git_ref: None,
+            subpath: Some("skills/pdf".into()),
+        };
+        let discovered = discover_and_import(&source, &fetcher).unwrap();
+        assert_eq!(discovered.len(), 1);
+        let skill = &discovered[0];
+        assert_eq!(skill.name, "pdf");
+        assert_eq!(skill.format, DetectedSkillFormat::AnthropicAgentSkill);
+        // Assets keyed relative to the skill root, README excluded.
+        assert!(skill.files.contains_key("SKILL.md"));
+        assert!(skill.files.contains_key("scripts/run.sh"));
+        assert!(!skill.files.keys().any(|k| k.contains("README")));
+    }
+
+    #[test]
+    fn discover_and_import_errors_on_normalized_name_collision() {
+        let mut files = BTreeMap::new();
+        files.insert("a/SKILL.md".to_string(), b"---\nname: PDF Helper\ndescription: x\n---\n\nbody\n".to_vec());
+        files.insert("b/SKILL.md".to_string(), b"---\nname: pdf-helper\ndescription: x\n---\n\nbody\n".to_vec());
+        let fetcher = FakeFetcher { files, default_branch: "main".to_string() };
+        let source =
+            GithubSkillSource { owner: "o".into(), repo: "r".into(), git_ref: Some("main".into()), subpath: None };
+        let err = discover_and_import(&source, &fetcher).unwrap_err();
+        assert!(err.to_string().contains("collision"), "got: {err}");
+    }
+
+    #[test]
+    fn discover_and_import_errors_when_no_skill_md() {
+        let mut files = BTreeMap::new();
+        files.insert("README.md".to_string(), b"no skills here\n".to_vec());
+        let fetcher = FakeFetcher { files, default_branch: "main".to_string() };
+        let source =
+            GithubSkillSource { owner: "o".into(), repo: "r".into(), git_ref: Some("main".into()), subpath: None };
+        let err = discover_and_import(&source, &fetcher).unwrap_err();
+        assert!(err.to_string().contains("no SKILL.md"), "got: {err}");
+    }
+
+    struct NoTreeFetcher {
+        skill_md: Vec<u8>,
+    }
+    impl RepoFetcher for NoTreeFetcher {
+        fn default_branch(&self, _owner: &str, _repo: &str) -> Result<String> {
+            Ok("main".to_string())
+        }
+        fn resolve_ref_to_sha(&self, _owner: &str, _repo: &str, git_ref: &str) -> Result<String> {
+            Ok(format!("sha-{git_ref}"))
+        }
+        fn list_tree(&self, _owner: &str, _repo: &str, _git_ref: &str) -> Result<Vec<String>> {
+            panic!("list_tree must not be called for a direct SKILL.md source");
+        }
+        fn fetch_file(&self, _owner: &str, _repo: &str, _git_ref: &str, _path: &str) -> Result<Vec<u8>> {
+            Ok(self.skill_md.clone())
+        }
+    }
+
+    #[test]
+    fn discover_and_import_direct_skill_md_skips_tree_enumeration() {
+        let fetcher = NoTreeFetcher { skill_md: b"---\nname: Direct Skill\ndescription: d\n---\n\nbody\n".to_vec() };
+        let source = GithubSkillSource {
+            owner: "o".into(),
+            repo: "r".into(),
+            git_ref: Some("main".into()),
+            subpath: Some("skills/foo/SKILL.md".into()),
+        };
+        let discovered = discover_and_import(&source, &fetcher).unwrap();
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name, "direct-skill");
+        assert_eq!(discovered[0].files.len(), 1, "direct import stages only the SKILL.md");
+    }
+
+    #[test]
+    fn points_at_skill_md_detects_trailing_file() {
+        assert!(points_at_skill_md("skills/foo/SKILL.md"));
+        assert!(points_at_skill_md("SKILL.md"));
+        assert!(!points_at_skill_md("skills/foo"));
+    }
+
+    #[test]
+    fn materialize_writes_skill_folders() {
+        let mut files = BTreeMap::new();
+        files.insert("SKILL.md".to_string(), b"---\nname: x\n---\nbody\n".to_vec());
+        files.insert("scripts/run.sh".to_string(), b"echo\n".to_vec());
+        let skill = DiscoveredSkill {
+            name: "x".to_string(),
+            format: DetectedSkillFormat::AnthropicAgentSkill,
+            definition: SkillDefinition {
+                name: "x".to_string(),
+                version: None,
+                description: String::new(),
+                category: None,
+                activation: Default::default(),
+                prompt: Default::default(),
+                tool_policy: None,
+                model: Default::default(),
+                mcp_servers: Vec::new(),
+                timeout_secs: None,
+                capabilities: Default::default(),
+                extra_args: Vec::new(),
+                env: Default::default(),
+                codex_config_overrides: Vec::new(),
+                adapters: Default::default(),
+                tags: Vec::new(),
+            },
+            skill_md_repo_path: "skills/x/SKILL.md".to_string(),
+            files,
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let roots = materialize_to_dir(&[skill], tmp.path()).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert!(roots[0].join("SKILL.md").exists());
+        assert!(roots[0].join("scripts/run.sh").exists());
+    }
+
+    #[test]
+    fn sanitize_dir_name_strips_path_traversal() {
+        assert_eq!(sanitize_dir_name("../../etc/passwd"), "etc-passwd");
+        assert_eq!(sanitize_dir_name("good-name_1"), "good-name_1");
+        assert_eq!(sanitize_dir_name("///"), "skill");
+    }
+
+    #[test]
+    fn encode_path_segment_encodes_slashes() {
+        assert_eq!(encode_path_segment("feature/foo"), "feature%2Ffoo");
+        assert_eq!(encode_path_segment("v1.2.0"), "v1.2.0");
+        assert_eq!(encode_path_segment("main"), "main");
+    }
+
+    #[test]
+    fn slugify_skill_name_is_safe_single_segment() {
+        assert_eq!(slugify_skill_name("PDF Helper"), "pdf-helper");
+        assert_eq!(slugify_skill_name("../../etc/passwd"), "etc-passwd");
+        assert_eq!(slugify_skill_name("good_name-1"), "good_name-1");
+        assert_eq!(slugify_skill_name("***"), "skill");
+    }
+
+    #[test]
+    fn rewrite_skill_md_name_replaces_top_level_name_and_keeps_body() {
+        let content = "---\nname: Evil/../Name\ndescription: x\n---\n\nbody text\n";
+        let out = rewrite_skill_md_name(content, "evil-name");
+        let (skill, _) = import_skill_definition(&out, "fallback").unwrap();
+        assert_eq!(skill.name, "evil-name");
+        assert_eq!(skill.description, "x");
+        assert_eq!(skill.prompt.system.as_deref(), Some("body text"));
+    }
+
+    #[test]
+    fn rewrite_skill_md_name_inserts_name_when_absent() {
+        let content = "Just a body, no frontmatter.\n";
+        let out = rewrite_skill_md_name(content, "my-skill");
+        let (skill, _) = import_skill_definition(&out, "fallback").unwrap();
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.prompt.system.as_deref(), Some("Just a body, no frontmatter."));
+    }
+
+    #[test]
+    fn discover_and_import_slugifies_unsafe_name() {
+        let mut files = BTreeMap::new();
+        files.insert(
+            "skills/x/SKILL.md".to_string(),
+            b"---\nname: ../../escape\ndescription: x\n---\n\nbody\n".to_vec(),
+        );
+        let fetcher = FakeFetcher { files, default_branch: "main".to_string() };
+        let source =
+            GithubSkillSource { owner: "o".into(), repo: "r".into(), git_ref: Some("main".into()), subpath: None };
+        let discovered = discover_and_import(&source, &fetcher).unwrap();
+        assert_eq!(discovered[0].name, "escape");
+        assert_eq!(discovered[0].definition.name, "escape");
+        // The staged SKILL.md reparses to the safe slug.
+        let staged = String::from_utf8(discovered[0].files["SKILL.md"].clone()).unwrap();
+        let (reparsed, _) = import_skill_definition(&staged, "fallback").unwrap();
+        assert_eq!(reparsed.name, "escape");
+    }
+
+    #[test]
+    fn discover_and_import_root_skill_includes_assets_excluding_other_skills() {
+        let mut files = BTreeMap::new();
+        files.insert("SKILL.md".to_string(), b"---\nname: root\n---\n\nroot body\n".to_vec());
+        files.insert("scripts/run.sh".to_string(), b"echo\n".to_vec());
+        files.insert("skills/nested/SKILL.md".to_string(), b"---\nname: nested\n---\n\nnested\n".to_vec());
+        let fetcher = FakeFetcher { files, default_branch: "main".to_string() };
+        let source =
+            GithubSkillSource { owner: "o".into(), repo: "r".into(), git_ref: Some("main".into()), subpath: None };
+        let discovered = discover_and_import(&source, &fetcher).unwrap();
+        let root = discovered.iter().find(|s| s.name == "root").expect("root skill");
+        // Root skill keeps its sibling assets ...
+        assert!(root.files.contains_key("scripts/run.sh"));
+        // ... but does not vacuum the nested skill's tree.
+        assert!(!root.files.keys().any(|k| k.contains("nested")));
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_skill/model.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_skill/model.rs
@@ -40,6 +40,14 @@ pub(super) struct ResolvedSkillEntry {
     pub(super) artifact: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) definition: Option<SkillDefinition>,
+    /// Where the skill was imported from (e.g. `owner/repo@ref` for a GitHub
+    /// install). `None` for registry-resolved installs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) origin: Option<String>,
+    /// The detected source skill format the importer normalized from
+    /// (`anthropic-agent-skill`, `animus-native`). `None` for registry installs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) format: Option<String>,
 }
 
 fn compare_versions_desc(left: &str, right: &str) -> Ordering {

--- a/crates/orchestrator-config/src/skill_scoping.rs
+++ b/crates/orchestrator-config/src/skill_scoping.rs
@@ -116,6 +116,13 @@ struct MarkdownSkillFrontmatter {
     description: Option<String>,
     #[serde(default)]
     version: Option<String>,
+    /// Anthropic "Agent Skills" tool permission list. Accepts the canonical
+    /// hyphenated `allowed-tools` and the underscored `allowed_tools` variant
+    /// some hosts emit. Mapped to `SkillDefinition.tool_policy.allow` during
+    /// import (the genuine tool-permission field) unless the `animus:`
+    /// namespace already declares an explicit `tool_policy`.
+    #[serde(default, alias = "allowed_tools", rename = "allowed-tools")]
+    allowed_tools: Option<AllowedTools>,
     #[serde(default)]
     metadata: MarkdownSkillMetadata,
     /// Animus-specific runtime configuration. Only fields nested under the
@@ -131,6 +138,26 @@ struct MarkdownSkillFrontmatter {
 struct MarkdownSkillMetadata {
     #[serde(default)]
     version: Option<String>,
+}
+
+/// `allowed-tools` in the Anthropic "Agent Skills" standard is loosely typed:
+/// some skills write a YAML sequence, others a single comma-separated string.
+/// Accept both and normalize to a `Vec<String>`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum AllowedTools {
+    List(Vec<String>),
+    Csv(String),
+}
+
+impl AllowedTools {
+    fn into_vec(self) -> Vec<String> {
+        let raw = match self {
+            AllowedTools::List(items) => items,
+            AllowedTools::Csv(value) => value.split(',').map(str::to_string).collect(),
+        };
+        raw.into_iter().map(|item| item.trim().to_string()).filter(|item| !item.is_empty()).collect()
+    }
 }
 
 /// Vendor-namespaced runtime config inside SKILL.md frontmatter (Phase 3).
@@ -532,6 +559,71 @@ fn markdown_skill_default_name(path: &Path) -> String {
     candidate.filter(|name| !name.trim().is_empty()).unwrap_or("unknown").to_string()
 }
 
+/// The skill format an imported `SKILL.md` was recognized as. Recorded as
+/// install provenance so `skill list` / `skill info` show where a normalized
+/// skill came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectedSkillFormat {
+    /// Already an Animus-native skill: the frontmatter carries an `animus:`
+    /// runtime namespace. Imported as-is (the body still becomes `system`).
+    AnimusNative,
+    /// Anthropic "Agent Skills" `SKILL.md` (also the lingua franca for Claude
+    /// Code, Hermes, OpenClaw, ...): `name` + `description` frontmatter with the
+    /// instructions in the markdown body. `allowed-tools` maps to
+    /// `tool_policy.allow`, the body maps to `system`.
+    AnthropicAgentSkill,
+}
+
+impl DetectedSkillFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DetectedSkillFormat::AnimusNative => "animus-native",
+            DetectedSkillFormat::AnthropicAgentSkill => "anthropic-agent-skill",
+        }
+    }
+}
+
+/// Parse a `SKILL.md` (or animus markdown skill) into a `SkillDefinition`,
+/// also reporting which foreign/native format it was recognized as.
+///
+/// Detection: a frontmatter that declares an `animus:` runtime namespace is
+/// treated as Animus-native (its structural fields flow through unmapped). Any
+/// other recognizable SKILL.md is imported under Anthropic "Agent Skills"
+/// semantics — the markdown body is the instruction source (`prompt.system`)
+/// and `allowed-tools` becomes `tool_policy.allow`. A file with neither a
+/// `name` nor a non-empty body is rejected as not a recognizable skill.
+pub fn import_skill_definition(content: &str, default_name: &str) -> Result<(SkillDefinition, DetectedSkillFormat)> {
+    let normalized = content.replace("\r\n", "\n");
+    let normalized = normalized.trim_start_matches('\u{feff}');
+    let (frontmatter, body) = split_markdown_frontmatter(normalized);
+    let metadata = match frontmatter {
+        Some(frontmatter) => serde_yaml::from_str::<MarkdownSkillFrontmatter>(frontmatter)?,
+        None => MarkdownSkillFrontmatter::default(),
+    };
+    let prompt_body = body.trim();
+    let has_name = metadata.name.as_deref().is_some_and(|value| !value.trim().is_empty());
+    let format = if metadata.animus.is_some() {
+        DetectedSkillFormat::AnimusNative
+    } else {
+        DetectedSkillFormat::AnthropicAgentSkill
+    };
+
+    // Reject content that resolves to neither an explicit name nor any
+    // instructions: there is nothing recognizable to import.
+    if !has_name && prompt_body.is_empty() {
+        anyhow::bail!(
+            "unsupported skill format: no `name` frontmatter and no instruction body found (expected an Anthropic/Animus SKILL.md)"
+        );
+    }
+
+    // Import does NOT enforce the strict animus name rules (no whitespace,
+    // slug shape). Foreign "Agent Skills" legitimately use display names like
+    // "PDF Processing"; the install caller normalizes the name to a safe slug
+    // afterwards. Skipping validation here lets such names import cleanly.
+    let skill = build_skill_from_markdown(metadata, prompt_body, default_name, false)?;
+    Ok((skill, format))
+}
+
 pub fn parse_markdown_skill_definition(content: &str, default_name: &str) -> Result<SkillDefinition> {
     let normalized = content.replace("\r\n", "\n");
     let normalized = normalized.trim_start_matches('\u{feff}');
@@ -540,12 +632,31 @@ pub fn parse_markdown_skill_definition(content: &str, default_name: &str) -> Res
         Some(frontmatter) => serde_yaml::from_str::<MarkdownSkillFrontmatter>(frontmatter)?,
         None => MarkdownSkillFrontmatter::default(),
     };
+    build_skill_from_markdown(metadata, body.trim(), default_name, true)
+}
 
+fn build_skill_from_markdown(
+    metadata: MarkdownSkillFrontmatter,
+    prompt_body: &str,
+    default_name: &str,
+    validate: bool,
+) -> Result<SkillDefinition> {
     let name =
         metadata.name.as_deref().map(str::trim).filter(|value| !value.is_empty()).unwrap_or(default_name).to_string();
     let description = metadata.description.unwrap_or_default().trim().to_string();
-    let prompt_body = body.trim();
     let animus = metadata.animus.unwrap_or_default();
+
+    // Map Anthropic `allowed-tools` to the genuine tool-permission field
+    // (`tool_policy.allow`). An explicit `animus.tool_policy` always wins so a
+    // native skill never has its policy silently rewritten by a stray
+    // `allowed-tools` key.
+    let tool_policy = animus.tool_policy.or_else(|| {
+        metadata
+            .allowed_tools
+            .map(AllowedTools::into_vec)
+            .filter(|allow| !allow.is_empty())
+            .map(|allow| crate::AgentToolPolicy { allow, deny: Vec::new() })
+    });
 
     let skill = SkillDefinition {
         name,
@@ -559,7 +670,7 @@ pub fn parse_markdown_skill_definition(content: &str, default_name: &str) -> Res
             suffix: None,
             directives: Vec::new(),
         },
-        tool_policy: animus.tool_policy,
+        tool_policy,
         model: animus.model,
         mcp_servers: animus.mcp_servers,
         timeout_secs: animus.timeout_secs,
@@ -570,7 +681,9 @@ pub fn parse_markdown_skill_definition(content: &str, default_name: &str) -> Res
         adapters: animus.adapters,
         tags: animus.tags,
     };
-    validate_skill_definition(&skill)?;
+    if validate {
+        validate_skill_definition(&skill)?;
+    }
     Ok(skill)
 }
 
@@ -1174,6 +1287,74 @@ mod tests {
     fn write_manifest_yaml(dir: &Path, filename: &str, content: &str) {
         fs::create_dir_all(dir).unwrap();
         fs::write(dir.join(filename), content).unwrap();
+    }
+
+    #[test]
+    fn import_anthropic_skill_maps_body_to_system_and_allowed_tools_to_policy() {
+        let content = "---\nname: pdf-helper\ndescription: Work with PDF files\nallowed-tools:\n  - Read\n  - Bash\n---\n\nUse pdftotext to extract text.\nThen summarize it.\n";
+        let (skill, format) = import_skill_definition(content, "fallback").expect("import");
+        assert_eq!(format, DetectedSkillFormat::AnthropicAgentSkill);
+        assert_eq!(skill.name, "pdf-helper");
+        assert_eq!(skill.description, "Work with PDF files");
+        // The markdown BODY becomes the instruction prompt.
+        assert_eq!(skill.prompt.system.as_deref(), Some("Use pdftotext to extract text.\nThen summarize it."));
+        // `allowed-tools` becomes the tool-permission allow-list.
+        let policy = skill.tool_policy.expect("allowed-tools should map to a tool_policy");
+        assert_eq!(policy.allow, vec!["Read".to_string(), "Bash".to_string()]);
+        assert!(policy.deny.is_empty());
+    }
+
+    #[test]
+    fn import_anthropic_allowed_tools_accepts_comma_separated_string() {
+        let content = "---\nname: csv-skill\ndescription: x\nallowed-tools: Read, Grep , Bash\n---\n\nbody\n";
+        let (skill, _) = import_skill_definition(content, "fallback").expect("import");
+        let policy = skill.tool_policy.expect("policy");
+        assert_eq!(policy.allow, vec!["Read".to_string(), "Grep".to_string(), "Bash".to_string()]);
+    }
+
+    #[test]
+    fn import_animus_native_skill_is_detected_and_not_remapped() {
+        let content = "---\nname: native\ndescription: native skill\nanimus:\n  tool_policy:\n    allow: [\"task.*\"]\n    deny: [\"task.delete\"]\n  model:\n    preferred: claude-sonnet-4-6\n---\n\nNative body becomes system.\n";
+        let (skill, format) = import_skill_definition(content, "fallback").expect("import");
+        assert_eq!(format, DetectedSkillFormat::AnimusNative);
+        assert_eq!(skill.prompt.system.as_deref(), Some("Native body becomes system."));
+        let policy = skill.tool_policy.expect("native policy preserved");
+        assert_eq!(policy.allow, vec!["task.*".to_string()]);
+        assert_eq!(policy.deny, vec!["task.delete".to_string()]);
+        assert_eq!(skill.model.preferred.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn import_animus_namespace_tool_policy_wins_over_allowed_tools() {
+        let content = "---\nname: both\ndescription: x\nallowed-tools:\n  - Read\nanimus:\n  tool_policy:\n    allow: [\"task.*\"]\n---\n\nbody\n";
+        let (skill, format) = import_skill_definition(content, "fallback").expect("import");
+        assert_eq!(format, DetectedSkillFormat::AnimusNative);
+        assert_eq!(skill.tool_policy.expect("policy").allow, vec!["task.*".to_string()]);
+    }
+
+    #[test]
+    fn import_rejects_content_with_no_name_and_empty_body() {
+        let content = "---\ndescription: only a description\n---\n\n   \n";
+        let err = import_skill_definition(content, "fallback").expect_err("should reject");
+        assert!(err.to_string().contains("unsupported skill format"), "got: {err}");
+    }
+
+    #[test]
+    fn import_accepts_display_name_with_whitespace() {
+        // Anthropic skills commonly use display names with spaces; import must
+        // not reject them (the install caller slugifies afterwards).
+        let content = "---\nname: PDF Processing\ndescription: x\n---\n\nbody\n";
+        let (skill, _) = import_skill_definition(content, "fallback").expect("import");
+        assert_eq!(skill.name, "PDF Processing");
+    }
+
+    #[test]
+    fn import_anthropic_without_frontmatter_keeps_body_and_default_name() {
+        let content = "Just an instruction body, no frontmatter at all.\n";
+        let (skill, format) = import_skill_definition(content, "my-skill").expect("import");
+        assert_eq!(format, DetectedSkillFormat::AnthropicAgentSkill);
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.prompt.system.as_deref(), Some("Just an instruction body, no frontmatter at all."));
     }
 
     #[test]

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -926,6 +926,79 @@ animus skill create --name rust-tips --description "Rust guidance" --prompt-file
 animus skill create --name pr-reviewer --description "v2" --prompt "..." --force
 ```
 
+### `animus skill install`
+
+Install a skill from a local path, a registry, or a GitHub-hosted source. The
+GitHub form **imports and normalizes** any Anthropic "Agent Skills"
+`SKILL.md` — the same standard used by Claude Code, Hermes, OpenClaw, and
+others — into an Animus skill before installing it.
+
+| Flag | Description |
+|---|---|
+| `<SOURCE>` (positional) or `--github <SOURCE>` | GitHub-hosted skill to import. Mutually exclusive with `--path`/`--name` |
+| `--path <PATH>` | Install a local Markdown skill file, skill folder, or directory of skill folders |
+| `--name <NAME>` | Resolve and install a named skill from the registry catalog |
+| `--version <REQ>` | Optional semver constraint (registry installs) |
+| `--source <SOURCE>` / `--registry <ID>` | Optional registry constraints |
+| `--allow-prerelease` | Allow pre-release versions during registry resolution |
+
+Accepted GitHub source shapes:
+
+- `OWNER/REPO` and `OWNER/REPO@REF` (branch, tag, or commit sha)
+- `https://github.com/OWNER/REPO[.git]`
+- `https://github.com/OWNER/REPO/tree/<ref>/<subpath>`
+- `https://github.com/OWNER/REPO/blob/<ref>/<path>/SKILL.md`
+- raw `https://raw.githubusercontent.com/OWNER/REPO/<ref>/<path>/SKILL.md`
+
+The `<ref>` may be a branch, tag, or commit sha; it is resolved to a commit sha
+before fetching so refs work even on private-default-branch repos. A branch name
+that itself contains `/` (e.g. `feature/foo`) is ambiguous inside a
+`/tree/<ref>/<path>` URL — use the unambiguous `OWNER/REPO@feature/foo` slug
+form for those.
+
+Discovery: a subpath pointing at a single `SKILL.md` (or its folder) installs
+that one skill; a directory containing multiple `skills/<name>/SKILL.md`
+folders installs every skill found. Bundled `scripts/`, `references/`, and
+other assets next to a `SKILL.md` are downloaded alongside it so the
+instructions' relative references resolve.
+
+Supported formats and the import mapping:
+
+- **Anthropic "Agent Skills" `SKILL.md`** (the primary target, shared by Claude
+  Code / Hermes / OpenClaw): frontmatter `name` → skill name, `description` →
+  description, `allowed-tools` → the Animus `tool_policy.allow` permission
+  list, and the **markdown body becomes the Animus `system` prompt** (this is
+  where the instructions live). Model/agent routing stays at Animus defaults.
+- **Animus-native `SKILL.md`** (frontmatter carries an `animus:` runtime
+  namespace): installed as-is — its explicit `tool_policy`, `model`, adapters,
+  etc. flow through unchanged and are never overwritten by a stray
+  `allowed-tools` key.
+
+Detection picks Animus-native when an `animus:` namespace is present; otherwise
+the file is imported under Anthropic semantics (non-empty body as instructions).
+Content with neither a `name` nor an instruction body is rejected with an
+"unsupported skill format" error.
+
+Each installed GitHub skill records provenance — its `origin` (`OWNER/REPO@ref`)
+and detected `format` (`anthropic-agent-skill` or `animus-native`) — surfaced by
+`animus skill list` and `animus skill info`. Public repos only; set
+`GITHUB_TOKEN` to lift API rate limits.
+
+```bash
+# Import a whole repo of skills (e.g. Anthropic's skills repo)
+animus skill install anthropics/skills
+
+# One skill folder at a tag (positional source or --github)
+animus skill install anthropics/skills@v1.0.0
+animus skill install --github https://github.com/anthropics/skills/tree/main/document-skills/pdf
+
+# A single raw SKILL.md
+animus skill install https://raw.githubusercontent.com/owner/repo/main/skills/foo/SKILL.md
+
+# Local install (unchanged)
+animus skill install --path ./my-skill
+```
+
 ### `animus logs tail`
 
 Tail recent persisted log entries from the active log storage backend. This is


### PR DESCRIPTION
`animus skill install <github>` imports & normalizes any GitHub-hosted Anthropic "Agent Skills" SKILL.md (the standard Claude Code / Hermes / OpenClaw share) into an Animus skill.

- **Source forms**: `OWNER/REPO[@ref]`, repo/`tree`/`blob` URLs, raw SKILL.md URLs (ref → commit sha first).
- **Import mapping**: frontmatter `animus:` → native passthrough; otherwise Anthropic — `name`/`description` map over, **markdown body → `prompt.system`**, `allowed-tools` → `tool_policy.allow`. Foreign names slugified to a safe segment (path-traversal-safe).
- **Multi-skill repos**: discovers a single SKILL.md/folder or a `skills/<name>/SKILL.md` tree; downloads SKILL.md + sibling assets preserving layout.
- **Provenance**: `installed` snapshot under reserved source `github-import` (origin `OWNER/REPO@ref` + detected format); shown by `skill list`/`info`; `update --all` skips imports.
- Installs through the same path-install pipeline; network behind a `RepoFetcher` trait (all parse/discover/import unit-tested).

## Verification (main loop)
- fmt ✅, clippy clean ✅, `cargo test skill` → 83 (cli) + 96 (config) ✅
- Codex self-vet: 4 rounds, P1-clear (round-1 path-traversal P1 fixed). One deferred P2 (truncated-monorepo `/tree/` subpath — TODO).

Pairs with the portal Skills view's "install from GitHub link". Needs a live install against a public Anthropic-format repo to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)