### PR TITLE
feat(journal): v0.6.25 — durable workflow_journal backend (JournalClient + event-sink)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "animus-journal-protocol"
+version = "0.1.15"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.1.26#a6e37ed730204449dfe61ff4f413d7bd3bec2401"
+dependencies = [
+ "animus-plugin-protocol 0.1.15",
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "animus-log-storage-protocol"
 version = "0.1.15"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.1.26#a6e37ed730204449dfe61ff4f413d7bd3bec2401"
@@ -353,7 +368,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -364,7 +379,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1303,7 +1318,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1402,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2569,7 +2584,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2840,6 +2855,7 @@ name = "orchestrator-core"
 version = "0.1.0"
 dependencies = [
  "animus-actor",
+ "animus-journal-protocol",
  "animus-plugin-protocol 0.1.0",
  "anyhow",
  "argon2",
@@ -3575,7 +3591,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3633,7 +3649,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4005,7 +4021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4145,7 +4161,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4549,7 +4565,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ categories = ["command-line-utilities", "development-tools"]
 animus-plugin-protocol = { path = "crates/animus-plugin-protocol" }
 animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.1.26" }
 animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.1.26" }
+animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.1.26" }
 animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.1.26" }
 animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.1.26" }
 animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.1.26" }

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.24"
+version = "0.6.25"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/operations/ops_doctor/checks_plugins.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_doctor/checks_plugins.rs
@@ -51,6 +51,7 @@ pub(crate) fn run(ctx: &CheckContext) -> Vec<DiagnosticCheck> {
             RequiredRole::WorkflowRunner => summaries.iter().any(|s| s.is_workflow_runner()),
             RequiredRole::Queue => summaries.iter().any(|s| s.is_queue()),
             RequiredRole::ConfigSource => summaries.iter().any(|s| s.is_config_source()),
+            RequiredRole::WorkflowJournal => summaries.iter().any(|s| s.is_workflow_journal()),
         };
         if !satisfied {
             missing_roles.push(label);

--- a/crates/orchestrator-core/Cargo.toml
+++ b/crates/orchestrator-core/Cargo.toml
@@ -19,6 +19,7 @@ zstd = "0.13"
 tempfile = "3"
 protocol = { workspace = true }
 animus-actor = { workspace = true }
+animus-journal-protocol = { workspace = true }
 animus-plugin-protocol = { workspace = true }
 orchestrator-plugin-host = { workspace = true }
 orchestrator-config = { workspace = true }

--- a/crates/orchestrator-core/src/plugin_preflight/mod.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/mod.rs
@@ -22,6 +22,8 @@ const PLUGIN_KIND_WORKFLOW_RUNNER: &str = "workflow_runner";
 const PLUGIN_KIND_QUEUE: &str = "queue";
 /// Plugin-kind wire value for `config_source` (v0.6). See [`PLUGIN_KIND_QUEUE`].
 const PLUGIN_KIND_CONFIG_SOURCE: &str = "config_source";
+/// Plugin-kind wire value for `workflow_journal` (BU-1). See [`PLUGIN_KIND_QUEUE`].
+const PLUGIN_KIND_WORKFLOW_JOURNAL: &str = "workflow_journal";
 
 /// Minimum `workflow_runner` plugin version that consumes phase skill
 /// payloads. The reference runner
@@ -176,6 +178,12 @@ pub enum RequiredRole {
     /// daemon default required-roles until the load path resolves it (else
     /// existing daemons fail preflight on upgrade).
     ConfigSource,
+    /// Satisfied by ANY installed `workflow_journal` plugin (BU-1). This role is
+    /// OPTIONAL: it is NEVER added to [`PluginPreflightSpec::daemon_default`], so
+    /// its absence never blocks boot — with no plugin installed the kernel uses
+    /// the in-tree SQLite journal, exactly as before. The variant exists so the
+    /// role's presence can be reported (and required by an explicit spec/test).
+    WorkflowJournal,
 }
 
 impl RequiredRole {
@@ -188,6 +196,7 @@ impl RequiredRole {
             RequiredRole::WorkflowRunner => "workflow_runner".to_string(),
             RequiredRole::Queue => "queue".to_string(),
             RequiredRole::ConfigSource => "config_source".to_string(),
+            RequiredRole::WorkflowJournal => "workflow_journal".to_string(),
         }
     }
 }
@@ -349,6 +358,10 @@ impl InstalledPluginSummary {
 
     pub fn is_config_source(&self) -> bool {
         self.plugin_kind == PLUGIN_KIND_CONFIG_SOURCE
+    }
+
+    pub fn is_workflow_journal(&self) -> bool {
+        self.plugin_kind == PLUGIN_KIND_WORKFLOW_JOURNAL
     }
 
     pub fn covers_subject_kind(&self, kind: &str) -> bool {

--- a/crates/orchestrator-core/src/plugin_preflight/runner.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/runner.rs
@@ -71,6 +71,7 @@ fn role_is_satisfied(role: &RequiredRole, installed: &[InstalledPluginSummary]) 
         RequiredRole::WorkflowRunner => installed.iter().any(|p| p.is_workflow_runner()),
         RequiredRole::Queue => installed.iter().any(|p| p.is_queue()),
         RequiredRole::ConfigSource => installed.iter().any(|p| p.is_config_source()),
+        RequiredRole::WorkflowJournal => installed.iter().any(|p| p.is_workflow_journal()),
     }
 }
 
@@ -102,6 +103,9 @@ fn fix_command_for(role: &RequiredRole, default_repo: Option<&str>) -> String {
         }
         RequiredRole::ConfigSource => {
             format!("animus plugin install {target}  # config_source backend")
+        }
+        RequiredRole::WorkflowJournal => {
+            format!("animus plugin install {target}  # workflow_journal backend (optional; SQLite by default)")
         }
     }
 }

--- a/crates/orchestrator-core/src/workflow.rs
+++ b/crates/orchestrator-core/src/workflow.rs
@@ -1,8 +1,13 @@
+mod journal_client;
 mod lifecycle_executor;
 mod phase_plan;
 mod resume;
 mod state_machine;
 mod state_manager;
