### PR TITLE
feat(subject): default subject.list to a bounded page + cursor paging (v0.6.13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/cli_types/subject_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/subject_types.rs
@@ -81,9 +81,17 @@ pub(crate) struct SubjectListArgs {
     #[arg(long, value_name = "STATUS")]
     pub status: Option<String>,
 
-    /// Maximum number of subjects to return.
+    /// Maximum subjects per page. Defaults to a bounded page so MCP/agent
+    /// callers don't pull the whole set. Pass `--limit 0` to remove the per-page
+    /// cap. The result carries `next_cursor` (and `total` when the backend
+    /// reports it) — page with `--cursor` until `next_cursor` is null to read
+    /// everything from a paginating backend.
     #[arg(long, value_name = "N")]
     pub limit: Option<u32>,
+
+    /// Opaque cursor from a prior page's `next_cursor`, to fetch the next page.
+    #[arg(long, value_name = "CURSOR")]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_command_args.rs
@@ -10,6 +10,7 @@ pub(super) fn build_subject_list_args(input: &SubjectListInput) -> Vec<String> {
         args.push("--limit".to_string());
         args.push(limit.to_string());
     }
+    push_opt(&mut args, "--cursor", input.cursor.clone());
     args
 }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_inputs.rs
@@ -5,8 +5,13 @@ pub(super) struct SubjectListInput {
     pub(super) kind: String,
     #[serde(default)]
     pub(super) status: Option<String>,
+    /// Max subjects per page. Defaults to a bounded page; pass 0 to remove the
+    /// per-page cap. The result carries `total` + `next_cursor`.
     #[serde(default)]
     pub(super) limit: Option<u32>,
+    /// Opaque cursor from a prior result's `next_cursor`, to fetch the next page.
+    #[serde(default)]
+    pub(super) cursor: Option<String>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -1580,6 +1580,7 @@ fn mcp_subject_list_routes_via_control() {
         kind: "task".to_string(),
         status: Some("ready".to_string()),
         limit: Some(25),
+        cursor: Some("page2".to_string()),
         project_root: None,
     };
     let args = build_subject_list_args(&input);
@@ -1594,6 +1595,8 @@ fn mcp_subject_list_routes_via_control() {
             "ready".to_string(),
             "--limit".to_string(),
             "25".to_string(),
+            "--cursor".to_string(),
+            "page2".to_string(),
         ]
     );
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_subject.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_subject.rs
@@ -47,6 +47,11 @@ pub(crate) async fn handle_subject(command: SubjectCommand, project_root: &str, 
     }
 }
 
