### PR TITLE
v0.6.23 — ship `subject list --query` (v0.6.22 tag collision)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.22"
+version = "0.6.23"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Re-cuts the `subject list --query` title filter (PR #288) as v0.6.23. Its release/v0.6.22 branch merged just after #289 also bumped to v0.6.22, so the auto-tagger skipped (tag already existed) and the v0.6.22 release binary excludes --query. The change is already on main; this only bumps the crate version so a tag/release is produced. No code diff vs main.