+
+pub use journal_client::{
+    record_wire_event as journal_record_wire_event, shutdown_resident_hosts as shutdown_journal_hosts,
+};
 
 pub use lifecycle_executor::WorkflowLifecycleExecutor;
 pub use phase_plan::{

--- a/crates/orchestrator-core/src/workflow/journal_client.rs
+++ b/crates/orchestrator-core/src/workflow/journal_client.rs
@@ -1,0 +1,709 @@
+//! BU-1: the `workflow_journal` plugin seam.
+//!
+//! [`WorkflowStateManager`](super::state_manager::WorkflowStateManager) persists
+//! workflow RUN STATE, CHECKPOINTS, and lifecycle EVENTS. Historically that lived
+//! exclusively in a local SQLite file (`workflow.db`), which is ephemeral on a
+//! disposable host (a Railway container loses run history on every redeploy).
+//!
+//! This module resolves the backend ONCE at `WorkflowStateManager::new`:
+//! - no `workflow_journal` plugin installed  => [`JournalBackend::Sqlite`]
+//!   (the in-tree rusqlite engine, byte-identical to pre-BU-1 behavior).
+//! - a `workflow_journal` plugin installed    => [`JournalBackend::Plugin`]
+//!   (run state/checkpoints/events persist through the plugin's `journal/*`
+//!   RPCs, e.g. Postgres).
+//!
+//! The plugin treats run state as an OPAQUE JSON blob (`JournalRun::blob`, the
+//! serialized `OrchestratorWorkflow`) plus indexed summary columns, so the kernel
+//! can evolve the workflow model without a protocol bump.
+//!
+//! ## Capability boundary (v1)
+//!
+//! The journal protocol lets a minimal backend advertise
+//! `supports_checkpoints = false` / `supports_events = false`. This kernel half
+//! (BU-1) does NOT yet read `journal/schema` to gate delegation: an installed
+//! `workflow_journal` plugin is expected to implement the FULL method set
+//! (run state + checkpoints + record). The reference Postgres backend does.
+//! A capability-aware fallback to local SQLite for checkpoints/events is a
+//! follow-up. The event sink (BU-3) is the one exception — it is purely additive
+//! and a `journal/record` failure is logged and dropped, never fatal.
+//!
+//! ## Resident-host model
+//!
+//! Mirrors `orchestrator_config::workflow_config::config_source_client`: ONE warm
+//! plugin host per project root, kept across calls (journal RPCs fire per phase),
+//! with death-aware respawn and a sync↔async bridge ([`run_blocking`]).
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use animus_actor::Actor;
+use animus_journal_protocol::{
+    CheckpointListResult, CheckpointLoadParams, CheckpointLoadResult, CheckpointPruneParams, CheckpointSaveParams,
+    JournalEvent, JournalQuery, JournalRun, ListResult, LoadResult, QueryIdsResult, RecordParams, SaveParams,
+    WorkflowIdParams, METHOD_JOURNAL_CHECKPOINT_LIST, METHOD_JOURNAL_CHECKPOINT_LOAD, METHOD_JOURNAL_CHECKPOINT_PRUNE,
+    METHOD_JOURNAL_CHECKPOINT_SAVE, METHOD_JOURNAL_DELETE, METHOD_JOURNAL_LIST, METHOD_JOURNAL_LOAD,
+    METHOD_JOURNAL_QUERY_IDS, METHOD_JOURNAL_RECORD, METHOD_JOURNAL_SAVE, PLUGIN_KIND_WORKFLOW_JOURNAL,
+};
+use anyhow::{anyhow, Context, Result};
+use orchestrator_plugin_host::session::plugin_supervisor::{classify, RetryDecision};
+use orchestrator_plugin_host::{discover_by_kind, DiscoveredPlugin, HostError, PluginHost, PluginSpawnOptions};
+
+use crate::types::{OrchestratorWorkflow, WorkflowStatus};
+
+const JOURNAL_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Env kill-switch: when set to `1`/`true`, force the in-tree SQLite backend even
+/// if a `workflow_journal` plugin is discovered. Safety valve so an operator (or a
+/// dev machine with a globally-installed journal plugin) can pin the byte-identical
+/// local path without uninstalling. Requires a process restart to take effect
+/// (the backend is resolved once and cached).
+const DISABLE_JOURNAL_PLUGIN_ENV: &str = "ANIMUS_DISABLE_WORKFLOW_JOURNAL_PLUGIN";
+
+/// Reserved blob key holding the run's transport-asserted [`Actor`] in the plugin
+/// backend. The journal protocol's `JournalRun` has no actor field (actor is kernel
+/// ROUTING context, not part of the wire run record), and the local SQLite backend
+/// stores it in a dedicated column. For the plugin backend we fold it into the
+/// opaque blob under this key; it is stripped before the blob is deserialized back
+/// into an `OrchestratorWorkflow`.
+const ACTOR_BLOB_KEY: &str = "__animus_actor__";
+
+/// Which persistence engine a [`WorkflowStateManager`](super::state_manager::WorkflowStateManager)
+/// is bound to for its lifetime. Resolved once at construction.
+#[derive(Debug, Clone)]
+pub(crate) enum JournalBackend {
+    /// In-tree rusqlite engine (`workflow.db`). The default; byte-identical to
+    /// pre-BU-1 behavior.
+    Sqlite,
+    /// An installed `workflow_journal` plugin. Carries the discovered plugin
+    /// (boxed — it is far larger than the unit `Sqlite` variant); the warm host
+    /// lives in the process-global resident-host cache keyed by root.
+    Plugin(Box<DiscoveredPlugin>),
+}
+
+/// Process-global cache of resolved backends keyed by normalized project root, so
+/// the (cheap, no-spawn) plugin discovery runs once per root rather than on every
+/// `WorkflowStateManager::new` (constructed ad hoc in ~12 call sites, some per
+/// phase). Mirrors the resident-host caching rationale in `config_source_client`.
+fn backend_cache() -> &'static Mutex<HashMap<PathBuf, JournalBackend>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, JournalBackend>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Resolve the journal backend for `project_root`, caching the decision. Returns
+/// [`JournalBackend::Sqlite`] when no `workflow_journal` plugin is installed (the
+/// default) or when the kill-switch is set; otherwise [`JournalBackend::Plugin`].
+pub(crate) fn resolve_backend(project_root: &Path) -> JournalBackend {
+    let key = normalize_root(project_root);
+    if let Some(cached) = backend_cache().lock().unwrap_or_else(|p| p.into_inner()).get(&key).cloned() {
+        return cached;
+    }
+    let resolved = discover_backend(project_root);
+    backend_cache().lock().unwrap_or_else(|p| p.into_inner()).insert(key, resolved.clone());
+    resolved
+}
+
+fn discover_backend(project_root: &Path) -> JournalBackend {
+    if env_flag_enabled(DISABLE_JOURNAL_PLUGIN_ENV) {
+        return JournalBackend::Sqlite;
+    }
+    match discover_by_kind(project_root.to_path_buf(), PLUGIN_KIND_WORKFLOW_JOURNAL) {
+        Ok(mut plugins) if !plugins.is_empty() => JournalBackend::Plugin(Box::new(plugins.remove(0))),
+        _ => JournalBackend::Sqlite,
+    }
+}
+
+fn env_flag_enabled(var: &str) -> bool {
+    std::env::var(var).map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on")).unwrap_or(false)
+}
+
+/// The installed `workflow_journal` plugin for `project_root`, or `None` (SQLite).
+/// Used by the free-function summary/index readers in `state_manager` so they
+/// route through the same backend as `WorkflowStateManager` rather than reading a
+/// stale local SQLite table when a plugin is installed.
+pub(crate) fn plugin_for(project_root: &Path) -> Option<DiscoveredPlugin> {
+    match resolve_backend(project_root) {
+        JournalBackend::Sqlite => None,
+        JournalBackend::Plugin(plugin) => Some(*plugin),
+    }
+}
+
+/// Clear the cached backend decisions. Test-only seam so a test that installs (or
+/// removes) a synthetic plugin between runs is not served a stale decision.
+#[cfg(test)]
+pub(crate) fn reset_backend_cache_for_tests() {
+    backend_cache().lock().unwrap_or_else(|p| p.into_inner()).clear();
+}
+
+// ---------------------------------------------------------------------------
+// Blob <-> OrchestratorWorkflow conversions
+// ---------------------------------------------------------------------------
+
+fn status_wire(status: WorkflowStatus) -> &'static str {
+    match status {
+        WorkflowStatus::Pending => "pending",
+        WorkflowStatus::Running => "running",
+        WorkflowStatus::Paused => "paused",
+        WorkflowStatus::Completed => "completed",
+        WorkflowStatus::Failed => "failed",
+        WorkflowStatus::Escalated => "escalated",
+        WorkflowStatus::Cancelled => "cancelled",
+    }
+}
+
+/// Serialize an [`OrchestratorWorkflow`] into a [`JournalRun`]: the blob is the
+/// serialized workflow (the same shape persisted as `snapshot_json` in checkpoints
+/// today), plus indexed summary columns the backend can query.
+pub(crate) fn to_journal_run(workflow: &OrchestratorWorkflow) -> Result<JournalRun> {
+    let blob = serde_json::to_value(workflow).context("serializing OrchestratorWorkflow for journal")?;
+    let kind = if workflow.subject.kind.is_empty() { None } else { Some(workflow.subject.kind.clone()) };
+    Ok(JournalRun {
+        workflow_id: workflow.id.clone(),
+        workflow_ref: workflow.workflow_ref.clone(),
+        status: status_wire(workflow.status).to_string(),
+        kind,
+        blob,
+        created_at: Some(workflow.started_at),
+        updated_at: Some(workflow.completed_at.unwrap_or(workflow.started_at)),
+    })
+}
+
+/// Reconstruct an [`OrchestratorWorkflow`] from a [`JournalRun`] blob. The reserved
+/// [`ACTOR_BLOB_KEY`] (kernel routing context, not part of the workflow record) is
+/// stripped before deserialization so it never leaks into the model.
+pub(crate) fn from_journal_run(run: JournalRun) -> Result<OrchestratorWorkflow> {
+    let mut blob = run.blob;
+    if let Some(obj) = blob.as_object_mut() {
+        obj.remove(ACTOR_BLOB_KEY);
+    }
+    serde_json::from_value(blob).context("deserializing OrchestratorWorkflow from journal blob")
+}
+
+fn actor_from_run(run: &JournalRun) -> Option<Actor> {
+    run.blob.as_object().and_then(|obj| obj.get(ACTOR_BLOB_KEY)).and_then(|v| serde_json::from_value(v.clone()).ok())
+}
+
+// ---------------------------------------------------------------------------
+// Public sync surface used by WorkflowStateManager (Plugin backend only).
+// Each resolves/reuses the resident host and bridges async->sync via run_blocking.
+// ---------------------------------------------------------------------------
+
+/// Upsert a run's state. Preserves a previously-bound [`Actor`] (folded into the
+/// blob by [`save_actor`]) across saves, mirroring the SQLite backend's
+/// column-preserving upsert which never NULLs `actor` on a lifecycle save.
+pub(crate) fn save(plugin: &DiscoveredPlugin, project_root: &Path, workflow: &OrchestratorWorkflow) -> Result<()> {
+    let mut run = to_journal_run(workflow)?;
+    // Carry an existing actor forward: a normal `save` rewrites the whole blob, so
+    // without this it would drop the actor `save_actor` wrote at bootstrap.
+    if let Ok(Some(existing)) = load_run_opt(plugin, project_root, &workflow.id) {
+        if let Some(actor_value) = existing.blob.as_object().and_then(|o| o.get(ACTOR_BLOB_KEY)).cloned() {
+            if let Some(obj) = run.blob.as_object_mut() {
+                obj.insert(ACTOR_BLOB_KEY.to_string(), actor_value);
+            }
+        }
+    }
+    run_blocking(call(plugin, project_root, METHOD_JOURNAL_SAVE, SaveParams { run }))?.map(|_: serde_json::Value| ())
+}
+
+pub(crate) fn load(plugin: &DiscoveredPlugin, project_root: &Path, workflow_id: &str) -> Result<OrchestratorWorkflow> {
+    match load_run_opt(plugin, project_root, workflow_id)? {
+        Some(run) => from_journal_run(run),
+        None => Err(anyhow!("workflow not found: {workflow_id}")),
+    }
+}
+
+fn load_run_opt(plugin: &DiscoveredPlugin, project_root: &Path, workflow_id: &str) -> Result<Option<JournalRun>> {
+    let params = WorkflowIdParams { workflow_id: workflow_id.to_string() };
+    let value = run_blocking(call(plugin, project_root, METHOD_JOURNAL_LOAD, params))??;
+    let resp: LoadResult = serde_json::from_value(value).context("decoding journal LoadResult")?;
+    Ok(resp.run)
+}
+
+pub(crate) fn delete(plugin: &DiscoveredPlugin, project_root: &Path, workflow_id: &str) -> Result<()> {
+    let params = WorkflowIdParams { workflow_id: workflow_id.to_string() };
+    run_blocking(call(plugin, project_root, METHOD_JOURNAL_DELETE, params))?.map(|_: serde_json::Value| ())
+}
+
+/// List runs whose status is in `statuses` (empty = all), newest-first as ordered
+/// by the backend. Decodes each blob back into an `OrchestratorWorkflow`; rows that
+/// fail to decode are skipped (matching the SQLite path's `filter_map`).
+pub(crate) fn list(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    statuses: &[&str],
+) -> Result<Vec<OrchestratorWorkflow>> {
+    let query = JournalQuery {
+        status: statuses.iter().map(|s| (*s).to_string()).collect(),
+        workflow_ref: None,
+        updated_since: None,
+        limit: None,
+    };
+    let value = run_blocking(call(plugin, project_root, METHOD_JOURNAL_LIST, query))??;
+    let resp: ListResult = serde_json::from_value(value).context("decoding journal ListResult")?;
+    Ok(resp.runs.into_iter().filter_map(|run| from_journal_run(run).ok()).collect())
+}
+
+/// All run ids matching `status` (None = all). The caller paginates client-side.
+pub(crate) fn query_ids(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    status: Option<WorkflowStatus>,
+) -> Result<Vec<String>> {
+    let query = JournalQuery {
+        status: status.map(|s| vec![status_wire(s).to_string()]).unwrap_or_default(),
+        workflow_ref: None,
+        updated_since: None,
+        limit: None,
+    };
+    let value = run_blocking(call(plugin, project_root, METHOD_JOURNAL_QUERY_IDS, query))??;
+    let resp: QueryIdsResult = serde_json::from_value(value).context("decoding journal QueryIdsResult")?;
+    Ok(resp.ids)
+}
+
+pub(crate) fn checkpoint_save(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    workflow_id: &str,
+    checkpoint_num: usize,
+    blob: serde_json::Value,
+) -> Result<()> {
+    let params =
+        CheckpointSaveParams { workflow_id: workflow_id.to_string(), checkpoint_num: checkpoint_num as u32, blob };
+    run_blocking(call(plugin, project_root, METHOD_JOURNAL_CHECKPOINT_SAVE, params))?.map(|_: serde_json::Value| ())
+}
+
+pub(crate) fn checkpoint_load(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    workflow_id: &str,
+    checkpoint_num: usize,
+) -> Result<OrchestratorWorkflow> {
+    let params = CheckpointLoadParams { workflow_id: workflow_id.to_string(), checkpoint_num: checkpoint_num as u32 };
+    let value = run_blocking(call(plugin, project_root, METHOD_JOURNAL_CHECKPOINT_LOAD, params))??;
+    let resp: CheckpointLoadResult = serde_json::from_value(value).context("decoding journal CheckpointLoadResult")?;
+    match resp.blob {
+        Some(blob) => from_journal_run(JournalRun {
+            workflow_id: workflow_id.to_string(),
+            workflow_ref: None,
+            status: String::new(),
+            kind: None,
+            blob,
+            created_at: None,
+            updated_at: None,
+        }),
+        None => Err(anyhow!("checkpoint not found: {workflow_id} #{checkpoint_num}")),
+    }
+}
+
+pub(crate) fn checkpoint_list(plugin: &DiscoveredPlugin, project_root: &Path, workflow_id: &str) -> Result<Vec<usize>> {
+    let params = WorkflowIdParams { workflow_id: workflow_id.to_string() };
+    let value = run_blocking(call(plugin, project_root, METHOD_JOURNAL_CHECKPOINT_LIST, params))??;
+    let resp: CheckpointListResult = serde_json::from_value(value).context("decoding journal CheckpointListResult")?;
+    Ok(resp.checkpoint_nums.into_iter().map(|n| n as usize).collect())
+}
+
+pub(crate) fn checkpoint_prune(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    workflow_id: &str,
+    keep: usize,
+) -> Result<()> {
+    let params = CheckpointPruneParams { workflow_id: workflow_id.to_string(), keep: keep as u32 };
+    run_blocking(call(plugin, project_root, METHOD_JOURNAL_CHECKPOINT_PRUNE, params))?.map(|_: serde_json::Value| ())
+}
+
+/// Bind/clear the run's [`Actor`] by loading the run, folding the actor into the
+/// blob under [`ACTOR_BLOB_KEY`] (or removing it), and re-saving. Best-effort: a
+/// missing run is a no-op (the row must exist; mirrors the SQLite UPDATE that
+/// affects zero rows when absent).
+pub(crate) fn save_actor(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    workflow_id: &str,
+    actor: Option<&Actor>,
+) -> Result<()> {
+    let Some(mut run) = load_run_opt(plugin, project_root, workflow_id)? else {
+        return Ok(());
+    };
+    if let Some(obj) = run.blob.as_object_mut() {
+        match actor {
+            Some(actor) => {
+                let value = serde_json::to_value(actor).context("serializing actor for journal blob")?;
+                obj.insert(ACTOR_BLOB_KEY.to_string(), value);
+            }
+            None => {
+                obj.remove(ACTOR_BLOB_KEY);
+            }
+        }
+    }
+    run_blocking(call(plugin, project_root, METHOD_JOURNAL_SAVE, SaveParams { run }))?.map(|_: serde_json::Value| ())
+}
+
+/// Load the run's bound [`Actor`], if any. Best-effort: a missing run / key / a
+/// malformed value yields `None` (global scope), so a lifecycle op never fails on
+/// actor lookup (matching the SQLite backend).
+pub(crate) fn load_actor(plugin: &DiscoveredPlugin, project_root: &Path, workflow_id: &str) -> Option<Actor> {
+    let run = load_run_opt(plugin, project_root, workflow_id).ok()??;
+    actor_from_run(&run)
+}
+
+/// BU-3 event sink: append a lifecycle event. No-op for the SQLite backend (events
+/// are a plugin-only feature — purely additive, state still flows through
+/// `WorkflowStateManager`); issues `journal/record` for the plugin backend.
+///
+/// Async-native (no [`run_blocking`]): the daemon's event broadcaster tees each
+/// event by spawning this on the runtime, so it must not block the emit path.
+pub async fn record_event_async(project_root: &Path, event: JournalEvent) {
+    let plugin = match resolve_backend(project_root) {
+        JournalBackend::Sqlite => return,
+        JournalBackend::Plugin(plugin) => plugin,
+    };
+    if let Err(err) = with_resident_host(&plugin, project_root, move |host| {
+        let params = RecordParams { event: event.clone() };
+        async move {
+            let params = serde_json::to_value(&params)
+                .map_err(|e| ResidentCallError::Other(anyhow!("serializing RecordParams: {e}")))?;
+            journal_rpc(&host, METHOD_JOURNAL_RECORD, params).await.map(|_| ())
+        }
+    })
+    .await
+    {
+        tracing::debug!(
+            target: "animus.workflow.journal",
+            error = %err,
+            "workflow_journal record failed (event dropped; state persistence is unaffected)"
+        );
+    }
+}
+
+/// Map a wire workflow-event kind (as emitted by the broadcaster) to a
+/// [`JournalEventKind`]. Returns `None` for kinds with no journal mapping
+/// (e.g. `phase_failed`), which the sink skips.
+fn wire_kind_to_journal(wire_kind: &str) -> Option<animus_journal_protocol::JournalEventKind> {
+    use animus_journal_protocol::JournalEventKind as K;
+    match wire_kind {
+        "workflow_started" => Some(K::RunStarted),
+        "phase_started" => Some(K::PhaseStarted),
+        "phase_completed" => Some(K::PhaseCompleted),
+        "workflow_completed" => Some(K::RunCompleted),
+        "workflow_failed" => Some(K::RunFailed),
+        _ => None,
+    }
+}
+
+/// BU-3 convenience: build a [`JournalEvent`] from a broadcaster wire event and
+/// record it. No-op (returns immediately) for unmapped kinds or the SQLite
+/// backend. The full payload is preserved in `detail`; `phase`/`agent`/`status`
+/// are best-effort lifted from common payload keys for indexed columns.
+pub async fn record_wire_event(
+    project_root: &Path,
+    workflow_id: &str,
+    wire_kind: &str,
+    payload: serde_json::Value,
+    occurred_at: chrono::DateTime<chrono::Utc>,
+) {
+    let Some(kind) = wire_kind_to_journal(wire_kind) else {
+        return;
+    };
+    let phase = payload.get("phase_id").and_then(|v| v.as_str()).map(str::to_string);
+    let agent = payload.get("agent").or_else(|| payload.get("tool")).and_then(|v| v.as_str()).map(str::to_string);
+    let status =
+        payload.get("phase_status").or_else(|| payload.get("status")).and_then(|v| v.as_str()).map(str::to_string);
+    let workflow_ref = payload.get("workflow_ref").and_then(|v| v.as_str()).map(str::to_string);
+    let event = JournalEvent {
+        run_id: workflow_id.to_string(),
+        workflow_ref,
+        kind,
+        phase,
+        agent,
+        status,
+        ts: occurred_at,
+        detail: payload,
+    };
+    record_event_async(project_root, event).await;
+}
+
+// ---------------------------------------------------------------------------
+// Resident-host machinery (mirrors config_source_client).
+// ---------------------------------------------------------------------------
+
+struct ResidentHost {
+    host: PluginHost,
+    plugin_path: PathBuf,
+    binary_mtime_nanos: u128,
+    generation: u64,
+}
+
+fn next_generation() -> u64 {
+    static GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+    GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+fn binary_mtime_nanos(path: &Path) -> u128 {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+fn resident_hosts() -> &'static Mutex<HashMap<PathBuf, ResidentHost>> {
+    static HOSTS: OnceLock<Mutex<HashMap<PathBuf, ResidentHost>>> = OnceLock::new();
+    HOSTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn normalize_root(project_root: &Path) -> PathBuf {
+    std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf())
+}
+
+/// Reap every resident `workflow_journal` host. Wired into daemon graceful
+/// shutdown so warm plugin processes terminate cleanly. Idempotent.
+pub async fn shutdown_resident_hosts() {
+    let hosts: Vec<ResidentHost> = {
+        let mut guard = resident_hosts().lock().unwrap_or_else(|p| p.into_inner());
+        guard.drain().map(|(_, v)| v).collect()
+    };
+    for resident in hosts {
+        let _ = resident.host.shutdown().await;
+    }
+}
+
+async fn drop_resident_host_if_current(project_root: &Path, failed_gen: u64) {
+    let key = normalize_root(project_root);
+    let resident = {
+        let mut guard = resident_hosts().lock().unwrap_or_else(|p| p.into_inner());
+        match guard.get(&key) {
+            Some(existing) if existing.generation == failed_gen => guard.remove(&key),
+            _ => None,
+        }
+    };
+    if let Some(resident) = resident {
+        let _ = resident.host.shutdown().await;
+    }
+}
+
+enum ResidentCallError {
+    Death(anyhow::Error),
+    Other(anyhow::Error),
+}
+
+impl ResidentCallError {
+    fn from_host_error(err: HostError) -> Self {
+        match classify(&err) {
+            RetryDecision::DeathLike => ResidentCallError::Death(anyhow!(err)),
+            RetryDecision::StructuredError => ResidentCallError::Other(anyhow!(err)),
+        }
+    }
+}
+
+/// Run one `journal/*` RPC: serialize `params`, dispatch against the resident host
+/// (spawning it once if absent), reap+respawn+retry once on a death-like failure.
+/// Returns the raw response `Value` for the caller to decode.
+async fn call<P: serde::Serialize>(
+    plugin: &DiscoveredPlugin,
+    project_root: &Path,
+    method: &'static str,
+    params: P,
+) -> Result<serde_json::Value> {
+    let params = serde_json::to_value(&params).with_context(|| format!("serializing params for {method}"))?;
+    with_resident_host(plugin, project_root, move |host| {
+        let params = params.clone();
+        async move { journal_rpc(&host, method, params).await }
+    })
+    .await
+}
+
+async fn journal_rpc(
+    host: &PluginHost,
+    method: &'static str,
+    params: serde_json::Value,
+) -> std::result::Result<serde_json::Value, ResidentCallError> {
+    host.request_typed_with_timeout(method, Some(params), JOURNAL_RPC_TIMEOUT)
+        .await
+        .map_err(ResidentCallError::from_host_error)
+}
+
+async fn with_resident_host<T, F, Fut>(plugin: &DiscoveredPlugin, project_root: &Path, mut call: F) -> Result<T>
+where
+    F: FnMut(PluginHost) -> Fut,
+    Fut: Future<Output = std::result::Result<T, ResidentCallError>>,
+{
+    let (host, generation) = acquire_resident_host(plugin, project_root).await?;
+    match call(host).await {
+        Ok(value) => Ok(value),
+        Err(ResidentCallError::Other(err)) => Err(err),
+        Err(ResidentCallError::Death(err)) => {
+            drop_resident_host_if_current(project_root, generation).await;
+            let (host, _gen) = acquire_resident_host(plugin, project_root).await?;
+            match call(host).await {
+                Ok(value) => Ok(value),
+                Err(ResidentCallError::Other(retry_err)) => Err(retry_err),
+                Err(ResidentCallError::Death(retry_err)) => Err(retry_err.context(format!(
+                    "workflow_journal plugin {} still failing after one re-spawn (first error: {err})",
+                    plugin.name
+                ))),
+            }
+        }
+    }
+}
+
+async fn acquire_resident_host(plugin: &DiscoveredPlugin, project_root: &Path) -> Result<(PluginHost, u64)> {
+    let key = normalize_root(project_root);
+    let current_mtime = binary_mtime_nanos(&plugin.path);
+    {
+        let guard = resident_hosts().lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(resident) = guard.get(&key) {
+            if resident.plugin_path == plugin.path && resident.binary_mtime_nanos == current_mtime {
+                return Ok((resident.host.clone(), resident.generation));
+            }
+        }
+    }
+
+    let host = spawn_journal_host(plugin).await?;
+    host.handshake().await.with_context(|| format!("handshake with workflow_journal plugin {}", plugin.name))?;
+
+    enum Outcome {
+        UseExisting { winner: PluginHost, generation: u64, reap_ours: PluginHost },
+        Installed { ours: PluginHost, generation: u64, reap_old: Option<PluginHost> },
+    }
+    let outcome = {
+        let mut guard = resident_hosts().lock().unwrap_or_else(|p| p.into_inner());
+        match guard.get(&key) {
+            Some(existing) if existing.plugin_path == plugin.path && existing.binary_mtime_nanos == current_mtime => {
+                Outcome::UseExisting { winner: existing.host.clone(), generation: existing.generation, reap_ours: host }
+            }
+            _ => {
+                let ours = host.clone();
+                let generation = next_generation();
+                let replaced = guard.insert(
+                    key,
+                    ResidentHost {
+                        host,
+                        plugin_path: plugin.path.clone(),
+                        binary_mtime_nanos: current_mtime,
+                        generation,
+                    },
+                );
+                Outcome::Installed { ours, generation, reap_old: replaced.map(|r| r.host) }
+            }
+        }
+    };
+
+    match outcome {
+        Outcome::UseExisting { winner, generation, reap_ours } => {
+            let _ = reap_ours.shutdown().await;
+            Ok((winner, generation))
+        }
+        Outcome::Installed { ours, generation, reap_old } => {
+            if let Some(old) = reap_old {
+                let _ = old.shutdown().await;
+            }
+            Ok((ours, generation))
+        }
+    }
+}
+
+async fn spawn_journal_host(plugin: &DiscoveredPlugin) -> Result<PluginHost> {
+    let forwarded_env: Vec<String> = std::env::vars().map(|(name, _)| name).collect();
+    let options =
+        PluginSpawnOptions::for_manifest(plugin.name.clone(), &plugin.manifest.env_required, forwarded_env, None);
+    PluginHost::spawn_with_options(&plugin.path, &[], options)
+        .await
+        .with_context(|| format!("spawning workflow_journal plugin {}", plugin.name))
+}
+
+/// Bridge an async future into a sync call. Works whether or not a tokio runtime
+/// is already running (daemon = inside a runtime; CLI = none). Mirrors
+/// `config_source_client::run_blocking`.
+fn run_blocking<F: Future>(fut: F) -> Result<F::Output> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(fut))),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("building tokio runtime for workflow_journal call")?;
+            Ok(rt.block_on(fut))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{SubjectRef, WorkflowCheckpointMetadata, WorkflowMachineState};
+
+    fn sample_workflow(id: &str) -> OrchestratorWorkflow {
+        OrchestratorWorkflow {
+            id: id.to_string(),
+            task_id: "TASK-1".to_string(),
+            workflow_ref: Some("task-default".to_string()),
+            subject: SubjectRef::task("TASK-1".to_string()),
+            input: None,
+            vars: HashMap::new(),
+            status: WorkflowStatus::Running,
+            current_phase_index: 0,
+            phases: Vec::new(),
+            machine_state: WorkflowMachineState::Idle,
+            current_phase: None,
+            started_at: chrono::Utc::now(),
+            completed_at: None,
+            failure_reason: None,
+            checkpoint_metadata: WorkflowCheckpointMetadata::default(),
+            rework_counts: HashMap::new(),
+            total_reworks: 0,
+            decision_history: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn journal_run_round_trips_through_blob() {
+        let wf = sample_workflow("wf-1");
+        let run = to_journal_run(&wf).expect("to run");
+        assert_eq!(run.workflow_id, "wf-1");
+        assert_eq!(run.workflow_ref.as_deref(), Some("task-default"));
+        assert_eq!(run.status, "running");
+        assert_eq!(run.kind.as_deref(), Some("animus.task"));
+        let back = from_journal_run(run).expect("from run");
+        assert_eq!(back.id, "wf-1");
+        assert_eq!(back.task_id, "TASK-1");
+        assert_eq!(back.status, WorkflowStatus::Running);
+    }
+
+    #[test]
+    fn actor_blob_key_is_stripped_before_deserialization() {
+        let wf = sample_workflow("wf-2");
+        let mut run = to_journal_run(&wf).expect("to run");
+        // Simulate save_actor having folded an actor into the blob.
+        let actor = Actor { user_id: "alice".into(), claims: vec!["c".into()], tenant_id: None };
+        run.blob.as_object_mut().unwrap().insert(ACTOR_BLOB_KEY.to_string(), serde_json::to_value(&actor).unwrap());
+
+        assert_eq!(actor_from_run(&run).map(|a| a.user_id), Some("alice".to_string()));
+        // The reserved key must not break workflow deserialization.
+        let back = from_journal_run(run).expect("from run with actor key");
+        assert_eq!(back.id, "wf-2");
+    }
+
+    #[test]
+    fn no_plugin_installed_resolves_to_sqlite() {
+        reset_backend_cache_for_tests();
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(matches!(resolve_backend(dir.path()), JournalBackend::Sqlite));
+    }
+
+    #[test]
+    fn kill_switch_forces_sqlite() {
+        // The discover path is exercised elsewhere; here assert the env flag parser.
+        assert!(env_flag_enabled_value("1"));
+        assert!(env_flag_enabled_value("true"));
+        assert!(!env_flag_enabled_value("0"));
+        assert!(!env_flag_enabled_value(""));
+    }
+
+    fn env_flag_enabled_value(v: &str) -> bool {
+        matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on")
+    }
+}

--- a/crates/orchestrator-core/src/workflow/state_manager.rs
+++ b/crates/orchestrator-core/src/workflow/state_manager.rs
@@ -202,14 +202,32 @@ fn dir_size_bytes(path: &std::path::Path) -> u64 {
 #[derive(Clone)]
 pub struct WorkflowStateManager {
     project_root: PathBuf,
+    /// Resolved ONCE at construction: SQLite (no plugin installed — the default,
+    /// byte-identical to pre-BU-1 behavior) or an installed `workflow_journal`
+    /// plugin. See [`super::journal_client`].
+    backend: super::journal_client::JournalBackend,
 }
 
 impl WorkflowStateManager {
     pub fn new(project_root: impl Into<PathBuf>) -> Self {
-        Self { project_root: project_root.into() }
+        let project_root = project_root.into();
+        let backend = super::journal_client::resolve_backend(&project_root);
+        Self { project_root, backend }
+    }
+
+    /// The installed `workflow_journal` plugin, if the backend resolved to one.
+    /// `None` => SQLite (run every existing code path unchanged).
+    fn journal_plugin(&self) -> Option<&orchestrator_plugin_host::DiscoveredPlugin> {
+        match &self.backend {
+            super::journal_client::JournalBackend::Sqlite => None,
+            super::journal_client::JournalBackend::Plugin(plugin) => Some(plugin.as_ref()),
+        }
     }
 
     pub fn save(&self, workflow: &OrchestratorWorkflow) -> Result<()> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::save(plugin, &self.project_root, workflow);
+        }
         let conn = self.open_db()?;
         self.save_with_conn(&conn, workflow)
     }
@@ -261,6 +279,9 @@ impl WorkflowStateManager {
     }
 
     pub fn load(&self, workflow_id: &str) -> Result<OrchestratorWorkflow> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::load(plugin, &self.project_root, workflow_id);
+        }
         let conn = self.open_db()?;
         let data: Vec<u8> = conn
             .query_row("SELECT json FROM workflows WHERE id = ?1", params![workflow_id], |row| row.get(0))
