### PR TITLE
chore(release): v0.6.18 — kernel stops scaffolding baked default workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-config/src/agent_runtime_config.rs
+++ b/crates/orchestrator-config/src/agent_runtime_config.rs
@@ -2453,10 +2453,13 @@ cli_tools:
         ensure_agent_runtime_config_file(temp.path()).expect("ensure file");
 
         let workflows_dir = crate::workflow_config::yaml_workflows_dir(temp.path());
-        assert!(workflows_dir.join("custom.yaml").exists());
-        assert!(workflows_dir.join("standard-workflow.yaml").exists());
-        assert!(workflows_dir.join("hotfix-workflow.yaml").exists());
-        assert!(workflows_dir.join("research-workflow.yaml").exists());
+        // Kernel ships zero baked workflow content: the dir is created but no
+        // default templates are scaffolded.
+        assert!(workflows_dir.exists());
+        assert!(!workflows_dir.join("custom.yaml").exists());
+        assert!(!workflows_dir.join("standard-workflow.yaml").exists());
+        assert!(!workflows_dir.join("hotfix-workflow.yaml").exists());
+        assert!(!workflows_dir.join("research-workflow.yaml").exists());
     }
 
     #[test]

--- a/crates/orchestrator-config/src/workflow_config/config_source_client.rs
+++ b/crates/orchestrator-config/src/workflow_config/config_source_client.rs
@@ -580,7 +580,7 @@ pub fn install_yaml_config_source_base(project_root: &Path) -> test_seam::TestBa
     // matches the historical kernel behavior where `FileServiceHub::new` wrote
     // the scaffold and the in-tree loader compiled it, so tests that create a
     // hub (which still scaffolds) and rely on the standard workflow keep working.
-    let _ = super::ensure_workflow_yaml_scaffold(project_root);
+    let _ = super::yaml_scaffold::scaffold_default_workflows_for_tests(project_root);
     let base = super::compile_yaml_workflow_files(project_root)
         .expect("compile project yaml base")
         .unwrap_or_else(super::builtin_workflow_config);

--- a/crates/orchestrator-config/src/workflow_config/yaml_scaffold.rs
+++ b/crates/orchestrator-config/src/workflow_config/yaml_scaffold.rs
@@ -9,6 +9,11 @@ use animus_config_protocol::yaml_types::{
     STANDARD_WORKFLOW_TEMPLATE_FILE_NAME,
 };
 
+// Default workflow templates — TEST FIXTURES ONLY. The kernel no longer
+// scaffolds these into real projects (see `ensure_workflow_yaml_scaffold`);
+// they survive solely so the `test-utils` config_source seam can give tests a
+// standard workflow to load.
+#[cfg(any(test, feature = "test-utils"))]
 pub fn default_workflow_template_files() -> [(&'static str, &'static str); 4] {
     [
         (
@@ -115,7 +120,26 @@ phase_catalog:
     ]
 }
 
+/// v0.6: the kernel ships ZERO baked workflow content. Workflows come from the
+/// active flavor / `config_source` plugin (e.g. config-postgres team_*, or
+/// config-yaml reading author-provided `.animus/workflows/*.yaml`), never from
+/// kernel-scaffolded defaults. This ensures the workflows directory exists but
+/// writes no template files — so deleting workflow YAML does NOT get silently
+/// repopulated with bundled defaults, and an empty project stays empty until the
+/// flavor/config_source provides workflows.
 pub fn ensure_workflow_yaml_scaffold(project_root: &Path) -> Result<Vec<PathBuf>> {
+    let workflows_dir = yaml_workflows_dir(project_root);
+    fs::create_dir_all(&workflows_dir).with_context(|| format!("failed to create {}", workflows_dir.display()))?;
+    Ok(Vec::new())
+}
+
+/// TEST ONLY: write the default workflow templates into a project (the historical
+/// `ensure_workflow_yaml_scaffold` behavior). Production no longer scaffolds
+/// baked defaults; the `test-utils` config_source seam uses this so tests that
+/// rely on the standard workflow keep working. Only writes when no workflow YAML
+/// already exists, so tests that author their own YAML are not clobbered.
+#[cfg(any(test, feature = "test-utils"))]
+pub fn scaffold_default_workflows_for_tests(project_root: &Path) -> Result<Vec<PathBuf>> {
     let workflows_dir = yaml_workflows_dir(project_root);
     fs::create_dir_all(&workflows_dir).with_context(|| format!("failed to create {}", workflows_dir.display()))?;
 
@@ -125,7 +149,6 @@ pub fn ensure_workflow_yaml_scaffold(project_root: &Path) -> Result<Vec<PathBuf>
             .with_context(|| format!("failed to read {}", workflows_dir.display()))?
             .filter_map(|entry| entry.ok())
             .any(|entry| entry.path().extension().map(|ext| ext == "yaml" || ext == "yml").unwrap_or(false));
-
     if has_existing_yaml {
         return Ok(Vec::new());
     }

--- a/crates/orchestrator-core/src/services/tests.rs
+++ b/crates/orchestrator-core/src/services/tests.rs
@@ -153,8 +153,12 @@ fn file_hub_new_bootstraps_base_configs_for_project_path() {
     assert!(scoped.join("core-state.json").exists());
     assert!(project_path.join(".animus").join("config.json").exists());
     assert!(scoped.join("resume-config.json").exists());
-    assert!(project_path.join(".animus").join("workflows").join("custom.yaml").exists());
-    assert!(project_path.join(".animus").join("workflows").join("standard-workflow.yaml").exists());
+    // The kernel ships zero baked workflow content: bootstrap creates the
+    // workflows dir but scaffolds NO default templates (workflows come from the
+    // flavor / config_source plugin).
+    assert!(project_path.join(".animus").join("workflows").exists());
+    assert!(!project_path.join(".animus").join("workflows").join("custom.yaml").exists());
+    assert!(!project_path.join(".animus").join("workflows").join("standard-workflow.yaml").exists());
     assert!(scoped.join("config").join("state-machines.v1.json").exists());
     assert!(!project_path.join(".git").exists());
     assert!(


### PR DESCRIPTION
## What
The kernel auto-wrote 4 baked workflow templates (standard/hotfix/research/custom) whenever \`.animus/workflows/\` was empty (\`ensure_workflow_yaml_scaffold\`), contradicting the v0.6 zero-built-in-content + config_source-exclusive architecture — deleting a project's workflow YAML silently repopulated bundled defaults.

## Fix
- \`ensure_workflow_yaml_scaffold\` is now a no-op (ensures the dir, writes nothing). Empty project → stays empty; config comes from the flavor/config_source plugin.
- **YAML is still fully supported** — author-provided \`.animus/workflows/*.yaml\` still compiles via the config-yaml plugin. Only the *auto-generation of bundled defaults* is removed.
- Default templates moved behind the \`test-utils\` config_source seam (\`scaffold_default_workflows_for_tests\`) so tests relying on a standard workflow keep working.
- Bootstrap tests updated to assert no auto-scaffold.

## Verification
- orchestrator-core services: 72 passed; orchestrator-config workflow_config: 188 passed; agent_runtime: 101 passed. clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)