### PR TITLE
chore: core providers use ACP / proper transports by default

### DIFF
--- a/crates/orchestrator-cli/config/default-install.json
+++ b/crates/orchestrator-cli/config/default-install.json
@@ -43,8 +43,8 @@
         "tag": "v0.2.7"
       },
       {
-        "repo": "launchapp-dev/animus-provider-codex",
-        "tag": "v0.2.8"
+        "repo": "launchapp-dev/animus-provider-codex-mcp",
+        "tag": "v0.1.0"
       },
       {
         "repo": "launchapp-dev/animus-provider-oai-agent",

--- a/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
@@ -8631,7 +8631,7 @@ description = "Manifest-resolution test fixture."
 
 [providers]
 required = ["launchapp-dev/animus-provider-claude"]
-recommended = ["launchapp-dev/animus-provider-codex", "launchapp-dev/animus-provider-ollama"]
+recommended = ["launchapp-dev/animus-provider-codex-mcp", "launchapp-dev/animus-provider-ollama"]
 
 [subjects]
 required = ["launchapp-dev/animus-subject-default", "launchapp-dev/animus-subject-requirements"]
@@ -8690,7 +8690,7 @@ required = ["launchapp-dev/animus-queue-default"]
         args.include_recommended = true;
         let targets = build_install_defaults_targets(&args, &tmp.path().to_string_lossy()).unwrap();
         let slugs = target_slugs(&targets);
-        assert!(slugs.contains(&"launchapp-dev/animus-provider-codex"), "got: {slugs:?}");
+        assert!(slugs.contains(&"launchapp-dev/animus-provider-codex-mcp"), "got: {slugs:?}");
         assert!(slugs.contains(&"launchapp-dev/animus-subject-linear"), "got: {slugs:?}");
         assert!(slugs.contains(&"launchapp-dev/animus-transport-graphql"), "got: {slugs:?}");
         assert!(slugs.contains(&"launchapp-dev/animus-web-ui"), "got: {slugs:?}");
@@ -8713,7 +8713,7 @@ required = ["launchapp-dev/animus-queue-default"]
         assert!(slugs.contains(&"launchapp-dev/animus-transport-graphql"), "got: {slugs:?}");
         assert!(slugs.contains(&"launchapp-dev/animus-web-ui"), "got: {slugs:?}");
         assert!(
-            !slugs.contains(&"launchapp-dev/animus-provider-codex"),
+            !slugs.contains(&"launchapp-dev/animus-provider-codex-mcp"),
             "--include-subjects/--include-transports must not pull in recommended providers: {slugs:?}"
         );
         let unique: std::collections::HashSet<&str> = slugs.iter().copied().collect();

--- a/crates/orchestrator-core/src/plugin_registry.rs
+++ b/crates/orchestrator-core/src/plugin_registry.rs
@@ -18,9 +18,12 @@
 /// `at_least_one_provider`.
 pub const DEFAULT_PROVIDER_PLUGINS: &[(&str, &str)] = &[
     ("launchapp-dev/animus-provider-claude", "v0.2.8"),
-    ("launchapp-dev/animus-provider-codex", "v0.2.3"),
+    // Codex is driven over MCP (`codex mcp-server`) by animus-provider-codex-mcp,
+    // which advertises provider_tool = "codex" (drop-in for the old stdout
+    // provider). Gemini + OpenCode drive their harnesses over ACP internally.
+    ("launchapp-dev/animus-provider-codex-mcp", "v0.1.0"),
     ("launchapp-dev/animus-provider-gemini", "v0.3.0"),
-    ("launchapp-dev/animus-provider-opencode", "v0.2.6"),
+    ("launchapp-dev/animus-provider-opencode", "v0.3.0"),
     ("launchapp-dev/animus-provider-oai", "v0.2.2"),
 ];
 

--- a/crates/orchestrator-core/src/plugin_registry.rs
+++ b/crates/orchestrator-core/src/plugin_registry.rs
@@ -19,7 +19,7 @@
 pub const DEFAULT_PROVIDER_PLUGINS: &[(&str, &str)] = &[
     ("launchapp-dev/animus-provider-claude", "v0.2.8"),
     ("launchapp-dev/animus-provider-codex", "v0.2.3"),
-    ("launchapp-dev/animus-provider-gemini", "v0.2.6"),
+    ("launchapp-dev/animus-provider-gemini", "v0.3.0"),
     ("launchapp-dev/animus-provider-opencode", "v0.2.6"),
     ("launchapp-dev/animus-provider-oai", "v0.2.2"),
 ];

--- a/flavors/default.toml
+++ b/flavors/default.toml
@@ -6,7 +6,7 @@ description = "Curated bundle for solo founders and small studios running a port
 
 [providers]
 required = ["launchapp-dev/animus-provider-claude"]
-recommended = ["launchapp-dev/animus-provider-codex", "launchapp-dev/animus-provider-ollama"]
+recommended = ["launchapp-dev/animus-provider-codex-mcp", "launchapp-dev/animus-provider-ollama"]
 
 # Both subject backends are required: daemon preflight refuses to start
 # unless `subject_kind:task` AND `subject_kind:requirement` are covered.


### PR DESCRIPTION
Completes the core-provider sweep: each provider now drives its harness properly instead of scraping stdout.

- **gemini** → v0.3.0 (`gemini --acp` over ACP) — validated end-to-end
- **opencode** → v0.3.0 (`opencode acp` over ACP)
- **codex** → `animus-provider-codex-mcp` v0.1.0 (`codex mcp-server` over MCP; advertises `provider_tool=codex`, drop-in)
- **claude / oai** → unchanged (native session JSON + approval hook / direct API)

`provider_tool` ids are unchanged, so kernel model→provider routing is identical; ACP/MCP is an internal transport detail. Touches `DEFAULT_PROVIDER_PLUGINS`, `default-install.json`, `flavors/default.toml`. Core+cli tests green (excl. 3 pre-existing oai-alias `auto_resume` failures that also fail on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)