### PR TITLE
feat(actor): v0.6.21 — --actor-json assertion surface (workflow run / config get / chat)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/cli_types/chat_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/chat_types.rs
@@ -1,12 +1,16 @@
 use clap::{Args, Subcommand, ValueEnum};
 
-use super::ReasoningEffortArg;
+use super::{ReasoningEffortArg, ACTOR_JSON_HELP};
 
 /// `animus chat` — hold multi-turn conversations with a provider tool.
 ///
 /// Continuity is owned by the wrapped CLI tool's native session; Animus
 /// stores a portable, queryable transcript and a thin continuity pointer
 /// (`session_id` + `tool`). See `docs/reference/chat.md`.
+// `Send` carries the rich per-turn flag set (provider/model/mcp/actor/...), so
+// it dwarfs the other variants. Boxing it would break clap's `Subcommand`
+// derive (a tuple-variant field must itself be `Args`); accept the size delta.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 pub(crate) enum ChatCommand {
     /// Start a new (empty) conversation and print its id.
@@ -137,6 +141,12 @@ pub(crate) struct ChatSendArgs {
     /// Visibility for a conversation created by this send.
     #[arg(long, value_enum, default_value = "private")]
     pub(crate) visibility: ChatVisibilityArg,
+    /// Transport-asserted authz identity for this chat turn (distinct from
+    /// `--as-user`, which is the conversation-ownership stamp). Binds the
+    /// chat agent's built-in `animus` MCP server to this user so its
+    /// per-user subject / queue / integration tools are scoped accordingly.
+    #[arg(long, value_name = "JSON", help = ACTOR_JSON_HELP)]
+    pub(crate) actor_json: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/orchestrator-cli/src/cli_types/mod.rs
+++ b/crates/orchestrator-cli/src/cli_types/mod.rs
@@ -907,6 +907,81 @@ mod tests {
     }
 
     #[test]
+    fn workflow_run_parses_actor_json_for_transport_scoping() {
+        let actor_json = r#"{"user_id":"alice","claims":["admin"],"tenant_id":"acme"}"#;
+        let cli = Cli::try_parse_from(["animus", "workflow", "run", "--task-id", "TASK-1", "--actor-json", actor_json])
+            .expect("workflow run --actor-json should parse");
+        match cli.command {
+            Command::Workflow { command: WorkflowCommand::Run(args) } => {
+                assert_eq!(args.actor_json.as_deref(), Some(actor_json));
+            }
+            other => panic!("expected workflow run, got {other:?}"),
+        }
+        // No flag => None => global scope.
+        let cli = Cli::try_parse_from(["animus", "workflow", "run", "--task-id", "TASK-1"])
+            .expect("bare workflow run should parse");
+        match cli.command {
+            Command::Workflow { command: WorkflowCommand::Run(args) } => assert_eq!(args.actor_json, None),
+            other => panic!("expected workflow run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workflow_config_get_and_validate_parse_actor_json() {
+        let actor_json = r#"{"user_id":"bob","claims":[]}"#;
+        let cli = Cli::try_parse_from(["animus", "workflow", "config", "get", "--actor-json", actor_json])
+            .expect("workflow config get --actor-json should parse");
+        match cli.command {
+            Command::Workflow { command: WorkflowCommand::Config { command: WorkflowConfigCommand::Get(args) } } => {
+                assert_eq!(args.actor_json.as_deref(), Some(actor_json));
+            }
+            other => panic!("expected workflow config get, got {other:?}"),
+        }
+        let cli = Cli::try_parse_from(["animus", "workflow", "config", "validate", "--actor-json", actor_json])
+            .expect("workflow config validate --actor-json should parse");
+        match cli.command {
+            Command::Workflow {
+                command: WorkflowCommand::Config { command: WorkflowConfigCommand::Validate(args) },
+            } => assert_eq!(args.actor_json.as_deref(), Some(actor_json)),
+            other => panic!("expected workflow config validate, got {other:?}"),
+        }
+        // No flag => global-only resolution.
+        let cli = Cli::try_parse_from(["animus", "workflow", "config", "get"])
+            .expect("bare workflow config get should parse");
+        match cli.command {
+            Command::Workflow { command: WorkflowCommand::Config { command: WorkflowConfigCommand::Get(args) } } => {
+                assert_eq!(args.actor_json, None)
+            }
+            other => panic!("expected workflow config get, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chat_send_parses_actor_json_distinct_from_as_user() {
+        let actor_json = r#"{"user_id":"carol","claims":["admin"]}"#;
+        let cli =
+            Cli::try_parse_from(["animus", "chat", "send", "hello", "--as-user", "carol", "--actor-json", actor_json])
+                .expect("chat send --actor-json should parse");
+        match cli.command {
+            Command::Chat { command: ChatCommand::Send(args) } => {
+                assert_eq!(args.actor_json.as_deref(), Some(actor_json));
+                assert_eq!(args.as_user.as_deref(), Some("carol"));
+            }
+            other => panic!("expected chat send, got {other:?}"),
+        }
+        // No actor flag => None (global authz scope) even with --as-user set.
+        let cli = Cli::try_parse_from(["animus", "chat", "send", "hello", "--as-user", "carol"])
+            .expect("bare chat send should parse");
+        match cli.command {
+            Command::Chat { command: ChatCommand::Send(args) } => {
+                assert_eq!(args.actor_json, None);
+                assert_eq!(args.as_user.as_deref(), Some("carol"));
+            }
+            other => panic!("expected chat send, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn output_read_is_primary_and_run_alias_is_retired() {
         let cli =
             Cli::try_parse_from(["animus", "output", "read", "--run-id", "RUN-1"]).expect("output read should parse");

--- a/crates/orchestrator-cli/src/cli_types/shared_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/shared_types.rs
@@ -6,6 +6,10 @@ pub(crate) const WORKFLOW_STATUS_HELP: &str =
     "Workflow status: pending|running|paused|completed|failed|escalated|cancelled.";
 pub(crate) const WORKFLOW_SORT_HELP: &str = "Workflow sort: started-at|started_at|status|workflow-ref|workflow_ref|id.";
 
+/// Help text shared by every `--actor-json` flag (`workflow run`,
+/// `workflow config get/validate`, `chat send`), mirroring `mcp serve`.
+pub(crate) const ACTOR_JSON_HELP: &str = "Transport-asserted caller identity as a JSON-encoded Actor (`{\"user_id\",\"claims\",\"tenant_id\"}`) to scope this operation to that user. TRUST BOUNDARY: the transport authenticates the user, then passes this flag; the kernel does NOT validate the claims, it relays them. Omit for global scope (system/local).";
+
 pub(crate) fn parse_positive_u64(value: &str) -> Result<u64, String> {
     let parsed = value.parse::<u64>().map_err(|_| "must be a whole number".to_string())?;
     if parsed == 0 {

--- a/crates/orchestrator-cli/src/cli_types/workflow_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/workflow_types.rs
@@ -1,8 +1,8 @@
 use clap::{Args, Subcommand};
 
 use super::{
-    parse_duration_secs_default_days, parse_positive_usize, INPUT_JSON_PRECEDENCE_HELP, WORKFLOW_SORT_HELP,
-    WORKFLOW_STATUS_HELP,
+    parse_duration_secs_default_days, parse_positive_usize, ACTOR_JSON_HELP, INPUT_JSON_PRECEDENCE_HELP,
+    WORKFLOW_SORT_HELP, WORKFLOW_STATUS_HELP,
 };
 
 /// Workflow identifier args: `--id` is primary, `--workflow-id` is a hidden
@@ -148,9 +148,9 @@ pub(crate) enum WorkflowDefinitionsCommand {
 #[derive(Debug, Subcommand)]
 pub(crate) enum WorkflowConfigCommand {
     /// Read resolved workflow config.
-    Get,
+    Get(WorkflowConfigReadArgs),
     /// Validate workflow config shape and references.
-    Validate,
+    Validate(WorkflowConfigReadArgs),
     /// Validate and resolve YAML workflow files.
     Compile,
     /// Re-run the workflow YAML compile pipeline and (when the daemon is
@@ -170,6 +170,16 @@ pub(crate) enum WorkflowConfigCommand {
     WorkflowSet(WorkflowConfigWorkflowSetArgs),
     /// Remove one workflow definition (read-modify-write).
     WorkflowRemove(WorkflowConfigEntityIdArgs),
+}
+
+/// Shared args for `workflow config get` / `workflow config validate`.
+///
+/// `--actor-json` scopes the resolved config to the asserted user
+/// (global ∪ private ∪ shared; admins see all). Omit for global-only.
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowConfigReadArgs {
+    #[arg(long, value_name = "JSON", help = ACTOR_JSON_HELP)]
+    pub(crate) actor_json: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -307,6 +317,8 @@ pub(crate) struct WorkflowRunArgs {
         help = "Workflow variable in KEY=VALUE format. Repeat for multiple variables."
     )]
     pub(crate) vars: Vec<String>,
+    #[arg(long, value_name = "JSON", help = ACTOR_JSON_HELP)]
+    pub(crate) actor_json: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/config.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/config.rs
@@ -179,9 +179,9 @@ pub(crate) fn set_agent_runtime_payload(project_root: &str, input_json: &str) ->
     }))
 }
 
-pub(crate) fn get_workflow_config_payload(project_root: &str) -> Value {
+pub(crate) fn get_workflow_config_payload(project_root: &str, actor: Option<&animus_actor::Actor>) -> Value {
     let path = workflow_config_path(project_root);
-    match orchestrator_core::load_workflow_config_with_metadata(Path::new(project_root), None) {
+    match orchestrator_core::load_workflow_config_with_metadata(Path::new(project_root), actor) {
         Ok(loaded) => serde_json::json!({
             "path": path.display().to_string(),
             "source": loaded.metadata.source,
@@ -231,10 +231,15 @@ fn config_error_to_value(error: &anyhow::Error) -> Value {
     serde_json::json!({ "message": format!("{error:#}") })
 }
 
-pub(crate) fn validate_workflow_config_payload(project_root: &str) -> Value {
-    let workflow_loaded = orchestrator_core::load_workflow_config_with_metadata(Path::new(project_root), None);
-    let runtime_loaded =
-        orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata(Path::new(project_root));
+pub(crate) fn validate_workflow_config_payload(project_root: &str, actor: Option<&animus_actor::Actor>) -> Value {
+    let workflow_loaded = orchestrator_core::load_workflow_config_with_metadata(Path::new(project_root), actor);
+    // The agent runtime derives from the SAME actor's workflow-config partition,
+    // so validate must load it for `actor` too — otherwise actor-private agents
+    // are missing and validation reports the wrong runtime (or spuriously fails).
+    let runtime_loaded = orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata_for_actor(
+        Path::new(project_root),
+        actor,
+    );
     let warnings = unenforced_warnings_payload(project_root);
 
     match (workflow_loaded, runtime_loaded) {
@@ -623,6 +628,51 @@ mod tests {
     }
 
     #[test]
+    fn get_payload_threads_distinct_actors_into_the_load() {
+        use orchestrator_config::workflow_config::config_source_client::test_seam;
+
+        let dir = tempdir().unwrap();
+        let animus = dir.path().join(".animus");
+        fs::create_dir_all(&animus).unwrap();
+
+        // Compile two distinct, valid bases off disk — one workflow vs two —
+        // to stand in for a per-user `config_source` partition.
+        let one = "tools_allowlist:\n  - cargo\nphases:\n  alpha:\n    mode: agent\n    agent_id: a\nagents:\n  a:\n    description: d\n    system_prompt: p\n    skills: []\nworkflows:\n  - id: only-mine\n    name: Only Mine\n    phases:\n      - alpha\n";
+        fs::write(animus.join("workflows.yaml"), one).unwrap();
+        let alice_base = orchestrator_core::compile_yaml_workflow_files(dir.path())
+            .expect("compile alice base")
+            .expect("alice base present");
+
+        let two = "tools_allowlist:\n  - cargo\nphases:\n  alpha:\n    mode: agent\n    agent_id: a\nagents:\n  a:\n    description: d\n    system_prompt: p\n    skills: []\nworkflows:\n  - id: only-mine\n    name: Only Mine\n    phases:\n      - alpha\n  - id: also-shared\n    name: Also Shared\n    phases:\n      - alpha\n";
+        fs::write(animus.join("workflows.yaml"), two).unwrap();
+        let bob_base = orchestrator_core::compile_yaml_workflow_files(dir.path())
+            .expect("compile bob base")
+            .expect("bob base present");
+
+        let alice = animus_actor::Actor { user_id: "alice".to_string(), claims: vec![], tenant_id: None };
+        let bob = animus_actor::Actor { user_id: "bob".to_string(), claims: vec![], tenant_id: None };
+        let _g_alice = test_seam::install_for_actor(dir.path(), &alice, alice_base);
+        let _g_bob = test_seam::install_for_actor(dir.path(), &bob, bob_base);
+
+        let root = dir.path().to_string_lossy().to_string();
+        let alice_payload = get_workflow_config_payload(&root, Some(&alice));
+        let bob_payload = get_workflow_config_payload(&root, Some(&bob));
+
+        let alice_workflows = alice_payload["workflow_config"]["workflows"]
+            .as_array()
+            .unwrap_or_else(|| panic!("alice workflows array: {alice_payload}"))
+            .len();
+        let bob_workflows = bob_payload["workflow_config"]["workflows"]
+            .as_array()
+            .unwrap_or_else(|| panic!("bob workflows array: {bob_payload}"))
+            .len();
+
+        // Distinct actors must resolve their own per-user base (no leak).
+        assert_eq!(alice_workflows, 1, "alice base has one workflow: {alice_payload}");
+        assert_eq!(bob_workflows, 2, "bob base has two workflows: {bob_payload}");
+    }
+
+    #[test]
     fn reload_payload_reports_reloaded_true_for_valid_overlay() {
         let dir = tempdir().unwrap();
         write_minimal_overlay(dir.path());
@@ -647,7 +697,7 @@ mod tests {
         let _config_source_seam =
             orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(dir.path());
         let project_root = dir.path().to_string_lossy().to_string();
-        let value = validate_workflow_config_payload(&project_root);
+        let value = validate_workflow_config_payload(&project_root, None);
         assert_eq!(value["valid"], serde_json::json!(true), "warnings must never fail validation: {value}");
         let warnings = value["warnings"].as_array().expect("warnings array");
         assert!(
@@ -681,7 +731,7 @@ mod tests {
         let _config_source_seam =
             orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(dir.path());
         let project_root = dir.path().to_string_lossy().to_string();
-        let value = validate_workflow_config_payload(&project_root);
+        let value = validate_workflow_config_payload(&project_root, None);
         assert_eq!(value["valid"], serde_json::json!(true), "minimal overlay must validate: {value}");
         let summary = value.get("summary").expect("summary present on success");
         assert!(summary["workflows"].as_u64().is_some(), "summary must count workflows: {summary}");

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -443,6 +443,12 @@ pub(crate) async fn handle_workflow(
             // stripped so a foreign-kind qualifier is not silently rewritten.
             args.task_id = args.task_id.map(|id| crate::bare_task_id(&id));
             let workflow_ref = args.pipeline.clone();
+            // Transport-asserted caller identity for this run. The transport
+            // (e.g. the portal) authenticates the user and passes
+            // `--actor-json`; the kernel relays it verbatim to the runner /
+            // config_source / MCP surfaces (which enforce). A malformed value
+            // hard-fails (fail-closed). Omitted => `None` => global scope.
+            let asserted_actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
             if args.sync {
                 let execute_args = WorkflowExecuteArgs {
                     workflow_id: args.workflow_id,
@@ -457,14 +463,16 @@ pub(crate) async fn handle_workflow(
                     phase_timeout_secs: args.phase_timeout_secs,
                     input_json: args.input_json,
                     vars: args.vars,
-                    // This `--sync` branch is also the entry point of the
-                    // daemon-spawned detached runner child. The daemon relays the
-                    // authenticated control-request actor to that child via the
-                    // trusted WORKFLOW_ACTOR_ENV env var; read it back here so the
-                    // runner request carries the caller identity. For a direct
-                    // local CLI invocation the env is unset => `None` (never
-                    // synthesized from local context, YAML, or subject content).
-                    actor: phases::workflow_actor_from_env(),
+                    // Actor precedence: an explicit transport-asserted
+                    // `--actor-json` flag wins. Otherwise this `--sync` branch
+                    // is also the entry point of the daemon-spawned detached
+                    // runner child, where the daemon relays the authenticated
+                    // control-request actor via the trusted WORKFLOW_ACTOR_ENV
+                    // env var — read it back so the runner request carries the
+                    // caller identity. A direct local CLI invocation with no
+                    // flag and no env => `None` (never synthesized from local
+                    // context, YAML, or subject content).
+                    actor: asserted_actor.clone().or_else(phases::workflow_actor_from_env),
                 };
                 execute::handle_workflow_execute(execute_args, hub, project_root, json).await?;
                 Ok(())
@@ -492,9 +500,11 @@ pub(crate) async fn handle_workflow(
                     model: args.model.clone(),
                     tool: args.tool.clone(),
                     phase_timeout_secs: args.phase_timeout_secs,
-                    // Local async `workflow run`: no authenticated transport
-                    // actor. The control path supplies the actor instead.
-                    actor: None,
+                    // The transport-asserted `--actor-json` (if any) is relayed
+                    // to the detached runner child via WORKFLOW_ACTOR_ENV. With
+                    // no flag this is `None` => global scope; an authenticated
+                    // inbound control request supplies its own actor instead.
+                    actor: asserted_actor.clone(),
                 };
                 if json && args.input_json.is_none() && args.requirement_id.is_none() && args.title.is_none() {
                     if let Some(task_id) = args.task_id.as_ref() {
@@ -735,9 +745,13 @@ pub(crate) async fn handle_workflow(
             }
         },
         WorkflowCommand::Config { command } => match command {
-            WorkflowConfigCommand::Get => print_value(config::get_workflow_config_payload(project_root), json),
-            WorkflowConfigCommand::Validate => {
-                let payload = config::validate_workflow_config_payload(project_root);
+            WorkflowConfigCommand::Get(args) => {
+                let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
+                print_value(config::get_workflow_config_payload(project_root, actor.as_ref()), json)
+            }
+            WorkflowConfigCommand::Validate(args) => {
+                let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
+                let payload = config::validate_workflow_config_payload(project_root, actor.as_ref());
                 if json {
                     print_value(payload, json)
                 } else {
@@ -903,11 +917,12 @@ async fn try_workflow_run_via_control(
         }
         params.insert("overrides".to_string(), serde_json::Value::Object(overrides_obj));
     }
-    // Local CLI → own daemon over the control wire: no authenticated transport
-    // actor (the operator is acting locally). Authenticated actors are asserted
-    // only by the transport plugins (http/graphql) on inbound requests — never
-    // synthesized by the CLI client.
-    let request = WireRequest { task_id: task_id.to_string(), definition, params, actor: None };
+    // Relay the transport-asserted actor (from an explicit `--actor-json`) over
+    // the control wire so the daemon scopes the run to that user. With no flag
+    // `overrides.actor` is `None` and the run is global — the CLI client never
+    // synthesizes an actor from local context; authenticated actors are
+    // asserted only by the caller (the flag) or the transport plugins.
+    let request = WireRequest { task_id: task_id.to_string(), definition, params, actor: overrides.actor.clone() };
     match client.workflow_run(request).await {
         Ok(response) => Ok(Some(response)),
         Err(err) if is_method_unavailable(&err) => {

--- a/crates/orchestrator-cli/src/services/runtime/agent_mcp.rs
+++ b/crates/orchestrator-cli/src/services/runtime/agent_mcp.rs
@@ -25,6 +25,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use animus_actor::Actor;
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 use tracing::warn;
@@ -102,6 +103,45 @@ pub(crate) fn assemble_agent_mcp_contract(
     disable_animus: bool,
     agent_id: Option<&str>,
 ) -> Result<Option<Value>> {
+    // Default (unauthenticated) ad-hoc path: no transport-asserted actor.
+    assemble_agent_mcp_contract_with_actor(
+        project_root,
+        tool,
+        model,
+        profile_servers,
+        skill_servers,
+        extra_servers,
+        tool_policy,
+        scope_selected,
+        disable_animus,
+        agent_id,
+        None,
+    )
+}
+
+/// Variant of [`assemble_agent_mcp_contract`] that binds the spawned built-in
+/// `animus mcp serve` child to a transport-asserted [`Actor`] (relayed as
+/// `--actor-json`). Used by `animus chat send --actor-json` so a chat turn's
+/// per-user subject / queue / integration tools are scoped to the caller.
+///
+/// TRUST BOUNDARY: `actor` originates ONLY from the authenticated caller (the
+/// transport asserts it via the flag). It is NEVER synthesized from local
+/// context, workflow YAML, agent output, or subject content. `None` = global
+/// scope.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn assemble_agent_mcp_contract_with_actor(
+    project_root: &Path,
+    tool: &str,
+    model: &str,
+    profile_servers: &[String],
+    skill_servers: &[String],
+    extra_servers: &[String],
+    tool_policy: &AgentToolPolicy,
+    scope_selected: bool,
+    disable_animus: bool,
+    agent_id: Option<&str>,
+    actor: Option<&Actor>,
+) -> Result<Option<Value>> {
     // Base contract carries the per-tool `cli` block (including
     // `cli/capabilities/supports_mcp`) plus an empty `mcp` block the
     // inject_* helpers fill in. An unknown/unsupported tool yields `None`.
@@ -144,10 +184,12 @@ pub(crate) fn assemble_agent_mcp_contract(
             &project_root.to_string_lossy(),
             &mcp_config,
             agent_id,
-            // Ad-hoc `animus chat` / `animus agent run` is a local, unauthenticated
-            // invocation — no transport actor. The workflow runner supplies the
-            // actor on the daemon-driven phase path; never synthesized here.
-            None,
+            // Transport-asserted actor (from `animus chat send --actor-json`),
+            // relayed to the spawned `animus mcp serve` child so its tools
+            // scope per-user. `None` for unauthenticated ad-hoc invocations;
+            // the workflow runner supplies the actor on the daemon-driven
+            // phase path. Never synthesized here.
+            actor,
         );
 
         // Mirror the shared IPC path: when a stdio MCP command is injected
@@ -523,6 +565,28 @@ pub(crate) fn materialize_mcp_json(cwd: &Path, runtime_contract: &Value) -> Resu
     Ok(written)
 }
 
+/// Return a clone of `runtime_contract` with any `--actor-json <json>` pair
+/// stripped from the built-in `animus` server's `/mcp/stdio/args`.
+///
+/// The transport-asserted actor is a PER-TURN authz identity. It rides the
+/// ephemeral `extras.runtime_contract` (the path the turn's own provider
+/// session consumes), but it must NEVER be persisted into the cwd-local,
+/// auto-discovered `.mcp.json`: that file outlives the turn and is shared, so a
+/// later or concurrent invocation from the same directory could silently
+/// inherit a previous user's identity (including `admin` claims). Use this to
+/// sanitize the contract before [`materialize_mcp_json`].
+pub(crate) fn strip_actor_from_contract(runtime_contract: &Value) -> Value {
+    let mut sanitized = runtime_contract.clone();
+    if let Some(args) = sanitized.pointer_mut("/mcp/stdio/args").and_then(Value::as_array_mut) {
+        if let Some(pos) = args.iter().position(|a| a.as_str() == Some("--actor-json")) {
+            // Remove the flag and its JSON value (when present).
+            let remove_to = (pos + 2).min(args.len());
+            args.drain(pos..remove_to);
+        }
+    }
+    sanitized
+}
+
 /// The MCP server names an `--agent` profile and `--skill` declare,
 /// resolved from project config. Either component is empty when its flag is
 /// absent.
@@ -697,6 +761,32 @@ mod tests {
 
     fn names(v: &[&str]) -> Vec<String> {
         v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn strip_actor_from_contract_removes_actor_pair_only() {
+        let contract = serde_json::json!({
+            "mcp": { "stdio": { "command": "animus", "args": [
+                "--project-root", "/p", "mcp", "serve", "--agent-id", "swe", "--actor-json", r#"{"user_id":"alice"}"#
+            ]}}
+        });
+        let stripped = strip_actor_from_contract(&contract);
+        let args: Vec<&str> = stripped
+            .pointer("/mcp/stdio/args")
+            .and_then(Value::as_array)
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(!args.contains(&"--actor-json"), "actor flag must be dropped: {args:?}");
+        assert!(!args.iter().any(|a| a.contains("alice")), "actor json value must be dropped: {args:?}");
+        // The rest of the args (incl. --agent-id) survive intact.
+        assert!(args.contains(&"--agent-id") && args.contains(&"swe"), "non-actor args must survive: {args:?}");
+        assert!(args.contains(&"serve"), "serve verb must survive: {args:?}");
+
+        // No actor present => unchanged.
+        let no_actor = serde_json::json!({ "mcp": { "stdio": { "command": "animus", "args": ["mcp", "serve"] }}});
+        assert_eq!(strip_actor_from_contract(&no_actor), no_actor);
     }
 
     #[test]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_chat/mod.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_chat/mod.rs
@@ -303,6 +303,16 @@ fn handle_chat_new(args: ChatNewArgs, project_root: &str, json: bool) -> Result<
 
 async fn handle_chat_send(args: ChatSendArgs, project_root: &str, json: bool) -> Result<()> {
     let project_root_path = PathBuf::from(project_root);
+
+    // Transport-asserted authz identity for this turn. The transport (e.g. the
+    // portal) authenticates the user, then passes `--actor-json`; the kernel
+    // relays it (it does not validate the claims). This is the authz identity,
+    // distinct from `--as-user` (conversation ownership). Parsed FIRST: a
+    // malformed value must fail closed BEFORE any store write (conversation
+    // create / title rename), so an invalid assertion leaves no state behind.
+    // Omitted => `None` => global scope.
+    let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
+
     let store = ConversationStoreClient::for_project_as_user(&project_root_path, args.as_user.as_deref())?;
 
     // Resolve (or create) the target conversation.
@@ -388,9 +398,10 @@ async fn handle_chat_send(args: ChatSendArgs, project_root: &str, json: bool) ->
 
     // Assemble the runtime contract the provider receives so the chat agent
     // sees the MCP servers its profile/skill declares. Plain chat (no
-    // --agent/--skill) defaults to the built-in `animus` server only.
+    // --agent/--skill) defaults to the built-in `animus` server only. When an
+    // actor is asserted, the spawned `animus mcp serve` child is bound to it.
     let scope_selected = args.agent.is_some() || args.skill.is_some();
-    let mcp_contract = crate::services::runtime::agent_mcp::assemble_agent_mcp_contract(
+    let mcp_contract = crate::services::runtime::agent_mcp::assemble_agent_mcp_contract_with_actor(
         &project_root_path,
         &args.tool,
         &model,
@@ -401,6 +412,7 @@ async fn handle_chat_send(args: ChatSendArgs, project_root: &str, json: bool) ->
         scope_selected,
         args.no_animus_mcp,
         args.agent.as_deref(),
+        actor.as_ref(),
     )?;
 
     // Provider CLIs that auto-discover a cwd-local `.mcp.json` (claude-code)
@@ -408,8 +420,28 @@ async fn handle_chat_send(args: ChatSendArgs, project_root: &str, json: bool) ->
     // per-agent set is also materialized there. The merge is additive — it
     // upserts only the resolved Animus-scoped names and preserves any
     // user-authored entries.
+    //
+    // The transport-asserted actor is NEVER written to this shared, persisted,
+    // auto-discovered file: a concurrent invocation in the same cwd, or a crash
+    // before any cleanup, would let another caller inherit the per-turn identity
+    // (incl. `admin` claims) and run MCP tools as that user. The actor instead
+    // rides the ephemeral `extras.runtime_contract` (below) for the turn's own
+    // provider session, so contract-consuming providers are still scoped.
+    //
+    // TODO(codex-p1): providers that scope ONLY off the cwd `.mcp.json` (and
+    // ignore the runtime contract's `mcp` block) therefore run the auto-
+    // discovered `animus` server unscoped. Closing that gap needs a per-run
+    // isolated MCP config path the provider is pointed at (e.g. claude's
+    // `--mcp-config`), which is provider-launch plumbing tracked separately;
+    // persisting the identity into the shared file is not an acceptable
+    // stopgap.
     if let Some(contract) = mcp_contract.as_ref() {
-        crate::services::runtime::agent_mcp::materialize_mcp_json(&cwd, contract)?;
+        let for_disk = if actor.is_some() {
+            std::borrow::Cow::Owned(crate::services::runtime::agent_mcp::strip_actor_from_contract(contract))
+        } else {
+            std::borrow::Cow::Borrowed(contract)
+        };
+        crate::services::runtime::agent_mcp::materialize_mcp_json(&cwd, &for_disk)?;
     }
 
     // Sink selection: --json => JSONL stdout; --stream (no json) => text;

--- a/crates/orchestrator-cli/src/shared/parsing.rs
+++ b/crates/orchestrator-cli/src/shared/parsing.rs
@@ -1,3 +1,4 @@
+use animus_actor::Actor;
 use anyhow::Result;
 use orchestrator_core::{WorkflowQuerySort, WorkflowStatus};
 use protocol::{AgentRunEvent, RunId};
@@ -158,6 +159,30 @@ pub(crate) fn parse_workflow_query_sort_opt(value: Option<&str>) -> Result<Optio
     Ok(Some(sort))
 }
 
+/// Parse the `--actor-json` flag (a JSON-encoded [`Actor`]) into an
+/// `Option<Actor>`, mirroring the parse `animus mcp serve --actor-json`
+/// performs in `ops_mcp`.
+///
+/// `None`/absent flag ⇒ `Ok(None)` ⇒ global scope (unchanged behavior). A
+/// present-but-malformed value is a HARD error: the flag is a transport
+/// assertion of an authenticated caller, so a garbled identity must fail loud
+/// rather than silently degrade to global scope (fail-closed).
+///
+/// TRUST BOUNDARY: the actor is supplied ONLY by the (authenticated) caller via
+/// this flag. The transport (e.g. the portal) authenticates the user and then
+/// passes `--actor-json`; the kernel does NOT validate the claims — it relays
+/// them verbatim to the config_source / runner / MCP surfaces, which enforce.
+/// The value is NEVER synthesized from local context, workflow YAML, agent
+/// output, or subject content.
+pub(crate) fn parse_actor_json_flag(value: Option<&str>) -> Result<Option<Actor>> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let actor = serde_json::from_str::<Actor>(raw)
+        .map_err(|error| invalid_input_error(format!("invalid --actor-json: {error}; {COMMAND_HELP_HINT}")))?;
+    Ok(Some(actor))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,6 +194,21 @@ mod tests {
     fn parse_workflow_filters_accept_aliases() {
         assert_eq!(parse_workflow_status_opt(Some("running")).unwrap(), Some(WorkflowStatus::Running));
         assert_eq!(parse_workflow_query_sort_opt(Some("workflow_ref")).unwrap(), Some(WorkflowQuerySort::WorkflowRef));
+    }
+
+    #[test]
+    fn parse_actor_json_flag_round_trips_and_fails_closed() {
+        assert_eq!(parse_actor_json_flag(None).unwrap(), None);
+
+        let actor = parse_actor_json_flag(Some(r#"{"user_id":"alice","claims":["admin"]}"#))
+            .expect("valid actor json should parse")
+            .expect("present flag yields Some");
+        assert_eq!(actor.user_id, "alice");
+        assert_eq!(actor.claims, vec!["admin".to_string()]);
+        assert_eq!(actor.tenant_id, None);
+
+        let error = parse_actor_json_flag(Some("not-json")).expect_err("malformed actor json must fail closed");
+        assert!(error.to_string().contains("invalid --actor-json"));
     }
 
     #[test]

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1813,6 +1813,38 @@ validation errors with rich caret-style line/column indicators. Under
 compile`. The `warnings[]` array reports declared-but-unenforced fields in
 both modes.
 
+### `--actor-json` (transport-asserted per-user scoping)
+
+`animus workflow run`, `animus workflow config get`, `animus workflow config
+validate`, and `animus chat send` accept `--actor-json <JSON>` — a JSON-encoded
+`Actor` (`{"user_id","claims","tenant_id"}`) that scopes the operation to that
+user, mirroring `animus mcp serve --actor-json`:
+
+```bash
+animus workflow run --task-id TASK-1 --actor-json '{"user_id":"alice"}'
+animus workflow config get  --actor-json '{"user_id":"alice"}'
+animus chat send "hi" --as-user alice --actor-json '{"user_id":"alice","claims":["admin"]}'
+```
+
+- `workflow run` relays the actor to the runner (and onward to the per-agent
+  `animus mcp serve` child + config_source), so the run resolves the actor's
+  config partition and the agent's tools scope per-user.
+- `workflow config get` / `validate` return the actor's
+  global ∪ private ∪ shared config set; an actor whose `claims` contains
+  `admin` sees everything; **no flag = global-only**.
+- `chat send --actor-json` is the **authz** identity for the turn (binds the
+  chat agent's built-in `animus` MCP server to that user). It is distinct from
+  `--as-user`, which only stamps **conversation ownership** for the
+  `conversation_store`.
+- Omitting the flag = `None` = global scope (system / local runs), unchanged.
+
+**Trust boundary:** the flag is a *transport assertion*. The transport (e.g. a
+portal) authenticates the user and then passes `--actor-json`; the kernel does
+**not** validate the claims — it relays them verbatim to the surfaces that
+enforce. The actor is never synthesized from local context, workflow YAML,
+agent output, or subject content. A malformed value is a hard error
+(fail-closed), never a silent downgrade to global scope.
+
 ### `animus workflow config set` / entity write-back
 
 The `set` family persists config back through the installed **writable**


### PR DESCRIPTION
## What
Adds the transport assertion surface for the per-user Actor: `--actor-json '<JSON>'` on `workflow run`, `workflow config get`, `workflow config validate`, and `chat send` (mirrors the existing `mcp serve --actor-json`). v0.6.20 already relays/consumes the actor; this is the only missing *setter*, so a portal that authenticates the user can now scope runs + config reads to them.

- Fail-closed JSON parse (`parse_actor_json_flag`); threads the actor into the run request / config load / chat MCP contract.
- Actor is never written to the shared cwd `.mcp.json` — it rides the ephemeral runtime contract.

## Verification
build/clippy clean; `cargo test` 1223 pass / 2 pre-existing fail; 7 new tests (clap parse ×3, fail-closed parse, distinct-actor config-get threading, contract strip). **codex 4 rounds → 0 findings.**

## Limitation (tracked)
Providers scoping only off cwd `.mcp.json` auto-discovery don't get the actor on that channel (needs per-run isolated MCP config — `TODO(codex-p1)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)