### PR TITLE
release: v0.6.11 — animus update defers to avm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.11] - 2026-06-24
+
+**v0.6.11 — `animus update` defers to avm.**
+
+- When the running binary is managed by [avm](https://github.com/launchapp-dev/avm)
+  (the Animus Version Manager — it installs kernels under `~/.avm/versions/` and
+  dispatches through an `animus` shim), `animus update` no longer self-replaces
+  the binary (which would corrupt avm's version directory). It now prints the
+  `avm install` / `avm use` commands and exits. Plain installs (`~/.local/bin`,
+  `/usr/local/bin`, Cargo) are unaffected and still self-update.
+- `scripts/install.sh` and the docs now point multi-project users at avm.
+
 ## [0.6.10] - 2026-06-24
 
 **v0.6.10 — first-party providers install without `--allow-shadow-builtin`.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/operations/ops_update.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_update.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::cli_types::{UpdateArgs, UpdateChannelArg};
 use crate::print_value;
 use crate::services::self_update::{
-    resolve_effective_config_block, run_manual_update, ManualUpdateOptions, UpdateOutcome,
+    avm_managed_version, resolve_effective_config_block, run_manual_update, ManualUpdateOptions, UpdateOutcome,
 };
 
 const UPDATE_SCHEMA: &str = "animus.update.cli.v1";
@@ -23,6 +23,33 @@ struct UpdateOutput {
 }
 
 pub(crate) async fn handle_update(args: UpdateArgs, project_root: &str, json: bool) -> Result<()> {
+    // When this binary is managed by avm (the Animus Version Manager), `animus
+    // update` must NOT self-replace it — avm owns kernel versioning under
+    // `~/.avm/versions/<version>/` and dispatches through an `animus` shim.
+    // Overwriting the running binary in place would corrupt avm's version dir.
+    // Defer to avm instead.
+    if let Some(version) = avm_managed_version() {
+        if !json {
+            eprintln!(
+                "animus {version} is managed by avm. Use avm to change versions:\n  \
+                 avm install <version>            # download a kernel\n  \
+                 avm use --global <version>       # set the machine default\n  \
+                 avm use <version>                # pin THIS project (.animus-version)\n  \
+                 avm list --remote                # available release tags"
+            );
+        }
+        return print_value(
+            UpdateOutput {
+                schema: UPDATE_SCHEMA,
+                action: "managed_by_avm",
+                current: version,
+                latest: None,
+                installed: None,
+                channel: "n/a",
+            },
+            json,
+        );
+    }
     let block = resolve_effective_config_block(project_root);
     // `--prerelease` (folded in from the retired `self update`) forces the
     // prerelease channel regardless of `--channel`, matching the documented

--- a/crates/orchestrator-cli/src/services/self_update.rs
+++ b/crates/orchestrator-cli/src/services/self_update.rs
@@ -436,6 +436,26 @@ pub(crate) fn current_binary_path() -> Result<PathBuf> {
     Ok(path.canonicalize().unwrap_or(path))
 }
 
+/// Detect whether the running `animus` binary is managed by avm (the Animus
+/// Version Manager). avm installs kernels under `<AVM_HOME>/versions/<version>/`
+/// and dispatches through an `animus` shim, so a managed binary's `current_exe`
+/// lives under `.avm/versions/`. Both the manual `animus update` path and the
+/// startup auto-update path must refuse to self-replace such a binary, or they
+/// corrupt avm's version directory. Returns the managed version when detected.
+pub(crate) fn avm_managed_version() -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    avm_version_from_exe_path(exe.to_string_lossy().as_ref())
+}
+
+/// Pure path heuristic, split out for testing: extract the avm-managed version
+/// segment from an `animus` executable path (`.../.avm/versions/<version>/...`).
+pub(crate) fn avm_version_from_exe_path(exe_path: &str) -> Option<String> {
+    const MARKER: &str = "/.avm/versions/";
+    let idx = exe_path.find(MARKER)?;
+    let version = exe_path[idx + MARKER.len()..].split('/').next().unwrap_or_default();
+    (!version.is_empty()).then(|| version.to_string())
+}
+
 /// Decision returned by [`should_check_now`] — drives the startup flow.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StartupAction {
@@ -650,6 +670,17 @@ pub async fn run_manual_update(
 /// Download, verify, and atomically install the chosen release for the
 /// running host.
 pub async fn apply_update(release: &GithubReleaseRecord) -> Result<()> {
+    // Never self-replace an avm-managed binary — that would overwrite a file
+    // under `~/.avm/versions/<version>/` and corrupt avm's version directory.
+    // This guards BOTH the manual `animus update` path and the startup
+    // auto-update path (which both funnel through here). Use `avm install` /
+    // `avm use` to change versions instead.
+    if let Some(version) = avm_managed_version() {
+        anyhow::bail!(
+            "refusing to self-update an avm-managed animus ({version}); avm owns kernel \
+             versioning. Use `avm install <version>` then `avm use --global <version>` instead."
+        );
+    }
     let platform = current_platform_token();
     let asset = pick_asset_for_host(&release.assets, &platform).ok_or_else(|| {
         anyhow!(
@@ -785,6 +816,14 @@ pub async fn run_startup_check(
     current_version: String,
     state: AutoUpdateState,
 ) -> Result<Option<String>> {
+    // avm-managed binaries are versioned by avm, not by animus' self-updater.
+    // Skip the whole startup check (no network call, no `apply_update` bail) so
+    // an avm install never tries — and never nags — to self-update. Use
+    // `avm install` / `avm use` to change versions.
+    if avm_managed_version().is_some() {
+        return Ok(None);
+    }
+
     let mode = effective_mode(config_block.as_ref());
     if matches!(mode, AutoUpdateMode::Off) {
         return Ok(None);
@@ -866,6 +905,16 @@ pub async fn run_startup_check(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detects_avm_managed_binary_from_exe_path() {
+        // avm-managed: <home>/.avm/versions/<version>/animus — extract the version.
+        assert_eq!(avm_version_from_exe_path("/.avm/versions/v0.6.10/animus").as_deref(), Some("v0.6.10"));
+        // Plain installs (Cargo bin, ~/.local/bin, /usr/local/bin) are not managed.
+        assert_eq!(avm_version_from_exe_path("/usr/local/bin/animus"), None);
+        // The avm shim itself isn't a versioned install dir.
+        assert_eq!(avm_version_from_exe_path("/.avm/shims/animus"), None);
+    }
 
     fn current() -> &'static str {
         "0.5.3"

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -339,7 +339,7 @@ animus
 │   ├── info                 Print a parsed flavor manifest (TOML by default, JSON via `--json`)
 │   └── install              Install every plugin the named flavor's manifest marks `required` (delegates to `animus plugin install-defaults --flavor <name>`); `--include-recommended` adds the recommended set
 │
-├── update                   Manage the `animus` binary itself — check for, download, and atomically install a newer release (`--check / --yes / --channel / --force / --prerelease`)
+├── update                   Manage the `animus` binary itself — check for, download, and atomically install a newer release (`--check / --yes / --channel / --force / --prerelease`). When the binary is managed by [avm](https://github.com/launchapp-dev/avm) (running from `~/.avm/versions/`), `update` defers to avm and prints the `avm install` / `avm use` commands instead of self-replacing the managed binary
 │
 ├── cost                     Inspect token + USD spend across workflow runs (v0.5.5)
 │   ├── summary              Aggregate spend over `--since <DURATION>` (default 24h) + top spenders. Default reports spend incurred inside the window only; `--lifetime` reports each touched run's full lifetime spend instead (restores pre-v0.5.x semantics). Output splits reported vs estimated cost with `(est.)` markers. `--by provider|model|task` groups spend by tool, model, or subject/task with token/USD totals and percentages

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -223,6 +223,10 @@ main() {
   printf '\nIf you use OAI-compatible providers (MiniMax/Z.AI/OpenRouter/etc), also install:\n'
   printf '  animus plugin install launchapp-dev/animus-provider-oai-agent\n'
 
+  printf '\nManaging multiple projects? Install avm (the Animus Version Manager) to pin\n'
+  printf 'each project to a kernel version (à la nvm/rustup) and dispatch automatically:\n'
+  printf '  curl -fsSL https://raw.githubusercontent.com/launchapp-dev/avm/main/install.sh | sh\n'
+
   if ! echo "${PATH}" | tr ':' '\n' | grep -qxF "${INSTALL_DIR}"; then
     warn "${INSTALL_DIR} is not in your PATH"
     echo ""


### PR DESCRIPTION
`animus update` (manual + startup auto-update) now detects an avm-managed binary and defers to `avm install`/`avm use` instead of overwriting the file under `~/.avm/versions/` (which would corrupt avm's version dir). install.sh + docs + CHANGELOG point multi-project users at avm.

Verified: fmt+clippy clean, tests pass, 2 codex rounds (P1 startup-self-update hole fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)