### PR TITLE
release: v0.6.9 — .env secret sync, oai resume fix, version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/operations/ops_manifest.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_manifest.rs
@@ -94,12 +94,35 @@ pub(crate) async fn handle_manifest_install(args: InstallArgs, project_root: &st
             install_pack_dep(id, dep, root, false)
                 .with_context(|| format!("--locked: failed to install declared pack '{id}'"))?;
         }
+        // Provision secrets from `.env` (best-effort) so a container's
+        // `animus install --locked` brings up secrets too. CI usually injects
+        // secrets via the environment instead; a missing `.env` is a no-op.
+        let locked_secrets = super::ops_secret::sync_project_env_secrets(root, false);
+        if !json {
+            if let Ok(summary) = &locked_secrets {
+                if !summary.imported.is_empty() {
+                    println!("Provisioned {} secret(s) from .env", summary.imported.len());
+                }
+                if !summary.missing_declared.is_empty() {
+                    println!(
+                        "Secrets declared in .env.example but not set: {} — add them to .env or `animus secret set <KEY>`.",
+                        summary.missing_declared.join(", ")
+                    );
+                }
+            }
+        }
         // A pack-only manifest has no plugin pins to reproduce — the plugin
         // locked installer would error on an empty/missing plugins.lock, so
         // skip it.
         if manifest.plugins.is_empty() {
+            let secrets_value = match &locked_secrets {
+                Ok(s) => {
+                    json!({ "imported": s.imported, "skipped": s.skipped, "missing_declared": s.missing_declared })
+                }
+                Err(err) => json!({ "error": err.to_string() }),
+            };
             return print_value(
-                json!({ "schema": "animus.install.v1", "locked": true, "plugins": [], "packs": manifest.packs.len() }),
+                json!({ "schema": "animus.install.v1", "locked": true, "plugins": [], "packs": manifest.packs.len(), "secrets": secrets_value }),
                 json,
             );
         }
@@ -145,6 +168,20 @@ pub(crate) async fn handle_manifest_install(args: InstallArgs, project_root: &st
         }
     }
 
