### PR TITLE
release: v0.6.12 — register daemon.pid for foreground `daemon run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -765,6 +765,11 @@ pub(super) async fn handle_daemon_run(args: DaemonRunArgs, project_root: &str, j
         std::path::Path::new(project_root),
         crate::services::metrics::EventTags::DaemonStarted {},
     );
+
+    // NB: the live `daemon.pid` file is written/cleared by `DaemonRunGuard`
+    // (acquired inside `run_daemon`), tied to the single-winner daemon lock so
+    // foreground `daemon run` registers liveness race-free. See
+    // `daemon_run_guard.rs`.
     let run_result =
         run_daemon(project_root, &mut runtime_options, &mut driver, &mut host, |driver| driver.active_process_count())
             .await;
@@ -787,6 +792,38 @@ mod tests {
     }
 
     use protocol::test_utils::EnvVarGuard;
+
+    // The foreground `daemon run` path registers its own PID so the daemon's
+    // status/health handlers can confirm liveness (without it a healthy daemon
+    // reports `running: false` / `unhealthy`). Verify the write creates the
+    // scoped daemon dir on a fresh scope, round-trips the PID, and the cleanup
+    // helper clears it.
+    #[test]
+    fn write_daemon_pid_creates_dir_and_round_trips() {
+        let _lock = lock_env();
+        let config_root = TempDir::new().expect("config temp dir");
+        let home_root = TempDir::new().expect("home temp dir");
+        let _config_guard = EnvVarGuard::set("ANIMUS_CONFIG_DIR", Some(config_root.path().to_string_lossy().as_ref()));
+        let _home_guard = EnvVarGuard::set("HOME", Some(home_root.path().to_string_lossy().as_ref()));
+        let _legacy_guard = EnvVarGuard::set("AGENT_ORCHESTRATOR_CONFIG_DIR", None);
+
+        let primary = TempDir::new().expect("primary project dir");
+        let primary_root = primary.path().to_string_lossy().to_string();
+
+        // Fresh scope: the scoped daemon dir does not exist yet.
+        assert_eq!(super::super::read_daemon_pid(&primary_root), None);
+
+        let pid = std::process::id();
+        super::super::write_daemon_pid(&primary_root, pid);
+        assert_eq!(
+            super::super::read_daemon_pid(&primary_root),
+            Some(pid),
+            "write_daemon_pid must create the daemon dir and persist the pid"
+        );
+
+        super::super::remove_daemon_pid(&primary_root);
+        assert_eq!(super::super::read_daemon_pid(&primary_root), None);
+    }
 
     #[tokio::test]
     async fn daemon_run_once_processes_current_project_root() {
@@ -816,6 +853,10 @@ mod tests {
             skip_preflight: true,
         };
         handle_daemon_run(args, &primary_root, true).await.expect("daemon run should succeed");
+
+        // A completed `--once` run registers then clears its PID; no stale PID
+        // should remain afterward.
+        assert_eq!(super::super::read_daemon_pid(&primary_root), None);
 
         let events_path = daemon_events_log_path();
         let events_content = std::fs::read_to_string(events_path).expect("daemon events log should exist");

--- a/crates/orchestrator-daemon-runtime/src/daemon/daemon_run_guard.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/daemon_run_guard.rs
@@ -52,6 +52,14 @@ impl DaemonRunGuard {
 
         DaemonRuntimeState::set_daemon_pid(&canonical_project_root, Some(current_pid))?;
         DaemonRuntimeState::set_runtime_paused(&canonical_project_root, false)?;
+        // Register the `daemon.pid` file alongside the lock so liveness probes
+        // (`daemon status`/`daemon health` and the daemon's own control-wire
+        // handlers, which read this file) succeed for a foreground `daemon run`
+        // too — previously only the parent of a detached `daemon start` wrote
+        // it, so a healthy containerized daemon reported `running: false` /
+        // `unhealthy`. Tying the write to the lock winner here is race-free; the
+        // Drop impl clears it.
+        DaemonRuntimeState::write_daemon_pid_file(&canonical_project_root, current_pid);
 
         Ok(Self { project_root: canonical_project_root, pid: current_pid, _lock_file: lock_file })
     }
@@ -63,6 +71,11 @@ impl Drop for DaemonRunGuard {
             if existing_pid == self.pid {
                 let _ = DaemonRuntimeState::set_daemon_pid(&self.project_root, None);
             }
+        }
+        // Clear the live PID file iff it still holds our PID — never remove a PID
+        // a successor daemon wrote.
+        if DaemonRuntimeState::read_daemon_pid_file(&self.project_root) == Some(self.pid) {
+            DaemonRuntimeState::remove_daemon_pid_file(&self.project_root);
         }
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/daemon/daemon_runtime_state.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/daemon_runtime_state.rs
@@ -78,6 +78,13 @@ impl DaemonRuntimeState {
 
     pub fn write_daemon_pid_file(project_root: &str, pid: u32) {
         let path = daemon_pid_path(project_root);
+        // Ensure the scoped daemon dir exists: the foreground `daemon run` path
+        // writes its PID before `run_daemon` boots (and creates the dir), so
+        // without this the very first write would silently no-op on a fresh
+        // scope and liveness probes would still find no PID.
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
         let _ = fs::write(path, pid.to_string());
     }
 


### PR DESCRIPTION
## What

Foreground `animus daemon run` (the launch mode every containerized deployment uses via start.sh) never wrote the `daemon.pid` file that `daemon status`/`daemon health` and the daemon's own control-wire handlers read to confirm liveness. With no pid on disk, the liveness probe found nothing and overrode the status to `Crashed` — so a perfectly healthy daemon (real uptime, all plugins healthy) reported `running: false` / `unhealthy` across the whole fleet (portal, media-portal, Juno).

## Fix

- Write/clear `daemon.pid` from `DaemonRunGuard` (acquired inside `run_daemon`), tied to the single-winner daemon lock — race-free, and covers both `daemon run` and the detached `daemon start` child.
- `Drop` clears the pid file only when it still holds our pid (never deletes a successor daemon's pid).
- Harden `write_daemon_pid_file` to create the scoped daemon dir on a fresh scope.

## Tests
- `write_daemon_pid_creates_dir_and_round_trips` — pid write creates the dir + round-trips.
- `daemon_run_once_processes_current_project_root` — `daemon run --once` leaves no stale pid.
- Cross-model review (codex, high reasoning): one race in an earlier inline approach surfaced + fixed by moving the lifecycle into the lock guard; final pass clean.