### PR TITLE
docs: CHANGELOG 0.6.9/0.6.10 + README avm & animus.toml flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.10] - 2026-06-24
+
+**v0.6.10 — first-party providers install without `--allow-shadow-builtin`.**
+
+- The reserved-provider guard (`enforce_provider_tool_policy`) no longer treats
+  the legitimate first-party plugins as name squatters. A canonical
+  `animus-provider-<reserved>` (claude / codex / gemini / opencode / oai /
+  oai-agent / oai-runner) published by a **built-in trusted publisher**
+  (`launchapp-dev`) is the rightful owner of the name and installs with **no
+  flag**. Untrusted orgs — and `--path` / `--url` installs (owner unknown) —
+  still require `--allow-shadow-builtin`. `enforce_manifest_name_matches_repo`
+  and the org-trust gate still run, so this is not a security loosening.
+- Corrected the misleading "reserved in-tree backend" error wording. These names
+  are reserved so an **untrusted** plugin cannot silently hijack the core
+  provider dispatch path — the providers are **plugins, not compiled into the
+  kernel** (the resolver only resolves to installed plugins; there is no
+  fallback, so the reserved names are an anti-squat guard, not native backends).
+
+## [0.6.9] - 2026-06-24
+
+**v0.6.9 — the npm-style project experience + core providers driven properly.**
+
+- **`animus.toml` project manifest + `install` / `add` / `remove`.** A committed
+  `animus.toml` (`[project]` kernel, `[plugins]`, `[packs]`; deps as a version
+  string, `{ git, tag }`, or `{ path }`) declares intent; `animus install`
+  resolves it into `.animus/plugins.lock` and installs the set. `--locked`
+  reproduces the committed lock exactly (npm-ci) and fails on manifest↔lock
+  drift. `animus add <spec>` / `animus remove <name>` mutate the manifest +
+  install/uninstall. `animus init` scaffolds `animus.toml`, `.env.example`, and
+  a merge-safe project `.gitignore`. Onboarding becomes `git clone && animus
+  install`; a Dockerfile is `animus install --locked`.
+- **Plugin lock = source of truth.** `.animus/plugins.lock` is authoritative; the
+  `plugins.yaml` registry is a derived projection regenerated on every mutating op.
+- **`.env` → secrets sync.** `animus install` provisions secrets from `.env` into
+  the device-encrypted store (idempotent; blank `KEY=` values are skipped, never
+  stored empty; imports are audited) and warns about keys declared (uncommented)
+  in `.env.example` but still unset.
+- **Core providers driven properly by default.** Curated provider defaults now
+  use proper transports instead of stdout scraping: **gemini** + **opencode**
+  drive their CLI over **ACP** (`animus-provider-{gemini,opencode}` v0.3.0, thin
+  wrappers on the shared `animus-provider-acp` client), **codex** over **MCP**
+  (`animus-provider-codex-mcp`). `claude` and `oai` stay native (native session +
+  approval hook / direct API). `provider_tool` ids are unchanged, so kernel
+  model→provider routing is identical — the transport is an internal detail.
+- **Fixed** restart-resume of the legacy `oai-runner` / `animus-oai-runner`
+  aliases: they canonicalize to `oai-agent` (the agentic provider), not `oai`.
+
 ## [0.6.8] - 2026-06-22
 
 **v0.6.8 — install Agent Skills from GitHub.**

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 Open a fresh **Claude Code** (or **Codex** / **OpenCode** / **Cursor**) session and paste this. The agent installs the Animus CLI, clones `animus-skills`, runs the setup script, and adds the project section to `CLAUDE.md` / `AGENTS.md`. You'll be running workflows in about a minute.
 
-> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.6.9` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
+> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.6.10` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
 
 For Codex CLI, swap the clone path to `~/.codex/skills/animus-skills` and edit `AGENTS.md` instead of `CLAUDE.md`.
 
@@ -54,12 +54,36 @@ The upstream installer currently targets macOS. On Linux and Windows, use a rele
 
 The second command is **required in v0.4.12 and later** (and expanded in **v0.5** to include `workflow_runner` and `queue` plugins) — the daemon no longer ships with bundled providers, subject backends, workflow runners, or queue implementations. It will refuse to start until at least one of each required role is installed. The command is idempotent and skips anything already installed. Pass `--include-recommended` to also get the web UI, GraphQL transport, and additional providers.
 
+### Install via avm (version manager, recommended for multi-project machines)
+
+[`avm`](https://github.com/launchapp-dev/avm) pins each project to a specific `animus` kernel version (à la `nvm`/`rustup`) and dispatches transparently: a project's `.animus-version` selects the kernel, with a global default fallback. Running `animus` in any project then uses the right version automatically.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/launchapp-dev/avm/main/install.sh | sh
+avm install v0.6.10            # download a kernel version
+avm use --global v0.6.10       # machine default; per-project: `avm use v0.6.10` writes .animus-version
+```
+
+### Project setup: `animus.toml` (v0.6.10+)
+
+Animus uses an npm/cargo-style manifest. A committed `animus.toml` declares the project's kernel, plugins, and packs; `animus install` resolves it into `.animus/plugins.lock` and installs the set, so onboarding a checked-out project is two commands:
+
+```bash
+git clone <repo> && cd <repo>
+cp .env.example .env && $EDITOR .env   # fill in the project's declared secrets
+animus install                          # plugins + packs from animus.lock, then load .env into the secret store
+# CI / containers: reproduce the lock exactly
+animus install --locked
+```
+
+`animus init` scaffolds `animus.toml`, `.env.example`, and a merge-safe `.gitignore`; `animus add <spec>` / `animus remove <name>` manage dependencies. See [`docs/reference/cli/index.md`](docs/reference/cli/index.md#project-manifest-animustoml-install--add--remove).
+
 <details>
 <summary><kbd>options</kbd></summary>
 
 ```bash
 # Specific version
-ANIMUS_VERSION=v0.6.9 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.6.10 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash


### PR DESCRIPTION
Documents the recent releases: CHANGELOG entries for **0.6.9** (manifest + install/add/remove, lock-as-truth, .env→secrets, ACP/MCP providers, oai resume fix) and **0.6.10** (first-party reserved-name install fix); README gains the **avm** install path and the **animus.toml / animus install** project-setup flow. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)