+    // Provision secrets from `.env` into the device store and report keys
+    // declared in `.env.example` that are still unset — the last leg of the
+    // `git clone && animus install` onboarding flow. Best-effort: a secret
+    // backend error must not fail the install (plugins/packs already landed).
+    let secrets = super::ops_secret::sync_project_env_secrets(root, false);
+    let secrets_value = match &secrets {
+        Ok(summary) => json!({
+            "imported": summary.imported,
+            "skipped": summary.skipped,
+            "missing_declared": summary.missing_declared,
+        }),
+        Err(err) => json!({ "error": err.to_string() }),
+    };
+
     let failed = plugin_rows.iter().chain(pack_rows.iter()).filter(|row| row["status"] == "failed").count();
     print_value(
         json!({
@@ -152,10 +189,25 @@ pub(crate) async fn handle_manifest_install(args: InstallArgs, project_root: &st
             "manifest": project_manifest_path(root).display().to_string(),
             "plugins": plugin_rows,
             "packs": pack_rows,
+            "secrets": secrets_value,
             "failed": failed,
         }),
         json,
     )?;
+    // Surface unset declared keys as an actionable, non-fatal hint.
+    if !json {
+        if let Ok(summary) = &secrets {
+            if !summary.imported.is_empty() {
+                println!("Provisioned {} secret(s) from .env", summary.imported.len());
+            }
+            if !summary.missing_declared.is_empty() {
+                println!(
+                    "Secrets declared in .env.example but not set: {} — add them to .env (then re-run `animus install`) or `animus secret set <KEY>`.",
+                    summary.missing_declared.join(", ")
+                );
+            }
+        }
+    }
     // Fail the command (non-zero exit) when any dependency failed — critical
     // for the documented CI / container `animus install [--locked]` use case.
     if failed > 0 {

--- a/crates/orchestrator-cli/src/services/operations/ops_secret.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_secret.rs
@@ -172,6 +172,98 @@ mod migrate_tests {
     }
 }
 
+/// Summary of an `.env` -> secret-store sync (the `animus install` provisioning
+/// step). `missing_declared` are keys declared (uncommented) in `.env.example`
+/// that are neither in `.env` nor already stored — i.e. what the operator still
+/// needs to supply.
+#[derive(Debug, Default, serde::Serialize)]
+pub(crate) struct EnvSyncSummary {
+    pub(crate) env_present: bool,
+    pub(crate) imported: Vec<String>,
+    pub(crate) skipped: Vec<String>,
+    pub(crate) missing_declared: Vec<String>,
+}
+
+/// Provision project secrets from `.env` into the device-encrypted store and
+/// report keys declared in `.env.example` that are still unset. Idempotent:
+/// keys already present are skipped unless `overwrite`. A missing `.env` is a
+/// no-op (still reports `.env.example` gaps). Used by `animus install` so a
+/// fresh `git clone && animus install` provisions secrets; commented example
+/// keys are NOT treated as declared, so the scaffolded `.env.example` produces
+/// no false "missing" noise until a project uncomments real keys.
+pub(crate) fn sync_project_env_secrets(project_root: &Path, overwrite: bool) -> Result<EnvSyncSummary> {
+    let store = build_store(project_root)?;
+    let summary = sync_env_secrets_into(store.as_ref(), project_root, overwrite)?;
+    // Record an audit event for install-time secret provisioning, mirroring the
+    // trail emitted by `secret set` / `import-env` / `rm` / `migrate` so
+    // install-time mutations are not invisible to audit-log consumers.
+    if !summary.imported.is_empty() {
+        if let Some(scoped_root) = scoped_state_root(project_root) {
+            let actor = resolve_actor(None);
+            log_secret_event(
+                &scoped_root,
+                &actor,
+                AuditEventKind::PolicyOverride,
+                "secret_import_env",
+                "*",
+                Some(json!({ "source": ".env", "imported": summary.imported.len(), "via": "install" })),
+            );
+        }
+    }
+    Ok(summary)
+}
+
+/// Store-bound core of [`sync_project_env_secrets`], split out so tests can
+/// drive it with a `MockSecretStore`.
+fn sync_env_secrets_into(store: &dyn SecretStore, project_root: &Path, overwrite: bool) -> Result<EnvSyncSummary> {
+    let mut have: std::collections::BTreeSet<String> = store.list_keys()?.into_iter().collect();
+
+    let env_path = project_root.join(".env");
+    let env_present = env_path.exists();
+    let mut imported = Vec::new();
+    let mut skipped = Vec::new();
+    if env_present {
+        let body = fs::read_to_string(&env_path).with_context(|| format!("failed to read {}", env_path.display()))?;
+        for (key, value) in parse_dotenv(&body)? {
+            if validate_secret_key(&key).is_err() {
+                skipped.push(key);
+                continue;
+            }
+            // A blank `KEY=` (the unfilled `.env.example` shape) must NOT be
+            // stored as an empty secret — that would mask the key as "present"
+            // and leave a credential set to "". Skip it and leave it to surface
+            // in `missing_declared` instead (mirrors `secret set` refusing empty).
+            if value.is_empty() {
+                skipped.push(key);
+                continue;
+            }
+            if have.contains(&key) && !overwrite {
+                skipped.push(key);
+                continue;
+            }
+            store.set(&key, &value)?;
+            have.insert(key.clone());
+            imported.push(key);
+        }
+    }
+
+    // Declared keys = uncommented `KEY=` lines in `.env.example`. `parse_dotenv`
+    // skips comments, so the scaffold's commented examples count as nothing.
+    let mut missing_declared = Vec::new();
+    let example_path = project_root.join(".env.example");
+    if example_path.exists() {
+        let body =
+            fs::read_to_string(&example_path).with_context(|| format!("failed to read {}", example_path.display()))?;
+        for (key, _value) in parse_dotenv(&body)? {
+            if !have.contains(&key) && !missing_declared.contains(&key) {
+                missing_declared.push(key);
+            }
+        }
+    }
+
+    Ok(EnvSyncSummary { env_present, imported, skipped, missing_declared })
+}
+
 /// Store one project-scoped secret in the OS keychain, with the same
 /// validation and audit logging as `animus secret set`. Used by the
 /// `animus init` walkthrough to migrate detected env-var API keys after
@@ -647,6 +739,55 @@ use std::collections::BTreeMap as _BTreeMap;
 mod tests {
     use super::*;
     use orchestrator_core::MockSecretStore;
+
+    #[test]
+    fn sync_env_imports_new_skips_present_and_reports_missing_declared() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "ALPHA_KEY=1\nBETA_KEY=2\n").unwrap();
+        // Declared keys: BETA_KEY (already supplied via .env) + GAMMA_KEY (unset);
+        // the commented DELTA_KEY must NOT count as declared.
+        std::fs::write(dir.path().join(".env.example"), "BETA_KEY=\nGAMMA_KEY=\n# DELTA_KEY=\n").unwrap();
+        // ALPHA_KEY already in the store -> skipped, not overwritten.
+        let store = MockSecretStore::with_entries([("ALPHA_KEY", "old")]);
+
+        let summary = sync_env_secrets_into(&store, dir.path(), false).unwrap();
+
+        assert!(summary.env_present);
+        assert_eq!(summary.imported, vec!["BETA_KEY"], "only the new key is imported");
+        assert!(summary.skipped.contains(&"ALPHA_KEY".to_string()), "already-present key is skipped");
+        assert_eq!(store.get("ALPHA_KEY").unwrap().as_deref(), Some("old"), "existing value preserved");
+        assert_eq!(
+            summary.missing_declared,
+            vec!["GAMMA_KEY"],
+            "declared-but-unset key surfaced; commented one ignored"
+        );
+    }
+
+    #[test]
+    fn sync_env_skips_blank_dotenv_values_and_flags_them_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // A copied-but-unfilled `.env`: real value for ONE key, blank for another.
+        std::fs::write(dir.path().join(".env"), "REAL_KEY=set\nBLANK_KEY=\n").unwrap();
+        std::fs::write(dir.path().join(".env.example"), "REAL_KEY=\nBLANK_KEY=\n").unwrap();
+        let store = MockSecretStore::new();
+
+        let summary = sync_env_secrets_into(&store, dir.path(), false).unwrap();
+
+        assert_eq!(summary.imported, vec!["REAL_KEY"]);
+        assert_eq!(store.get("BLANK_KEY").unwrap(), None, "blank value must not be stored as an empty secret");
+        assert_eq!(summary.missing_declared, vec!["BLANK_KEY"], "blank declared key surfaces as still-missing");
+    }
+
+    #[test]
+    fn sync_env_missing_dotenv_is_noop_but_still_checks_example() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env.example"), "NEEDED_KEY=\n").unwrap();
+        let store = MockSecretStore::new();
+        let summary = sync_env_secrets_into(&store, dir.path(), false).unwrap();
+        assert!(!summary.env_present);
+        assert!(summary.imported.is_empty());
+        assert_eq!(summary.missing_declared, vec!["NEEDED_KEY"]);
+    }
 
     #[test]
     fn parse_dotenv_handles_quoted_and_unquoted_and_comments() {

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -1624,22 +1624,24 @@ mod tests {
         #[test]
         fn restart_resume_finds_oai_plugin_via_canonical_alias_when_checkpoint_says_oai_runner() {
             use super::super::resolve_resume_provider_key;
-            let providers = vec!["oai".to_string()];
+            // Post-PR#249 the legacy `oai-runner` alias canonicalizes to the
+            // agentic `oai-agent` provider (the one-shot is `oai`).
+            let providers = vec!["oai-agent".to_string()];
             assert_eq!(
                 resolve_resume_provider_key(&providers, "oai-runner").as_deref(),
-                Some("oai"),
-                "checkpoint provider 'oai-runner' must canonicalize to installed key 'oai'"
+                Some("oai-agent"),
+                "checkpoint provider 'oai-runner' must canonicalize to installed key 'oai-agent'"
             );
         }
 
         #[test]
         fn restart_resume_finds_oai_plugin_when_checkpoint_says_animus_oai_runner() {
             use super::super::resolve_resume_provider_key;
-            let providers = vec!["oai".to_string()];
+            let providers = vec!["oai-agent".to_string()];
             assert_eq!(
                 resolve_resume_provider_key(&providers, "animus-oai-runner").as_deref(),
-                Some("oai"),
-                "checkpoint provider 'animus-oai-runner' must canonicalize to installed key 'oai'"
+                Some("oai-agent"),
+                "checkpoint provider 'animus-oai-runner' must canonicalize to installed key 'oai-agent'"
             );
         }
 
@@ -1658,11 +1660,11 @@ mod tests {
         #[test]
         fn restart_resume_canonical_alias_lookup_is_case_insensitive() {
             use super::super::resolve_resume_provider_key;
-            let providers = vec!["oai".to_string()];
+            let providers = vec!["oai-agent".to_string()];
             // Mirror the resolver: canonicalization lowercases the input
             // before comparing, so uppercase aliases must still match.
-            assert_eq!(resolve_resume_provider_key(&providers, "OAI-RUNNER").as_deref(), Some("oai"));
-            assert_eq!(resolve_resume_provider_key(&providers, "Animus-OAI-Runner").as_deref(), Some("oai"));
+            assert_eq!(resolve_resume_provider_key(&providers, "OAI-RUNNER").as_deref(), Some("oai-agent"));
+            assert_eq!(resolve_resume_provider_key(&providers, "Animus-OAI-Runner").as_deref(), Some("oai-agent"));
         }
 
         #[test]

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -389,7 +389,9 @@ pins the exact per-platform artifacts. `animus init` scaffolds `animus.toml`,
 
 ```bash
 git clone <repo> && cd <repo>
-animus install            # resolve animus.toml -> lock -> install plugins + packs
+cp .env.example .env && $EDITOR .env   # fill in the project's declared keys
+animus install            # resolve animus.toml -> lock -> install plugins + packs,
+                          # then load .env into the secret store (warns on unset keys)
 # in CI / a container:
 animus install --locked   # reproduce EXACTLY the committed lockfile (npm ci)
 ```
@@ -416,9 +418,13 @@ tag (or the explicit git tag) selects the release, and the lock records the
 installed sha. `animus init` emits explicit `{ git, tag }` pins for the default
 set so the scaffold is fully reproducible.
 
-- `animus install [--locked] [--force]` — resolve + install. `--locked`
-  refuses to proceed if the manifest declares a plugin the lockfile does not
-  pin (run `animus install` without `--locked` to refresh).
+- `animus install [--locked] [--force]` — resolve + install plugins and packs,
+  then **provision secrets from `.env`** into the device-encrypted store
+  (idempotent; keys already set are skipped) and warn about any keys declared
+  (uncommented) in `.env.example` that are still unset. `--locked` refuses to
+  proceed if the manifest declares a plugin the lockfile does not pin (run
+  `animus install` without `--locked` to refresh). A missing `.env` is a no-op,
+  so the secret step never blocks the install.
 - `animus add <spec> [--pack] [--path PATH] [--force]` — `spec` is
   `name[@version]`, `OWNER/REPO@tag`, or a bare `name`. Updates `animus.toml`
   and installs the one dependency. `--pack` targets `[packs]`.


### PR DESCRIPTION
Cuts **v0.6.9**, bundling the npm-experience + ACP-provider work.

**This branch adds:**
- `orchestrator-cli` 0.6.8 → **0.6.9**
- **M2 — `.env` → secrets sync**: `animus install` provisions `.env` into the device-encrypted store (idempotent; blank `KEY=` values skipped, never stored empty; audited) and warns about keys declared (uncommented) in `.env.example` but still unset. Wired into both normal and `--locked` install.
- **Fix 3 stale `auto_resume` tests**: legacy `oai-runner`/`animus-oai-runner` aliases canonicalize to `oai-agent` (post-PR#249), not `oai`. Suite fully green (1212 + new tests).
- Docs: install secret-provisioning + onboarding flow.

**Already on main (ships in this tag):**
- `animus.toml` manifest + `install`/`add`/`remove` (#271)
- Plugin lock = source of truth (#270)
- Core providers driven over ACP/MCP by default (#272): gemini/opencode via ACP, codex via codex-mcp; claude/oai native.

Verified: fmt + clippy clean; full cli suite green; 2 codex review rounds (no P1s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)