@@ -277,6 +298,9 @@ impl WorkflowStateManager {
     /// TRUST BOUNDARY: the actor originates only from the authenticated control
     /// request that started the run — never from agent output / YAML / subject.
     pub fn set_workflow_actor(&self, workflow_id: &str, actor: Option<&Actor>) -> Result<()> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::save_actor(plugin, &self.project_root, workflow_id, actor);
+        }
         let conn = self.open_db()?;
         let json = match actor {
             Some(actor) => Some(serde_json::to_string(actor).context("serializing actor for persistence")?),
@@ -291,6 +315,9 @@ impl WorkflowStateManager {
     /// missing row / column / malformed value yields `None` (global scope) so a
     /// lifecycle op never fails on actor lookup.
     pub fn load_workflow_actor(&self, workflow_id: &str) -> Option<Actor> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::load_actor(plugin, &self.project_root, workflow_id);
+        }
         let conn = self.open_db().ok()?;
         let json: Option<String> =
             conn.query_row("SELECT actor FROM workflows WHERE id = ?1", params![workflow_id], |row| row.get(0)).ok()?;
@@ -298,6 +325,9 @@ impl WorkflowStateManager {
     }
 
     pub fn list(&self) -> Result<Vec<OrchestratorWorkflow>> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::list(plugin, &self.project_root, &["running", "paused"]);
+        }
         let conn = self.open_db()?;
         let mut stmt = conn.prepare("SELECT json FROM workflows WHERE status IN ('running', 'paused')")?;
         let workflows = stmt
