### PR TITLE
release: v0.6.8 — install Agent Skills from GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-06-22
+
+**v0.6.8 — install Agent Skills from GitHub.**
+
+- `animus skill install <github>` imports & normalizes any GitHub-hosted Anthropic
+  "Agent Skills" `SKILL.md` (the standard Claude Code / Hermes / OpenClaw share)
+  into an Animus skill. Source forms: `OWNER/REPO[@ref]`, repo/`tree`/`blob` URLs,
+  raw `SKILL.md` URLs. Format detection: `animus:` frontmatter → native passthrough;
+  otherwise Anthropic semantics — `name`/`description` map over, the markdown BODY
+  → `prompt.system`, `allowed-tools` → `tool_policy.allow`. Handles single skills
+  and `skills/<name>/SKILL.md` trees (downloads sibling assets). Foreign names are
+  slugified (path-traversal-safe); provenance recorded under the `github-import`
+  source (origin + format), shown by `skill list`/`info`.
+
 ## [0.6.7] - 2026-06-22
 
 **v0.6.7 — platform-aware plugin lock + resident config_source.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Cuts v0.6.8. Bumps orchestrator-cli 0.6.7→0.6.8 + CHANGELOG. Ships `animus skill install <github>` (#268). Merging fires auto-tag-release → v0.6.8 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)