### PR TITLE
chore(release): v0.6.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Release v0.6.16.

Includes #281 — `skill list` now emits `description` + `category` for installed entries.

Merging this `release/v0.6.16` branch triggers auto-tag (`v0.6.16`), which triggers the release-binaries build.