@@ -310,6 +340,9 @@ impl WorkflowStateManager {
     }
 
     pub fn list_active(&self) -> Result<Vec<OrchestratorWorkflow>> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::list(plugin, &self.project_root, &["pending", "running", "paused"]);
+        }
         let conn = self.open_db()?;
         let mut stmt = conn.prepare("SELECT json FROM workflows WHERE status IN ('pending', 'running', 'paused')")?;
         let workflows = stmt
@@ -322,6 +355,9 @@ impl WorkflowStateManager {
     }
 
     pub fn list_all(&self) -> Result<Vec<OrchestratorWorkflow>> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::list(plugin, &self.project_root, &[]);
+        }
         let conn = self.open_db()?;
         let mut stmt = conn.prepare("SELECT json FROM workflows")?;
         let workflows = stmt
@@ -338,6 +374,16 @@ impl WorkflowStateManager {
         page: ListPageRequest,
         status: Option<crate::types::WorkflowStatus>,
     ) -> Result<(Vec<String>, usize)> {
+        if let Some(plugin) = self.journal_plugin() {
+            // The journal protocol's query_ids has no offset/total, so fetch the
+            // full matching id set from the plugin and paginate client-side to
+            // preserve the (page, total) contract.
+            let all_ids = super::journal_client::query_ids(plugin, &self.project_root, status)?;
+            let total = all_ids.len();
+            let (start, end) = page.bounds(total);
+            let ids = all_ids.into_iter().skip(start).take(end.saturating_sub(start)).collect();
+            return Ok((ids, total));
+        }
         let conn = self.open_db()?;
 
         let total: usize = match status {
@@ -385,6 +431,18 @@ impl WorkflowStateManager {
 
     pub fn cleanup_terminal_workflows(&self, max_age_hours: u64) -> Result<CleanupResult> {
         let cutoff = Utc::now() - Duration::hours(max_age_hours as i64);
+        if let Some(plugin) = self.journal_plugin() {
+            let terminal = &["completed", "failed", "escalated", "cancelled"];
+            let runs = super::journal_client::list(plugin, &self.project_root, terminal)?;
+            let mut deleted = 0usize;
+            for workflow in runs {
+                if workflow.completed_at.unwrap_or(workflow.started_at) < cutoff {
+                    super::journal_client::delete(plugin, &self.project_root, &workflow.id)?;
+                    deleted += 1;
+                }
+            }
+            return Ok(CleanupResult { deleted });
+        }
         let cutoff_str = cutoff.to_rfc3339();
 
         let mut conn = self.open_db()?;
@@ -405,6 +463,9 @@ impl WorkflowStateManager {
     }
 
     pub fn delete(&self, workflow_id: &str) -> Result<()> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::delete(plugin, &self.project_root, workflow_id);
+        }
         let mut conn = self.open_db()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         tx.execute("DELETE FROM workflows WHERE id = ?1", params![workflow_id])?;
@@ -431,6 +492,20 @@ impl WorkflowStateManager {
     }
 
     fn list_run_prune_candidates(&self) -> Result<Vec<WorkflowRunPruneCandidate>> {
+        if let Some(plugin) = self.journal_plugin() {
+            // Terminal runs only; effective_at = completed_at (fall back to started_at).
+            let terminal = &["completed", "failed", "escalated", "cancelled"];
+            let runs = super::journal_client::list(plugin, &self.project_root, terminal)?;
+            let mut candidates = Vec::with_capacity(runs.len());
+            for workflow in runs {
+                candidates.push(WorkflowRunPruneCandidate {
+                    workflow_id: workflow.id.clone(),
+                    status: workflow.status,
+                    effective_at: workflow.completed_at.unwrap_or(workflow.started_at),
+                });
+            }
+            return Ok(candidates);
+        }
         let conn = self.open_db()?;
         let mut stmt = conn.prepare(
             "SELECT id, status, started_at, completed_at FROM workflows
@@ -516,13 +591,19 @@ impl WorkflowStateManager {
         }
 
         if !removable_ids.is_empty() {
-            let mut conn = self.open_db()?;
-            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-            for workflow_id in &removable_ids {
-                tx.execute("DELETE FROM workflows WHERE id = ?1", params![workflow_id])?;
-                tx.execute("DELETE FROM checkpoints WHERE workflow_id = ?1", params![workflow_id])?;
+            if let Some(plugin) = self.journal_plugin() {
+                for workflow_id in &removable_ids {
+                    super::journal_client::delete(plugin, &self.project_root, workflow_id)?;
+                }
+            } else {
+                let mut conn = self.open_db()?;
+                let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                for workflow_id in &removable_ids {
+                    tx.execute("DELETE FROM workflows WHERE id = ?1", params![workflow_id])?;
+                    tx.execute("DELETE FROM checkpoints WHERE workflow_id = ?1", params![workflow_id])?;
+                }
+                tx.commit()?;
             }
-            tx.commit()?;
         }
         Ok(report)
     }
@@ -562,6 +643,9 @@ impl WorkflowStateManager {
         workflow: &OrchestratorWorkflow,
         reason: CheckpointReason,
     ) -> Result<OrchestratorWorkflow> {
+        if let Some(plugin) = self.journal_plugin() {
+            return self.save_checkpoint_plugin(plugin, workflow, reason);
+        }
         let mut workflow = workflow.clone();
 
         let mut conn = self.open_db()?;
@@ -600,6 +684,47 @@ impl WorkflowStateManager {
         )?;
         self.save_with_conn(&tx, &workflow)?;
         tx.commit()?;
+
+        if workflow.checkpoint_metadata.checkpoint_count.is_multiple_of(5) {
+            let _ = self.prune_checkpoints(&workflow.id, DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST_PER_PHASE, None, false);
+        }
+
+        Ok(workflow)
+    }
+
+    /// Plugin-backend variant of [`Self::save_checkpoint`]: derives the next
+    /// checkpoint number from the plugin's checkpoint list, persists the snapshot
+    /// and the run via `journal/*`, and triggers the periodic prune. Mirrors the
+    /// SQLite path's bookkeeping; the snapshot blob is the serialized workflow
+    /// (raw JSON `Value`, exactly what the SQLite path compresses into
+    /// `snapshot_json`).
+    fn save_checkpoint_plugin(
+        &self,
+        plugin: &orchestrator_plugin_host::DiscoveredPlugin,
+        workflow: &OrchestratorWorkflow,
+        reason: CheckpointReason,
+    ) -> Result<OrchestratorWorkflow> {
+        let mut workflow = workflow.clone();
+        let max_persisted_number = super::journal_client::checkpoint_list(plugin, &self.project_root, &workflow.id)?
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+        workflow.checkpoint_metadata.checkpoint_count =
+            workflow.checkpoint_metadata.checkpoint_count.max(max_persisted_number) + 1;
+
+        let checkpoint = WorkflowCheckpoint {
+            number: workflow.checkpoint_metadata.checkpoint_count,
+            timestamp: Utc::now(),
+            reason,
+            phase_id: checkpoint_phase_id(&workflow),
+            machine_state: workflow.machine_state,
+            status: workflow.status,
+        };
+        workflow.checkpoint_metadata.checkpoints.push(checkpoint.clone());
+
+        let snapshot = serde_json::to_value(&workflow).context("serializing checkpoint snapshot")?;
+        super::journal_client::checkpoint_save(plugin, &self.project_root, &workflow.id, checkpoint.number, snapshot)?;
+        super::journal_client::save(plugin, &self.project_root, &workflow)?;
 
         if workflow.checkpoint_metadata.checkpoint_count.is_multiple_of(5) {
             let _ = self.prune_checkpoints(&workflow.id, DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST_PER_PHASE, None, false);
@@ -704,16 +829,36 @@ impl WorkflowStateManager {
         if !dry_run {
             workflow.checkpoint_metadata.checkpoints = retained_checkpoints;
 
-            let mut conn = self.open_db()?;
-            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-            self.save_with_conn(&tx, &workflow)?;
-            for checkpoint_num in &pruned_checkpoint_numbers {
-                tx.execute(
-                    "DELETE FROM checkpoints WHERE workflow_id = ?1 AND number = ?2",
-                    params![workflow_id, *checkpoint_num as i64],
+            if let Some(plugin) = self.journal_plugin() {
+                // TODO(codex-p2): the journal protocol exposes only
+                // `checkpoint_prune(keep)` (keep most-recent-N), not per-number
+                // deletion, so for multi-phase / age-based pruning the backend's
+                // retained SET can differ from the kernel's per-phase selection
+                // (`pruned_checkpoint_numbers`). The count converges and the
+                // report reflects the kernel's intended selection, but a backend
+                // that strictly keeps the newest N may retain a different blob set
+                // than the saved workflow metadata claims. Needs a protocol
+                // `checkpoint_delete(nums)` (or `checkpoint_retain(nums)`) to make
+                // the plugin path exact; the SQLite path is already exact.
+                super::journal_client::save(plugin, &self.project_root, &workflow)?;
+                super::journal_client::checkpoint_prune(
+                    plugin,
+                    &self.project_root,
+                    workflow_id,
+                    checkpoint_count_after,
                 )?;
+            } else {
+                let mut conn = self.open_db()?;
+                let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                self.save_with_conn(&tx, &workflow)?;
+                for checkpoint_num in &pruned_checkpoint_numbers {
+                    tx.execute(
+                        "DELETE FROM checkpoints WHERE workflow_id = ?1 AND number = ?2",
+                        params![workflow_id, *checkpoint_num as i64],
+                    )?;
+                }
+                tx.commit()?;
             }
-            tx.commit()?;
         }
 
         Ok(WorkflowCheckpointPruneResult {
@@ -753,6 +898,9 @@ impl WorkflowStateManager {
     }
 
     pub fn list_checkpoints(&self, workflow_id: &str) -> Result<Vec<usize>> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::checkpoint_list(plugin, &self.project_root, workflow_id);
+        }
         let conn = self.open_db()?;
         let mut stmt = conn.prepare("SELECT number FROM checkpoints WHERE workflow_id = ?1 ORDER BY number")?;
         let numbers: Vec<usize> = stmt
@@ -764,6 +912,9 @@ impl WorkflowStateManager {
     }
 
     pub fn load_checkpoint(&self, workflow_id: &str, checkpoint_num: usize) -> Result<OrchestratorWorkflow> {
+        if let Some(plugin) = self.journal_plugin() {
+            return super::journal_client::checkpoint_load(plugin, &self.project_root, workflow_id, checkpoint_num);
+        }
         let conn = self.open_db()?;
         let data: Vec<u8> = conn
             .query_row(
@@ -782,6 +933,21 @@ impl WorkflowStateManager {
 }
 
 pub fn load_active_workflow_summaries(project_root: &std::path::Path) -> Result<Vec<WorkflowActivitySummary>> {
+    if let Some(plugin) = super::journal_client::plugin_for(project_root) {
+        let runs = super::journal_client::list(&plugin, project_root, &["running", "paused"])?;
+        return Ok(runs
+            .into_iter()
+            .map(|workflow| {
+                let summary = workflow_summary_fields(&workflow);
+                WorkflowActivitySummary {
+                    workflow_id: workflow.id.clone(),
+                    task_id: workflow.task_id.clone(),
+                    status: status_str(workflow.status).to_string(),
+                    phase_id: summary.phase_id.unwrap_or_else(|| "unknown".to_string()),
+                }
+            })
+            .collect());
+    }
     let conn = open_project_db(project_root)?;
     let mut stmt = conn.prepare(
         "SELECT id, task_id, status, phase_id
@@ -815,6 +981,26 @@ pub fn load_recent_failed_workflow_summaries(
     project_root: &std::path::Path,
     limit: usize,
 ) -> Result<Vec<WorkflowFailureSummary>> {
+    if let Some(plugin) = super::journal_client::plugin_for(project_root) {
+        let runs = super::journal_client::list(&plugin, project_root, &["failed"])?;
+        let mut out: Vec<WorkflowFailureSummary> = runs
+            .into_iter()
+            .filter_map(|workflow| {
+                let summary = workflow_summary_fields(&workflow);
+                let failed_at = DateTime::parse_from_rfc3339(&summary.failed_at?).ok()?.with_timezone(&Utc);
+                Some(WorkflowFailureSummary {
+                    workflow_id: workflow.id.clone(),
+                    task_id: workflow.task_id.clone(),
+                    phase_id: summary.phase_id.unwrap_or_else(|| "unknown".to_string()),
+                    failed_at,
+                    failure_reason: summary.failure_reason,
+                })
+            })
+            .collect();
+        out.sort_by(|a, b| b.failed_at.cmp(&a.failed_at).then_with(|| a.workflow_id.cmp(&b.workflow_id)));
+        out.truncate(limit);
+        return Ok(out);
+    }
     let conn = open_project_db(project_root)?;
     let limit = i64::try_from(limit).context("recent failed workflow limit overflow")?;
     let mut stmt = conn.prepare(
@@ -853,6 +1039,21 @@ pub fn load_recent_failed_workflow_summaries(
 }
 
 pub fn load_workflow_history_summaries(project_root: &std::path::Path) -> Result<Vec<WorkflowHistorySummary>> {
+    if let Some(plugin) = super::journal_client::plugin_for(project_root) {
+        let runs = super::journal_client::list(&plugin, project_root, &[])?;
+        let mut out: Vec<WorkflowHistorySummary> = runs
+            .into_iter()
+            .map(|workflow| WorkflowHistorySummary {
+                workflow_id: workflow.id.clone(),
+                task_id: workflow.task_id.clone(),
+                status: status_str(workflow.status).to_string(),
+                started_at: workflow.started_at,
+                completed_at: workflow.completed_at,
+            })
+            .collect();
+        out.sort_by(|a, b| b.started_at.cmp(&a.started_at).then_with(|| a.workflow_id.cmp(&b.workflow_id)));
+        return Ok(out);
+    }
     let conn = open_project_db(project_root)?;
     let mut stmt = conn.prepare(
         "SELECT id, task_id, status, started_at, completed_at
@@ -896,6 +1097,15 @@ pub fn load_workflow_history_summaries(project_root: &std::path::Path) -> Result
 /// fail to decompress or parse are skipped silently — the caller
 /// gets a partial index rather than a hard error.
 pub fn load_workflow_ref_index(project_root: &std::path::Path) -> Result<std::collections::HashMap<String, String>> {
+    if let Some(plugin) = super::journal_client::plugin_for(project_root) {
+        // Best-effort, matching the SQLite path: a backend error yields an empty
+        // index rather than failing the caller (cost attribution degrades, not breaks).
+        let runs = super::journal_client::list(&plugin, project_root, &[]).unwrap_or_default();
+        return Ok(runs
+            .into_iter()
+            .filter_map(|workflow| workflow.workflow_ref.clone().map(|r| (workflow.id.clone(), r)))
+            .collect());
+    }
     let conn = match open_project_db(project_root) {
         Ok(conn) => conn,
         Err(_) => return Ok(std::collections::HashMap::new()),

--- a/crates/orchestrator-daemon-runtime/src/control/workflow_events.rs
+++ b/crates/orchestrator-daemon-runtime/src/control/workflow_events.rs
@@ -136,6 +136,11 @@ struct SubscriberSlot {
 pub struct WorkflowEventBroadcaster {
     next_id: AtomicU64,
     subscribers: Mutex<Vec<SubscriberSlot>>,
+    /// BU-3 event sink: when set, each emitted event is additionally tee'd into
+    /// the project's `workflow_journal` plugin via `journal/record` (a no-op when
+    /// no journal plugin is installed). `None` => no tee (the default). Stored as
+    /// the project root so the sink can resolve the (per-root) journal backend.
+    journal_sink_root: Mutex<Option<std::path::PathBuf>>,
 }
 
 impl WorkflowEventBroadcaster {
@@ -172,6 +177,19 @@ impl WorkflowEventBroadcaster {
         let mut guard = self.subscribers.lock().expect("workflow event subscribers mutex poisoned");
         guard.push(SubscriberSlot { id, sender: tx, filter, user_buffer });
         (id, rx)
+    }
+
+    /// BU-3: enable the journal event sink for `project_root`. Idempotent; the
+    /// daemon calls this at startup so phase/run lifecycle events are tee'd into
+    /// an installed `workflow_journal` plugin. No-op behaviorally when no such
+    /// plugin is installed (the sink resolves to the SQLite backend, which has no
+    /// `journal/record`).
+    pub fn set_journal_sink(&self, project_root: std::path::PathBuf) {
+        *self.journal_sink_root.lock().expect("journal sink mutex poisoned") = Some(project_root);
+    }
+
+    fn journal_sink_root(&self) -> Option<std::path::PathBuf> {
+        self.journal_sink_root.lock().expect("journal sink mutex poisoned").clone()
     }
 
     /// Drop a subscription by id. Called on client disconnect.
@@ -230,6 +248,27 @@ impl WorkflowEventBroadcaster {
                 crate::metrics::incr(&crate::metrics::labeled("phase_executions_total", &[("status", "failed")]));
             }
             _ => {}
+        }
+        // BU-3: tee the event into the workflow_journal plugin (fire-and-forget,
+        // off the emit path). No-op when no sink is configured or no runtime is
+        // current (e.g. unit tests). State persistence is unaffected either way.
+        if let Some(root) = self.journal_sink_root() {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let workflow_id = event.workflow_id.clone();
+                let kind = event.kind.clone();
+                let payload = event.payload.clone();
+                let occurred_at = event.occurred_at;
+                handle.spawn(async move {
+                    orchestrator_core::workflow::journal_record_wire_event(
+                        &root,
+                        &workflow_id,
+                        &kind,
+                        payload,
+                        occurred_at,
+                    )
+                    .await;
+                });
+            }
         }
         let mut delivered = 0usize;
         let mut closed_ids: Vec<SubscriptionId> = Vec::new();

--- a/crates/orchestrator-daemon-runtime/src/daemon/run_daemon.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/run_daemon.rs
@@ -284,6 +284,9 @@ where
     let subject_dispatch = resolve_subject_dispatch_for_daemon(project_root, &primary_root, hooks).await;
 
     let workflow_event_broadcaster = WorkflowEventBroadcaster::new();
+    // BU-3: tee phase/run lifecycle events into an installed workflow_journal
+    // plugin (no-op when none is installed — the SQLite backend has no events).
+    workflow_event_broadcaster.set_journal_sink(std::path::PathBuf::from(project_root));
     install_workflow_event_emitter(BroadcastWorkflowEventEmitter::new(workflow_event_broadcaster.clone()));
     install_workflow_event_broadcaster(workflow_event_broadcaster.clone());
 
@@ -620,6 +623,11 @@ where
     // loads/writes (v0.6.6). Without this the warm plugin process would survive
     // daemon teardown until kill_on_drop fires at runtime exit.
     orchestrator_config::workflow_config::config_source_client::shutdown_resident_hosts().await;
+
+    // BU-1: likewise reap the resident workflow_journal plugin host (kept warm
+    // across run-state/checkpoint/event RPCs) so its child process — and any DB
+    // connection it holds — is terminated cleanly on daemon teardown.
+    orchestrator_core::workflow::shutdown_journal_hosts().await;
 
     if stop_daemon_on_exit {
         let _ = hooks.stop_daemon(&primary_root).await;


### PR DESCRIPTION
## What
Adds a `JournalClient` (InTree | Plugin) behind `WorkflowStateManager` so run-state + checkpoints can persist to an optional `workflow_journal` plugin (e.g. animus-journal-postgres) instead of only local SQLite — durable across restarts/redeploys.

- **No-plugin path = byte-identical to today** (SQLite). Plugin resolved once per root via `discover_by_kind("workflow_journal")`; kill-switch `ANIMUS_DISABLE_WORKFLOW_JOURNAL_PLUGIN=1`.
- Mirrors `config_source_client` (resident host, death-aware respawn, `run_blocking` sync↔async bridge). All `WorkflowStateManager` methods routed via guard-at-top; readers (history/cost/status) too, so plugin mode doesn't read a stale local table.
- `RequiredRole::WorkflowJournal` is **optional** — presence reported, never blocks boot.
- BU-3 event-sink: tees phase transitions → `journal/record` (fire-and-forget, no-op on SQLite).
- BU-4 (boot-reconcile resume-vs-cancel) intentionally NOT included — separate careful pass.

Merges current main (v0.6.24: subject `--query`, chat-search perf) — no journal-file conflicts.

## Verification
346 orchestrator-core tests pass (existing unchanged + 4 new journal_client); workspace only the 2 pre-existing `decision_gate::workflow_*` fail. clippy/fmt clean. codex P1-clear (one P2 deferred: approximate plugin checkpoint-prune needs a `checkpoint_delete` wire method; SQLite path exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)