### PR TITLE
chore(release): v0.6.19 — phase-plan resolution recognizes config_source plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "animus-control-protocol",
  "animus-log-storage-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-config/src/workflow_config/yaml_scaffold.rs
+++ b/crates/orchestrator-config/src/workflow_config/yaml_scaffold.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use animus_config_protocol::parse::yaml_workflows_dir;
+// Only the test-only `default_workflow_template_files` consumes these template
+// name constants; gate the import so non-test builds don't warn on unused imports.
+#[cfg(any(test, feature = "test-utils"))]
 use animus_config_protocol::yaml_types::{
     DEFAULT_WORKFLOW_TEMPLATE_FILE_NAME, HOTFIX_WORKFLOW_TEMPLATE_FILE_NAME, RESEARCH_WORKFLOW_TEMPLATE_FILE_NAME,
     STANDARD_WORKFLOW_TEMPLATE_FILE_NAME,

--- a/crates/orchestrator-core/src/workflow/phase_plan.rs
+++ b/crates/orchestrator-core/src/workflow/phase_plan.rs
@@ -79,10 +79,21 @@ pub fn resolve_phase_plan_for_workflow_ref(
         crate::resolve_pack_registry(root).map(|registry| registry.has_pack_overlays()).unwrap_or(false);
     let has_legacy_workflow_config =
         crate::legacy_workflow_config_paths(root).iter().any(|candidate| candidate.exists());
-    if !has_yaml_workflows && !has_pack_workflows && !workflow_config_path.exists() && !has_legacy_workflow_config {
+    // An installed `config_source` plugin (e.g. config-postgres reading team_*,
+    // or config-yaml reading author YAML) is an authoritative config source even
+    // when no `.animus/workflows/*.yaml`, pack, or compiled cache exists on disk.
+    // Mirror `load_workflow_config`'s own gate (loading.rs) so config_source-only
+    // projects (no on-disk YAML) can still resolve workflows.
+    let has_config_source = orchestrator_config::config_source_client::config_source_installed(root);
+    if !has_config_source
+        && !has_yaml_workflows
+        && !has_pack_workflows
+        && !workflow_config_path.exists()
+        && !has_legacy_workflow_config
+    {
         let requested = requested_workflow_ref.as_deref().or(normalized_workflow_ref.as_deref()).unwrap_or("<default>");
         return Err(anyhow!(
-            "workflow '{requested}' is not available until the project defines workflows in .animus/workflows.yaml or .animus/workflows/*.yaml, or installs a pack"
+            "workflow '{requested}' is not available until the project defines workflows in .animus/workflows.yaml or .animus/workflows/*.yaml, installs a pack, or installs a config_source plugin"
         ));
     }
 


### PR DESCRIPTION
## What
`resolve_phase_plan_for_workflow_ref` (the `workflow/run` resolution path) had a YAML-assuming pre-check: it errored "workflow not available until .animus/workflows.yaml…" whenever no on-disk YAML / pack / compiled-cache / legacy-config existed — **ignoring an installed `config_source` plugin**. So a config-postgres-only project (no `.animus/workflows/*.yaml`) could not resolve ANY workflow via `workflow run` / MCP `run_workflow`, even though `load_workflow_config` reads config-postgres fine (`config get`/`validate` showed all workflows).

Surfaced by the launchapp portal no-YAML cutover.

## Fix
- Add `config_source_installed()` to the pre-check gate, mirroring `load_workflow_config`'s own gate in `loading.rs`. config_source-only projects now resolve workflows.
- Gate the test-only template-name imports behind `test-utils` (clippy hygiene from the v0.6.18 scaffold change).

Run-path analogue of the v0.6.18 scaffold fix — together they make a true no-YAML (config-postgres) portal work end to end.

## Verification
- orchestrator-core phase_plan tests: 12 passed (incl. the missing-config error tests). clippy clean (core + config/test-utils).

🤖 Generated with [Claude Code](https://claude.com/claude-code)