+/// Default page size for `subject list` when no `--limit` is given. Bounds
+/// MCP/agent list calls (the common token-bloat source) while `--limit 0`
+/// returns everything.
+const DEFAULT_SUBJECT_LIST_LIMIT: u32 = 50;
+
 async fn handle_subject_list(args: SubjectListArgs, project_root: &str, json: bool) -> Result<()> {
     let kind = resolve_kind(args.kind.as_deref(), project_root, json)?;
     let mut filter = serde_json::Map::new();
@@ -54,8 +59,16 @@ async fn handle_subject_list(args: SubjectListArgs, project_root: &str, json: bo
     if let Some(status) = args.status.as_deref() {
         filter.insert("status".to_string(), json!([status]));
     }
-    if let Some(limit) = args.limit {
+    // Default to a bounded page so MCP/agent callers (and a bare `subject list`)
+    // don't pull the entire set; `--limit 0` opts out and returns ALL. Backends
+    // that honor `limit` also return `total` + `next_cursor` for paging; backends
+    // that ignore it simply return everything (no behavior change for them).
+    let limit = args.limit.unwrap_or(DEFAULT_SUBJECT_LIST_LIMIT);
+    if limit > 0 {
         filter.insert("limit".to_string(), json!(limit));
+    }
+    if let Some(cursor) = args.cursor.as_deref() {
+        filter.insert("cursor".to_string(), json!(cursor));
     }
     let params = Some(Value::Object(filter));
     dispatch(&kind, "list", params, project_root, json).await
@@ -606,7 +619,9 @@ fn render_subject_human(verb: &str, kind: &str, result: &Value) {
     match verb {
         "list" => {
             let subjects = extract_subjects(result);
+            let shown = subjects.len();
             render_subject_table(&subjects);
+            render_list_pagination_footer(result, shown);
         }
         "next" => match extract_single_subject(result) {
             Some(subject) => render_subject_block(subject),
@@ -617,6 +632,23 @@ fn render_subject_human(verb: &str, kind: &str, result: &Value) {
             Some(subject) => render_subject_block(subject),
             None => println!("{result}"),
         },
+    }
+}
+
+/// Print a one-line pagination footer for `subject list` human output when the
+/// backend reports another page, so the bounded default page isn't silently
+/// truncated. No-op when there's no non-empty `next_cursor`.
+fn render_list_pagination_footer(result: &Value, shown: usize) {
+    let Some(cursor) = result.get("next_cursor").and_then(Value::as_str).filter(|c| !c.is_empty()) else {
+        return;
+    };
+    match result.get("total").and_then(Value::as_u64) {
+        Some(total) => {
+            println!("\nshowing {shown} of {total} — next page: --cursor {cursor}  (all: --limit 0)")
+        }
+        None => {
+            println!("\nshowing {shown} — more available, next page: --cursor {cursor}  (all: --limit 0)")
+        }
     }
 }
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -474,7 +474,7 @@ Act on `remediation` first when present; see the
 
 ## Recommended Flow
 
-1. Discover or create a subject with `animus.subject.list` or `animus.subject.create`.
+1. Discover or create a subject with `animus.subject.list` or `animus.subject.create`. `animus.subject.list` returns a bounded page by default (`limit` defaults to 50) plus a `next_cursor` (and `total` when the backend reports it); pass `cursor` to fetch the next page, or `limit: 0` to remove the cap. Prefer paging over `limit: 0` for large boards to keep results small.
 2. Mark it ready with `animus.subject.status`.
 3. Start work with `animus.workflow.run` or let the daemon schedule it.
 4. Observe progress with `animus.workflow.list`, `animus.output.*`, and `animus.logs.tail`.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1769,7 +1769,7 @@ mode. Pass `--json` to get the `animus.cli.v1` envelope instead.
 
 | Command | Notes |
 |---|---|
-| `animus subject list` | Table with id, title, status, priority |
+| `animus subject list` | Table with id, title, status, priority. Returns a bounded page by default (`--limit` defaults to 50); a footer shows `next_cursor` (and `total` when the backend reports it) when more remain. Pass `--cursor <c>` to page, or `--limit 0` to remove the cap. |
 | `animus subject get` | Detail card |
 | `animus subject next` | Single-row card; prints nothing when no ready subject exists |
 | `animus queue list` | Table with id, title, status, priority |

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -156,7 +156,7 @@ plugin (e.g. `linear`, `jira`, `github-issue`).
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `animus.subject.list` | List subjects for a kind via the active `subject_backend` plugin | `kind`, `status`, `limit`, `project_root` |
+| `animus.subject.list` | List subjects for a kind via the active `subject_backend` plugin. Returns a bounded page by default (`limit` defaults to 50; pass `limit: 0` to remove the cap); the result carries `next_cursor` (and `total` when the backend reports it) — pass `cursor` to fetch the next page. | `kind`, `status`, `limit`, `cursor`, `project_root` |
 | `animus.subject.get` | Fetch a subject by wire id (`<kind>:<native_id>`) | `kind`, `id`, `project_root` |
 | `animus.subject.create` | Create a subject through the active `subject_backend` plugin | `kind`, `title`, `priority`, `status`, `labels[]`, `body`, `project_root` |
 | `animus.subject.update` | Update a subject through the active `subject_backend` plugin | `kind`, `id`, `priority`, `status`, `labels[]`, `body`, `project_root` |


### PR DESCRIPTION
subject.list returned the entire set, bloating MCP/agent context. Now defaults to a bounded page (`--limit` 50, `--limit 0` opts out) with `--cursor`/`cursor` paging; backends that honor limit also report `total` + `next_cursor`; human table prints a pagination footer. Fleet-wide and backend-agnostic (backends that ignore `limit` are unchanged).

Docs updated (mcp-tools, cli/index, agents). codex 3 rounds: 0 P1; P2s fixed; P3 (total is backend-reported) reflected in docs.