### PR TITLE
fix(skill): emit description + category for installed entries in skill list

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_skill.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_skill.rs
@@ -805,6 +805,15 @@ fn handle_list(args: SkillListArgs, project_root: &str, json: bool) -> Result<()
         for entry in &state.installed {
             items.push(serde_json::json!({
                 "name": entry.name,
+                // Surface the captured definition's description/category (when the
+                // install snapshotted one) so `skill list` callers don't have to
+                // fan out to `skill info` per skill just to render a catalog.
+                "description": entry.definition.as_ref().map(|d| d.description.clone()),
+                "category": entry
+                    .definition
+                    .as_ref()
+                    .and_then(|d| d.category.as_ref())
+                    .map(|c| format!("{:?}", c)),
                 "version": entry.version,
                 "source": entry.source,
                 "registry": entry.registry,


### PR DESCRIPTION
## Problem

`animus skill list --source installed --json` collapses each skill's captured definition to a boolean (`definition_snapshot`) and drops `description`/`category`. Callers that render an installed-skill catalog (e.g. the LaunchApp portal Skills page) get `description: null` for every skill, forcing a per-skill `skill info` fan-out just to show what each skill does.

## Fix

The full `SkillDefinition` is already persisted on the registry entry at install time (`ResolvedSkillEntry.definition`). Surface its `description` and `category` directly on the installed entry JSON, mirroring how the definition branch already formats them.

- Backward compatible — only adds fields (`definition_snapshot` etc. unchanged).
- Null when the install didn't snapshot a definition.

## Test

- `cargo check -p orchestrator-cli` ✓
- `cargo test -p orchestrator-cli skill` ✓ (no test asserts the installed-entry key set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)