### PR TITLE
feat(journal): v0.6.27 — BU-4 resume-not-cancel boot reconcile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/crates/animus-runtime-shared/src/phase_session.rs
+++ b/crates/animus-runtime-shared/src/phase_session.rs
@@ -232,6 +232,45 @@ pub fn list_running_checkpoints(scoped_root: &Path) -> io::Result<Vec<(PathBuf, 
     Ok(out)
 }
 
+/// Workflow ids that have at least one session checkpoint in `Blocked` state.
+///
+/// A `Blocked` checkpoint marks a mid-phase resume that was intentionally held
+/// (e.g. the provider plugin is not installed, or `resume_agent` returned a
+/// failure) and is waiting on an operator `animus workflow resume --force`. The
+/// daemon's journal-resume re-dispatch consults this so it does NOT spawn a
+/// fresh runner for such a run and bypass the hold.
+pub fn blocked_checkpoint_workflow_ids(scoped_root: &Path) -> io::Result<std::collections::HashSet<String>> {
+    let runs_dir = scoped_root.join("runs");
+    let mut out = std::collections::HashSet::new();
+    let entries = match fs::read_dir(&runs_dir) {
+        Ok(e) => e,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
+        Err(err) => return Err(err),
+    };
+    for run_entry in entries {
+        let run_entry = run_entry?;
+        let phases_dir = run_entry.path().join("phases");
+        let phase_entries = match fs::read_dir(&phases_dir) {
+            Ok(e) => e,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err),
+        };
+        for phase_entry in phase_entries {
+            let phase_entry = phase_entry?;
+            let path = phase_entry.path();
+            if !path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.ends_with(".session.json")) {
+                continue;
+            }
+            if let Some(checkpoint) = read_path(&path)? {
+                if matches!(checkpoint.status, SessionCheckpointStatus::Blocked) {
+                    out.insert(checkpoint.workflow_id);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
 fn mutate(
     scoped_root: &Path,
     workflow_id: &str,

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.26"
+version = "0.6.27"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
+++ b/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
@@ -16,7 +16,7 @@ pub(crate) async fn reconcile_completed_processes(
 ) -> CompletedProcessReconciliation {
     let plan = build_completion_reconciliation_plan(completed_processes);
 
-    for fact in plan.execution_facts {
+    for fact in &plan.execution_facts {
         for event in &fact.runner_events {
             debug!(
                 actor = protocol::ACTOR_DAEMON,
@@ -32,9 +32,9 @@ pub(crate) async fn reconcile_completed_processes(
         // `fact.completion_status()` already maps
         // onto the plugin's `completion_status` vocabulary
         // (`completed`/`failed`/`cancelled`).
-        finalize_plugin_queue_entry(root, &fact).await;
+        finalize_plugin_queue_entry(root, fact).await;
 
-        if !project_execution_fact(hub.clone(), root, &fact).await {
+        if !project_execution_fact(hub.clone(), root, fact).await {
             info!(
                 actor = protocol::ACTOR_DAEMON,
                 subject_id = %fact.subject_id,
@@ -44,7 +44,59 @@ pub(crate) async fn reconcile_completed_processes(
             );
         }
 
-        project_schedule_execution_fact(root, &fact);
+        project_schedule_execution_fact(root, fact);
+    }
+
+    // BU-4: when durable journal resume is active, terminalize the persisted
+    // workflow row for any run that FAILED before the runner could write a
+    // terminal status itself (e.g. a resume re-dispatch that died on a bad
+    // `--workflow-id`, plugin/startup failure, or arg parse error). The
+    // task/queue projectors above do NOT update the workflow row, so without
+    // this the run stays `Running` and `resumable_orphans_for_redispatch`
+    // re-dispatches it every tick (livelock). Cancel is idempotent here — a run
+    // the runner already terminalized is skipped by the non-terminal guard.
+    // Gated on `journal_resume_enabled` so the no-journal path is byte-identical
+    // (its stuck runs are still handled by the orphan-sweep cancel path).
+    if crate::services::runtime::runtime_daemon::daemon_reconciliation::journal_resume_enabled(root) {
+        for fact in &plan.execution_facts {
+            let Some(workflow_id) = fact.workflow_id.as_deref() else {
+                continue;
+            };
+            if !matches!(fact.completion_status(), "failed" | "cancelled") {
+                continue;
+            }
+            match hub.workflows().get(workflow_id).await {
+                Ok(workflow) if !orchestrator_core::is_terminal_workflow_run_status(workflow.status) => {
+                    // Use `cancel` (Running -> Cancelled): it is the only
+                    // service transition GUARANTEED to terminalize a Running
+                    // run here. `mark_completed_failed` no-ops unless the run is
+                    // already Completed, and `fail_current_phase` may apply the
+                    // phase RETRY policy and leave the run Running — both would
+                    // leave the livelock unbroken (codex P1). Cancelling a run
+                    // that died before doing any work is correct cleanup (live
+                    // runners / live agent records were already excluded from
+                    // re-dispatch), not a wrongful cancel; the operator can
+                    // re-enqueue. The original failure reason is preserved in
+                    // the execution fact / task projection above.
+                    if let Err(error) = hub.workflows().cancel(workflow_id).await {
+                        warn!(
+                            actor = protocol::ACTOR_DAEMON,
+                            workflow_id = %workflow_id,
+                            error = %error,
+                            "failed to terminalize failed resume target; it may be re-dispatched next tick"
+                        );
+                    } else {
+                        info!(
+                            actor = protocol::ACTOR_DAEMON,
+                            workflow_id = %workflow_id,
+                            status = %fact.completion_status(),
+                            "terminalized failed resume target (runner exited before persisting terminal status)"
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 
     CompletedProcessReconciliation {

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -4,11 +4,11 @@ use crate::services::runtime::workflow_mutation_surface::cancel_orphaned_running
 use anyhow::Result;
 use orchestrator_core::{
     active_workflow_runner_ids, dispatch_workflow_event, load_agent_runtime_config_or_default, services::ServiceHub,
-    WorkflowEvent, WorkflowMachineState, WorkflowStatus,
+    OrchestratorWorkflow, WorkflowEvent, WorkflowMachineState, WorkflowStatus,
 };
 use std::collections::HashSet;
 use std::path::Path;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 /// Grace period after a workflow's `started_at` before the orphan
 /// reconciler is allowed to cancel it. Async dispatch paths (control-wire
@@ -18,10 +18,63 @@ use tracing::{error, warn};
 /// before the scheduler picks them up.
 pub(crate) const ORPHAN_RECONCILIATION_GRACE_SECS: i64 = 90;
 
+/// BU-4 kill-switch: force the pre-BU-4 cancel-orphans behavior even when the
+/// durable journal backend is active. Safe rollback valve if journal-resume
+/// misbehaves in production. Requires a daemon restart to take effect.
+const DISABLE_JOURNAL_RESUME_ENV: &str = "ANIMUS_DAEMON_DISABLE_JOURNAL_RESUME";
+
+fn env_flag_enabled(var: &str) -> bool {
+    std::env::var(var).map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on")).unwrap_or(false)
+}
+
+/// BU-4: whether the boot/steady-state orphan sweep should RESUME (preserve +
+/// re-dispatch) in-flight runs instead of CANCELLING them.
+///
+/// `true` only when BOTH hold:
+///   * the DURABLE (plugin-backed, e.g. Postgres) workflow journal is active —
+///     so run state survived a host/volume wipe and there is something to
+///     resume; AND
+///   * the `ANIMUS_DAEMON_DISABLE_JOURNAL_RESUME` kill-switch is NOT set.
+///
+/// When `false` (the default for the in-tree SQLite backend), the orphan sweep
+/// is byte-identical to the pre-BU-4 cancel behavior.
+pub(crate) fn journal_resume_enabled(project_root: &str) -> bool {
+    if env_flag_enabled(DISABLE_JOURNAL_RESUME_ENV) {
+        return false;
+    }
+    orchestrator_core::durable_journal_active(Path::new(project_root))
+}
+
+/// BU-4: is an orphaned (no-live-runner) non-terminal run RESUMABLE, i.e. does
+/// it have a concrete current phase to (re)enter?
+///
+/// A run is resumable from a phase boundary when it has either an explicit
+/// `current_phase`, or a `current_phase_index` that points at a real phase in
+/// its plan. A `Running` record with no addressable current phase (never
+/// initialized / corrupt) is genuinely UNRESUMABLE and falls through to
+/// cancellation — the fallback the BU-4 spec requires.
+///
+/// ## provider_session_id durability boundary (interim)
+///
+/// Exact MID-PHASE resume (re-attaching to the agent's in-flight provider
+/// session) requires a session checkpoint carrying a `provider_session_id`,
+/// handled separately by `auto_resume_running_checkpoints`. That checkpoint
+/// lives on the scoped LOCAL volume; this pass relies on it surviving on a
+/// durable volume (design recommendation a). When no recoverable
+/// `provider_session_id` exists, resume falls back to re-dispatching the run
+/// from its current PHASE BOUNDARY (a fresh workflow_runner re-enters
+/// `current_phase` from scratch) — which only needs the run-state that the
+/// durable journal preserves. `is_resumable_orphan` gates that phase-boundary
+/// fallback; only a run with no phase boundary at all is cancelled.
+fn is_resumable_orphan(workflow: &OrchestratorWorkflow) -> bool {
+    workflow.current_phase.is_some() || workflow.phases.get(workflow.current_phase_index).is_some()
+}
+
 pub async fn recover_orphaned_running_workflows(
     hub: Arc<dyn ServiceHub>,
     project_root: &str,
     active_subject_ids: &HashSet<String>,
+    resume_orphans: bool,
 ) -> usize {
     let workflows = match hub.workflows().list().await {
         Ok(workflows) => workflows,
@@ -68,6 +121,31 @@ pub async fn recover_orphaned_running_workflows(
             continue;
         }
 
+        // BU-4: when the durable journal is active (and the kill-switch is
+        // off), do NOT destroy resumable in-flight work on daemon
+        // restart/redeploy. Preserve the Running run so it can be resumed:
+        //   * MID-PHASE via `auto_resume_running_checkpoints` when a session
+        //     checkpoint with a provider_session_id survives, or
+        //   * from its current PHASE BOUNDARY via the re-dispatch leg
+        //     (`resumable_orphans_for_redispatch`), which restarts
+        //     `current_phase` under a fresh runner using only the run-state
+        //     the durable journal preserves.
+        // Only genuinely UNRESUMABLE runs (no addressable current phase) fall
+        // through to cancellation below. When `resume_orphans` is false (no
+        // durable journal / kill-switch set), this is a no-op and the cancel
+        // path is byte-identical to pre-BU-4.
+        if resume_orphans && is_resumable_orphan(&workflow) {
+            info!(
+                actor = protocol::ACTOR_DAEMON,
+                workflow_id = %workflow.id,
+                subject_id = %workflow.subject.id(),
+                task_id = %workflow.task_id,
+                current_phase = workflow.current_phase.as_deref().unwrap_or_default(),
+                "preserving resumable in-flight workflow for resume (durable journal active); not cancelling"
+            );
+            continue;
+        }
+
         warn!(
             actor = protocol::ACTOR_DAEMON,
             workflow_id = %workflow.id,
@@ -88,6 +166,146 @@ pub async fn recover_orphaned_running_workflows(
     }
 
     recovered
+}
+
+/// BU-4 re-dispatch candidates: non-terminal `Running` orphans (no live runner)
+/// that should be RESTARTED from their current phase boundary by a fresh
+/// `workflow_runner`. The caller (the steady-state dispatch leg) spawns one
+/// runner per returned run via the `ProcessManager`.
+///
+/// This MIRRORS every guard in [`recover_orphaned_running_workflows`] so the
+/// two never disagree about which runs are "orphaned": status `Running`, not a
+/// merge conflict, not waiting on a manual phase, no live runner (neither in
+/// `active_subject_ids` — runners owned by THIS daemon — nor in the
+/// pid-liveness registry), past the `started_at` grace window, and resumable
+/// from a phase boundary. It additionally REQUIRES `journal_resume_enabled`
+/// (durable journal + kill-switch off) so it returns an empty set on the
+/// SQLite path.
+///
+/// Idempotency / no-double-dispatch: the `ProcessManager` records the subject
+/// as active the moment a runner is spawned, and `spawn_workflow_runner`
+/// registers a live pid — so a run re-dispatched on one tick is excluded from
+/// both guards on every subsequent tick. Runs already recovered MID-PHASE by
+/// `auto_resume_running_checkpoints` move to `Paused` (handoff) and are
+/// excluded here by the `Running`-only filter.
+pub(crate) async fn resumable_orphans_for_redispatch(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    active_subject_ids: &HashSet<String>,
+) -> Vec<OrchestratorWorkflow> {
+    if !journal_resume_enabled(project_root) {
+        return Vec::new();
+    }
+    let workflows = match hub.workflows().list().await {
+        Ok(workflows) => workflows,
+        Err(error) => {
+            warn!(
+                actor = protocol::ACTOR_DAEMON,
+                error = %error,
+                "failed to list workflows for journal-resume re-dispatch"
+            );
+            return Vec::new();
+        }
+    };
+    let externally_active_workflows = match active_workflow_runner_ids(Path::new(project_root)) {
+        Ok(ids) => ids,
+        Err(error) => {
+            warn!(
+                actor = protocol::ACTOR_DAEMON,
+                error = %error,
+                "failed to read active workflow runner ids for journal-resume re-dispatch"
+            );
+            HashSet::new()
+        }
+    };
+
+    // Codex P1: a detached workflow runner spawned by a PREVIOUS daemon can
+    // still be alive after this daemon restarted. Such a runner is tracked by
+    // the agent-record orphan scan (`runs/_pending/agents`), NOT by this fresh
+    // process's `active_subject_ids` and not necessarily by the workflow-runner
+    // pid registry. Re-dispatching its subject would spawn a SECOND runner for
+    // the same work (double-dispatch). Exclude any subject/task that has a live
+    // detected orphan. On scan failure we cannot verify liveness, so we
+    // suppress re-dispatch entirely this tick (fail safe — never risk a
+    // duplicate runner).
+    let live_orphan_subjects: HashSet<String> =
+        match orchestrator_daemon_runtime::agent_record::scan_orphans_for_project(Path::new(project_root)) {
+            Ok(report) => {
+                report.detected.into_iter().flat_map(|o| std::iter::once(o.subject_id).chain(o.task_id)).collect()
+            }
+            Err(error) => {
+                warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    error = %error,
+                    "agent-record orphan scan failed; suppressing journal-resume re-dispatch this tick to avoid double-dispatch"
+                );
+                return Vec::new();
+            }
+        };
+
+    // Codex P2: a run whose MID-PHASE resume was intentionally HELD by the
+    // startup auto-resume pass (a `Blocked` session checkpoint — provider
+    // plugin missing, or `resume_agent` returned a failure) is left `Running`
+    // awaiting an operator `animus workflow resume --force`. Re-dispatching it
+    // from the phase boundary would bypass that hold and re-run intentionally
+    // paused work, so exclude it. On scan failure, fail safe by suppressing
+    // re-dispatch this tick.
+    let blocked_resume_workflows: HashSet<String> = match protocol::scoped_state_root(Path::new(project_root)) {
+        Some(scoped_root) => {
+            match animus_runtime_shared::phase_session::blocked_checkpoint_workflow_ids(&scoped_root) {
+                Ok(ids) => ids,
+                Err(error) => {
+                    warn!(
+                        actor = protocol::ACTOR_DAEMON,
+                        error = %error,
+                        "blocked-checkpoint scan failed; suppressing journal-resume re-dispatch this tick"
+                    );
+                    return Vec::new();
+                }
+            }
+        }
+        None => HashSet::new(),
+    };
+    let now = chrono::Utc::now();
+
+    let mut candidates = Vec::new();
+    for workflow in workflows {
+        if workflow.status != WorkflowStatus::Running {
+            continue;
+        }
+        if workflow.machine_state == WorkflowMachineState::MergeConflict {
+            continue;
+        }
+        if workflow_is_waiting_on_manual_phase(project_root, &workflow) {
+            continue;
+        }
+        if active_subject_ids.contains(&workflow.id)
+            || externally_active_workflows.contains(&workflow.id)
+            || active_subject_ids.contains(workflow.subject.id())
+        {
+            continue;
+        }
+        // Skip subjects whose detached runner from a previous daemon is still
+        // alive (see `live_orphan_subjects` above).
+        if live_orphan_subjects.contains(workflow.subject.id())
+            || (!workflow.task_id.is_empty() && live_orphan_subjects.contains(&workflow.task_id))
+        {
+            continue;
+        }
+        // Skip runs whose mid-phase resume was intentionally held (Blocked
+        // session checkpoint awaiting operator `--force`).
+        if blocked_resume_workflows.contains(&workflow.id) {
+            continue;
+        }
+        if (now - workflow.started_at).num_seconds() < ORPHAN_RECONCILIATION_GRACE_SECS {
+            continue;
+        }
+        if !is_resumable_orphan(&workflow) {
+            continue;
+        }
+        candidates.push(workflow);
+    }
+    candidates
 }
 
 pub async fn reconcile_manual_phase_timeouts(hub: Arc<dyn ServiceHub>, project_root: &str) -> Result<usize> {
@@ -186,7 +404,7 @@ pub async fn reconcile_manual_phase_timeouts(hub: Arc<dyn ServiceHub>, project_r
 mod tests {
     #![allow(clippy::await_holding_lock)]
 
-    use super::recover_orphaned_running_workflows;
+    use super::{recover_orphaned_running_workflows, resumable_orphans_for_redispatch};
     use crate::shared::test_env_lock;
     use orchestrator_core::{
         register_workflow_runner_pid, services::ServiceHub, unregister_workflow_runner_pid, FileServiceHub, Priority,
@@ -268,16 +486,178 @@ mod tests {
         // While a live runner pid is registered (the mechanism `workflow
         // resume` uses), the reconciler must leave the workflow alone.
         register_workflow_runner_pid(temp.path(), &workflow.id, std::process::id()).expect("pid should register");
-        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new()).await;
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), false).await;
         assert_eq!(recovered, 0, "live runner pid must shield the resumed workflow");
         let reloaded = hub.workflows().get(&workflow.id).await.expect("workflow should reload");
         assert_eq!(reloaded.status, WorkflowStatus::Running);
 
         // Once the runner is gone, the same workflow is reconciled.
         unregister_workflow_runner_pid(temp.path(), &workflow.id).expect("pid should unregister");
-        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new()).await;
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), false).await;
         assert_eq!(recovered, 1, "orphaned workflow without a live runner must be cancelled");
         let reloaded = hub.workflows().get(&workflow.id).await.expect("workflow should reload");
+        assert_eq!(reloaded.status, WorkflowStatus::Cancelled);
+    }
+
+    /// Shared BU-4 fixture: a project with a single backdated `Running`
+    /// workflow (started_at two hours ago, well past the orphan grace). The
+    /// returned `Box<dyn Any>` holds the config_source test seam alive for the
+    /// duration of the test (dropping it would uninstall the synthetic base).
+    async fn backdated_running_workflow_fixture(
+        temp: &TempDir,
+    ) -> (Arc<dyn ServiceHub>, String, String, Box<dyn std::any::Any>) {
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        init_git_repo(temp);
+        let project_root = temp.path().to_string_lossy().to_string();
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(&project_root).expect("file service hub"));
+        let seam =
+            orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(temp.path());
+
+        let task = hub
+            .tasks()
+            .create(TaskCreateInput {
+                title: "resumable workflow".to_string(),
+                description: "BU-4 journal-resume reconcile test".to_string(),
+                task_type: Some(TaskType::Feature),
+                priority: Some(Priority::Medium),
+                created_by: Some("test".to_string()),
+                tags: Vec::new(),
+                linked_requirements: Vec::new(),
+                linked_architecture_entities: Vec::new(),
+            })
+            .await
+            .expect("task should be created");
+        let workflow = hub
+            .workflows()
+            .run(WorkflowRunInput::for_task(task.id.clone(), None), None)
+            .await
+            .expect("workflow should start");
+
+        let manager = WorkflowStateManager::new(temp.path());
+        let mut stored = manager.load(&workflow.id).expect("workflow should load");
+        stored.started_at = chrono::Utc::now() - chrono::Duration::hours(2);
+        manager.save(&stored).expect("backdated workflow should save");
+
+        // The fixture must produce a run that the orphan sweep classifies as
+        // RESUMABLE (a real current phase boundary); otherwise the BU-4
+        // preserve branch would never fire.
+        assert!(
+            super::is_resumable_orphan(&stored),
+            "fixture workflow must have an addressable current phase to exercise resume"
+        );
+        (hub.clone(), project_root, workflow.id, Box::new((_home, seam)))
+    }
+
+    // BU-4 core: with the durable-journal resume gate ON, an orphaned
+    // (no-live-runner) non-terminal run is PRESERVED, not cancelled — it stays
+    // Running so the resume / re-dispatch path can pick it up.
+    #[tokio::test]
+    async fn resumable_orphan_is_preserved_not_cancelled_when_resume_enabled() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), true).await;
+        assert_eq!(recovered, 0, "resumable orphan must be preserved (not cancelled) when resume is enabled");
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow should reload");
+        assert_eq!(reloaded.status, WorkflowStatus::Running, "preserved orphan must stay Running for resume");
+    }
+
+    // BU-4 idempotency: a run WITH a live runner is skipped under resume —
+    // never preserved-and-also-handled, never re-cancelled. The live-runner
+    // guard short-circuits before the resume branch, exactly as it does on the
+    // cancel path.
+    #[tokio::test]
+    async fn live_runner_run_is_skipped_under_resume() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+
+        register_workflow_runner_pid(temp.path(), &workflow_id, std::process::id()).expect("pid should register");
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), true).await;
+        assert_eq!(recovered, 0, "a run with a live runner must be skipped, not cancelled");
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow should reload");
+        assert_eq!(reloaded.status, WorkflowStatus::Running);
+
+        // And the re-dispatch leg must NOT select a run whose runner is live
+        // (no double-dispatch). Even with the journal gate, the active-runner
+        // guard excludes it; on the SQLite test path the gate already returns
+        // empty, which is the stronger safety guarantee asserted below.
+        let candidates = resumable_orphans_for_redispatch(hub.clone(), &project_root, &HashSet::new()).await;
+        assert!(
+            !candidates.iter().any(|w| w.id == workflow_id),
+            "live-runner run must never be a re-dispatch candidate"
+        );
+    }
+
+    // BU-4: a terminal run is ignored by the resume sweep (the Running-only
+    // filter), so resume never resurrects completed work.
+    #[tokio::test]
+    async fn terminal_run_is_ignored_under_resume() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+
+        let manager = WorkflowStateManager::new(temp.path());
+        let mut stored = manager.load(&workflow_id).expect("workflow should load");
+        stored.status = WorkflowStatus::Completed;
+        stored.completed_at = Some(chrono::Utc::now());
+        manager.save(&stored).expect("terminal workflow should save");
+
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), true).await;
+        assert_eq!(recovered, 0, "terminal runs must be ignored by the resume sweep");
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow should reload");
+        assert_eq!(reloaded.status, WorkflowStatus::Completed, "terminal run must be left untouched");
+
+        let candidates = resumable_orphans_for_redispatch(hub.clone(), &project_root, &HashSet::new()).await;
+        assert!(!candidates.iter().any(|w| w.id == workflow_id), "terminal run must never be a re-dispatch candidate");
+    }
+
+    // BU-4: a run still inside its `started_at` grace window is untouched
+    // under resume — the grace guard is preserved exactly as on the cancel
+    // path, so async-dispatched runs are not yanked before a runner registers.
+    #[tokio::test]
+    async fn orphan_within_grace_is_untouched_under_resume() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+
+        // Pull started_at back into the grace window.
+        let manager = WorkflowStateManager::new(temp.path());
+        let mut stored = manager.load(&workflow_id).expect("workflow should load");
+        stored.started_at = chrono::Utc::now();
+        manager.save(&stored).expect("workflow should save");
+
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), true).await;
+        assert_eq!(recovered, 0, "a run within the grace window must not be cancelled");
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow should reload");
+        assert_eq!(reloaded.status, WorkflowStatus::Running);
+
+        let candidates = resumable_orphans_for_redispatch(hub.clone(), &project_root, &HashSet::new()).await;
+        assert!(
+            !candidates.iter().any(|w| w.id == workflow_id),
+            "a run within the grace window must never be a re-dispatch candidate"
+        );
+    }
+
+    // BU-4 safety gate: the SQLite path (no durable journal) cancels the
+    // orphan exactly as pre-BU-4 (resume_orphans=false), AND the re-dispatch
+    // leg returns an empty set because `journal_resume_enabled` is false.
+    #[tokio::test]
+    async fn sqlite_path_cancels_orphan_and_redispatch_is_empty() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+
+        // No workflow_journal plugin installed in the test => SQLite backend =>
+        // journal_resume_enabled() == false. The re-dispatch leg self-gates.
+        let candidates = resumable_orphans_for_redispatch(hub.clone(), &project_root, &HashSet::new()).await;
+        assert!(candidates.is_empty(), "re-dispatch must be inert without a durable journal");
+
+        // resume_orphans=false reproduces the exact pre-BU-4 cancel behavior.
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), false).await;
+        assert_eq!(recovered, 1, "SQLite orphan without a live runner must still be cancelled");
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow should reload");
         assert_eq!(reloaded.status, WorkflowStatus::Cancelled);
     }
 
@@ -325,7 +705,7 @@ mod tests {
         stored.started_at = chrono::Utc::now() - chrono::Duration::hours(2);
         manager.save(&stored).expect("backdated workflow should save");
 
-        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new()).await;
+        let recovered = recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), false).await;
         assert_eq!(recovered, 0, "paused workflows must be exempt from orphan recovery");
         let reloaded = hub.workflows().get(&workflow.id).await.expect("workflow should reload");
         assert_eq!(reloaded.status, WorkflowStatus::Paused);

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -3,7 +3,9 @@ use crate::services::operations::{
     build_plugin_routing, build_queue_routing, build_workflow_routing, run_plugin_install, PluginInstallRequest,
 };
 use crate::services::runtime::runtime_daemon::build_daemon_ops_routing;
-use crate::services::runtime::runtime_daemon::daemon_reconciliation::recover_orphaned_running_workflows;
+use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
+    journal_resume_enabled, recover_orphaned_running_workflows,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use orchestrator_core::services::DaemonStartConfig;
@@ -645,10 +647,18 @@ impl DaemonRunHooks for CliDaemonRunHost {
         // and resume has nothing left to recover. See codex round-4 P2.
         let resumable_workflow_ids = resumable_workflow_ids_for_project(project_root);
 
+        // BU-4: when the durable journal is active, preserve ALL resumable
+        // in-flight runs (not just those with a mid-phase session checkpoint)
+        // so a restart/redeploy resumes them instead of destroying them. The
+        // no-sid runs are re-dispatched from their phase boundary by the
+        // steady-state dispatch leg on the first tick after boot.
+        let resume_orphans = journal_resume_enabled(project_root);
+
         let orphans = recover_orphaned_running_workflows(
             startup_hub as Arc<dyn ServiceHub>,
             project_root,
             &resumable_workflow_ids,
+            resume_orphans,
         )
         .await;
 

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::services::runtime::execution_fact_projection::reconcile_completed_processes;
 use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
-    reconcile_manual_phase_timeouts, recover_orphaned_running_workflows,
+    journal_resume_enabled, reconcile_manual_phase_timeouts, recover_orphaned_running_workflows,
+    resumable_orphans_for_redispatch,
 };
 use anyhow::Result;
 use orchestrator_core::services::ServiceHub;
@@ -21,6 +22,99 @@ pub(crate) struct CliProjectTickServices {
 impl CliProjectTickServices {
     fn new(_args: &DaemonRuntimeOptions, logger: Arc<Logger>) -> Self {
         Self { logger }
+    }
+
+    /// BU-4: spawn a fresh `workflow_runner` for up to `limit` in-flight runs
+    /// the orphan sweep preserved (durable journal active). Each runner
+    /// re-enters the run at its persisted `current_phase` (phase-boundary
+    /// resume). The relayed actor preserves owner scoping across the restart.
+    /// Returns the number of runners spawned (resumed runs), so the caller can
+    /// subtract it from the queue-drain capacity.
+    async fn redispatch_resumable_orphans(
+        &mut self,
+        root: &str,
+        process_manager: &mut ProcessManager,
+        limit: usize,
+    ) -> usize {
+        let hub: Arc<dyn ServiceHub> = match orchestrator_core::FileServiceHub::new(root) {
+            Ok(hub) => Arc::new(hub),
+            Err(error) => {
+                self.logger
+                    .warn("reconciliation", format!("journal-resume re-dispatch skipped: hub init failed: {error}"))
+                    .emit();
+                return 0;
+            }
+        };
+        let active_subject_ids = process_manager.active_subject_ids();
+        let candidates = resumable_orphans_for_redispatch(hub, root, &active_subject_ids).await;
+        if candidates.is_empty() {
+            return 0;
+        }
+        let state_manager = WorkflowStateManager::new(root);
+        let mut started = 0usize;
+        // Within-tick dedupe (codex P2): the candidate set is computed from a
+        // single pre-loop `active_subject_ids` snapshot, so two Running records
+        // for the SAME subject could both be returned. The ProcessManager only
+        // reflects the first spawn AFTER it happens, so guard here too — never
+        // drive one subject with two concurrent runners in a single tick.
+        let mut dispatched_subjects: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for workflow in candidates {
+            if started >= limit {
+                break;
+            }
+            if !dispatched_subjects.insert(workflow.subject.id().to_string()) {
+                continue;
+            }
+            let workflow_ref = workflow.workflow_ref.clone().unwrap_or_else(|| "standard".to_string());
+            // Relay the owner actor the run bootstrapped with so the restarted
+            // run scopes identically; `None` => system/global run.
+            let actor = state_manager.load_workflow_actor(&workflow.id);
+            let dispatch = orchestrator_daemon_runtime::SubjectDispatch::for_subject_with_metadata(
+                workflow.subject.clone(),
+                workflow_ref,
+                "journal-resume",
+                chrono::Utc::now(),
+            )
+            .with_input(workflow.input.clone())
+            .with_vars(workflow.vars.clone())
+            .with_actor(actor);
+
+            // Target the EXISTING persisted run by id so the runner continues
+            // it from `current_phase` (phase-boundary resume) instead of
+            // starting a duplicate workflow for the subject.
+            match process_manager.spawn_workflow_runner_resume(&dispatch, root, &workflow.id) {
+                Ok(()) => {
+                    started += 1;
+                    self.logger
+                        .info(
+                            "reconciliation",
+                            format!(
+                                "journal-resume: re-dispatched in-flight workflow {} (subject {}) from phase boundary {}",
+                                workflow.id,
+                                workflow.subject.id(),
+                                workflow.current_phase.as_deref().unwrap_or("<index>")
+                            ),
+                        )
+                        .emit();
+                }
+                Err(error) => {
+                    // Concurrency cap reached: stop — the remaining candidates
+                    // are picked up on a later tick (still preserved, never
+                    // cancelled). Any other spawn error is logged and the run
+                    // stays preserved for the next attempt.
+                    if error.downcast_ref::<orchestrator_daemon_runtime::WorkflowConcurrencyCapReached>().is_some() {
+                        break;
+                    }
+                    self.logger
+                        .warn(
+                            "reconciliation",
+                            format!("journal-resume re-dispatch of workflow {} failed: {error}", workflow.id),
+                        )
+                        .emit();
+                }
+            }
+        }
+        started
     }
 }
 
@@ -51,7 +145,13 @@ impl DefaultProjectTickServices for CliProjectTickServices {
         root: &str,
         active_subject_ids: &std::collections::HashSet<String>,
     ) -> Result<usize> {
-        Ok(recover_orphaned_running_workflows(hub, root, active_subject_ids).await)
+        // BU-4: when the durable journal is active, the zombie sweep PRESERVES
+        // resumable orphans (re-dispatched from their phase boundary by
+        // `dispatch_ready_tasks` below) instead of cancelling them. On the
+        // SQLite path `journal_resume_enabled` is false and this is the
+        // byte-identical pre-BU-4 cancel behavior.
+        let resume_orphans = journal_resume_enabled(root);
+        Ok(recover_orphaned_running_workflows(hub, root, active_subject_ids, resume_orphans).await)
     }
 
     async fn reconcile_manual_timeouts(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {
@@ -173,16 +273,34 @@ impl DefaultProjectTickServices for CliProjectTickServices {
         let Some(process_manager) = process_manager else {
             return Ok(DispatchWorkflowStartSummary::default());
         };
+        // Suppressed entirely while the pool is draining (`queue_drain_limit
+        // == 0`): no resume re-dispatch, no queue lease.
+        if queue_drain_limit == 0 {
+            return Ok(DispatchWorkflowStartSummary::default());
+        }
+
+        // BU-4 journal-resume re-dispatch leg: when the durable journal is
+        // active, restart in-flight runs the orphan sweep PRESERVED (rather
+        // than cancelled) from their current phase boundary. Run this BEFORE
+        // the queue lease (codex P2): the queue lease only excludes
+        // ProcessManager-active subjects, so a pending queue entry for the
+        // SAME subject as a preserved run would otherwise start first, strand
+        // the preserved run, and duplicate the subject's work. Spawning the
+        // resume first marks the subject active, so the lease's
+        // `exclude_subjects` filter skips it. Bounded by `queue_drain_limit`
+        // so it never exceeds pool sizing. Idempotent: a re-dispatched run
+        // registers a live runner + agent record, excluding it on later ticks.
+        let resumed = self.redispatch_resumable_orphans(root, process_manager, queue_drain_limit).await;
+
         // Queue-only dispatch model: the daemon executes ONLY what has been
-        // explicitly enqueued, leasing up to the available agent-slot
-        // capacity (`queue_drain_limit`, zeroed while the pool is draining).
-        // It does NOT scan the subject backend for Ready tasks — moving a
-        // task from a subject backend into the queue is the end user's
-        // responsibility (an agent, a script, or a configured trigger calls
-        // `animus queue enqueue`). Cron `schedules:` still dispatch via their
-        // own leg.
-        let summary = if queue_drain_limit > 0 {
-            dispatch_queued_entries_via_runner(root, process_manager, queue_drain_limit).await?
+        // explicitly enqueued, leasing up to the agent-slot capacity left
+        // after resumes. It does NOT scan the subject backend for Ready tasks —
+        // moving a task into the queue is the end user's responsibility (an
+        // agent, a script, or a configured trigger calls `animus queue
+        // enqueue`). Cron `schedules:` still dispatch via their own leg.
+        let remaining = queue_drain_limit.saturating_sub(resumed);
+        let summary = if remaining > 0 {
+            dispatch_queued_entries_via_runner(root, process_manager, remaining).await?
         } else {
             DispatchWorkflowStartSummary::default()
         };

--- a/crates/orchestrator-core/src/lib.rs
+++ b/crates/orchestrator-core/src/lib.rs
@@ -150,8 +150,8 @@ pub use workflow::{
     DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST_PER_PHASE, STANDARD_WORKFLOW_REF, UI_UX_WORKFLOW_REF,
 };
 pub use workflow::{
-    is_terminal_workflow_run_status, select_workflow_prune_candidates, WorkflowRunDeletion, WorkflowRunPruneCandidate,
-    WorkflowRunPruneFilter, WorkflowRunPruneReport,
+    durable_journal_active, is_terminal_workflow_run_status, select_workflow_prune_candidates, WorkflowRunDeletion,
+    WorkflowRunPruneCandidate, WorkflowRunPruneFilter, WorkflowRunPruneReport,
 };
 pub use workflow_config::{
     builtin_workflow_config, compile_yaml_workflow_files, ensure_workflow_config_compiled, ensure_workflow_config_file,

--- a/crates/orchestrator-core/src/workflow.rs
+++ b/crates/orchestrator-core/src/workflow.rs
@@ -6,7 +6,8 @@ mod state_machine;
 mod state_manager;
 
 pub use journal_client::{
-    record_wire_event as journal_record_wire_event, shutdown_resident_hosts as shutdown_journal_hosts,
+    durable_journal_active, record_wire_event as journal_record_wire_event,
+    shutdown_resident_hosts as shutdown_journal_hosts,
 };
 
 pub use lifecycle_executor::WorkflowLifecycleExecutor;

--- a/crates/orchestrator-core/src/workflow.rs
+++ b/crates/orchestrator-core/src/workflow.rs
@@ -6,8 +6,7 @@ mod state_machine;
 mod state_manager;
 
 pub use journal_client::{
-    durable_journal_active, import_local_sqlite_into_plugin,
-    record_wire_event as journal_record_wire_event,
+    durable_journal_active, import_local_sqlite_into_plugin, record_wire_event as journal_record_wire_event,
     shutdown_resident_hosts as shutdown_journal_hosts, JournalImportStats,
 };
 

--- a/crates/orchestrator-core/src/workflow/journal_client.rs
+++ b/crates/orchestrator-core/src/workflow/journal_client.rs
@@ -130,6 +130,18 @@ pub(crate) fn plugin_for(project_root: &Path) -> Option<DiscoveredPlugin> {
     }
 }
 
+/// BU-4: whether the DURABLE (plugin-backed, e.g. Postgres) workflow journal is
+/// active for `project_root`. Workflow RUN STATE survives a host/volume wipe
+/// (a Railway redeploy) ONLY when this is `true`.
+///
+/// Returns `false` for the in-tree SQLite backend — the default, and what the
+/// `ANIMUS_DISABLE_WORKFLOW_JOURNAL_PLUGIN` kill-switch forces. In that case the
+/// daemon's boot orphan-sweep keeps its byte-identical pre-BU-4 cancel behavior;
+/// resume-from-journal is gated entirely on this returning `true`.
+pub fn durable_journal_active(project_root: &Path) -> bool {
+    matches!(resolve_backend(project_root), JournalBackend::Plugin(_))
+}
+
 /// Clear the cached backend decisions. Test-only seam so a test that installs (or
 /// removes) a synthetic plugin between runs is not served a stale decision.
 #[cfg(test)]
@@ -692,6 +704,15 @@ mod tests {
         reset_backend_cache_for_tests();
         let dir = tempfile::tempdir().expect("tempdir");
         assert!(matches!(resolve_backend(dir.path()), JournalBackend::Sqlite));
+    }
+
+    #[test]
+    fn durable_journal_inactive_without_plugin() {
+        // BU-4 gate: no workflow_journal plugin installed => SQLite => NOT
+        // durable, so the daemon keeps its byte-identical cancel-orphans path.
+        reset_backend_cache_for_tests();
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!durable_journal_active(dir.path()));
     }
 
     #[test]

--- a/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
@@ -13,6 +13,24 @@ pub fn build_runner_command(
     phase_routing: Option<&PhaseRoutingConfig>,
     mcp_config: Option<&McpRuntimeConfig>,
 ) -> std::process::Command {
+    build_runner_command_with_resume(dispatch, project_root, phase_routing, mcp_config, None)
+}
+
+/// Build the `execute` command for the workflow runner.
+///
+/// `resume_workflow_id` (BU-4 journal-resume re-dispatch) targets an EXISTING
+/// persisted run by id via `--workflow-id`, so the runner CONTINUES that run
+/// from its persisted `current_phase` instead of starting a fresh workflow for
+/// the subject. The subject args (`--task-id` / `--requirement-id` / `--title`)
+/// are still emitted so the runner can resolve subject context (the v0.6.17
+/// detached-run reattach fix requires both). `None` is a normal fresh dispatch.
+pub fn build_runner_command_with_resume(
+    dispatch: &SubjectDispatch,
+    project_root: &str,
+    phase_routing: Option<&PhaseRoutingConfig>,
+    mcp_config: Option<&McpRuntimeConfig>,
+    resume_workflow_id: Option<&str>,
+) -> std::process::Command {
     let mut cmd = std::process::Command::new(resolve_workflow_runner_binary_for(Some(project_root)));
     cmd.arg("execute");
 
@@ -27,6 +45,10 @@ pub fn build_runner_command(
             cmd.arg("--title").arg(title);
             cmd.arg("--description").arg(description);
         }
+    }
+
+    if let Some(workflow_id) = resume_workflow_id {
+        cmd.arg("--workflow-id").arg(workflow_id);
     }
 
     if let Some(input) = &dispatch.input {

--- a/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
@@ -27,7 +27,9 @@ mod process_manager;
 mod ready_dispatch_plan;
 pub mod reattach;
 
-pub use build_runner_command_from_dispatch::{build_runner_command, build_runner_command_from_dispatch};
+pub use build_runner_command_from_dispatch::{
+    build_runner_command, build_runner_command_from_dispatch, build_runner_command_with_resume,
+};
 pub use completed_process::CompletedProcess;
 pub use completion_reconciliation_plan::{
     build_completion_reconciliation_plan, CompletedProcessReconciliation, CompletionReconciliationPlan,

--- a/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinHandle;
 use crate::control::WorkflowEventBroadcaster;
 #[cfg(unix)]
 use crate::dispatch::event_pipe::SubprocessEventPipe;
-use crate::{build_runner_command, CompletedProcess, RunnerEvent};
+use crate::{build_runner_command_with_resume, CompletedProcess, RunnerEvent};
 
 #[cfg(unix)]
 #[allow(unsafe_code)]
@@ -160,6 +160,13 @@ struct WorkflowProcess {
     event_pipe: Option<SubprocessEventPipe>,
     agent_session_id: Option<String>,
     project_root: Option<std::path::PathBuf>,
+    /// BU-4 journal-resume: the EXISTING workflow id this runner was spawned to
+    /// continue (via `execute --workflow-id`), if any. Used as the
+    /// `workflow_id` fallback in completion reconciliation so an early runner
+    /// exit (before any `workflow_events` is emitted) still fails/cancels the
+    /// TARGETED run rather than leaving it Running — which would otherwise let
+    /// the resume sweep re-dispatch it every tick in an endless loop.
+    resume_workflow_id: Option<String>,
 }
 
 pub struct ProcessManager {
@@ -253,14 +260,42 @@ impl ProcessManager {
     }
 
     pub fn spawn_workflow_runner(&mut self, dispatch: &SubjectDispatch, project_root: &str) -> Result<()> {
+        self.spawn_workflow_runner_inner(dispatch, project_root, None)
+    }
+
+    /// BU-4 journal-resume re-dispatch: spawn a runner that CONTINUES the
+    /// EXISTING persisted run `resume_workflow_id` from its `current_phase`
+    /// (via `execute --workflow-id`), rather than starting a fresh workflow for
+    /// the subject. Same spawn bookkeeping (concurrency cap, agent record,
+    /// event pipe, reattach socket) as [`Self::spawn_workflow_runner`].
+    pub fn spawn_workflow_runner_resume(
+        &mut self,
+        dispatch: &SubjectDispatch,
+        project_root: &str,
+        resume_workflow_id: &str,
+    ) -> Result<()> {
+        self.spawn_workflow_runner_inner(dispatch, project_root, Some(resume_workflow_id))
+    }
+
+    fn spawn_workflow_runner_inner(
+        &mut self,
+        dispatch: &SubjectDispatch,
+        project_root: &str,
+        resume_workflow_id: Option<&str>,
+    ) -> Result<()> {
         if let Some(cap) = self.workflow_concurrency_max {
             if self.processes.len() >= cap {
                 return Err(anyhow::Error::new(WorkflowConcurrencyCapReached { active: self.processes.len(), cap }));
             }
         }
 
-        let std_cmd =
-            build_runner_command(dispatch, project_root, self.phase_routing.as_ref(), self.mcp_config.as_ref());
+        let std_cmd = build_runner_command_with_resume(
+            dispatch,
+            project_root,
+            self.phase_routing.as_ref(),
+            self.mcp_config.as_ref(),
+            resume_workflow_id,
+        );
         let command_line: Vec<String> = std::iter::once(std_cmd.get_program().to_string_lossy().into_owned())
             .chain(std_cmd.get_args().map(|a| a.to_string_lossy().into_owned()))
             .collect();
@@ -446,6 +481,7 @@ impl ProcessManager {
             event_pipe,
             agent_session_id,
             project_root: Some(project_root_path),
+            resume_workflow_id: resume_workflow_id.map(String::from),
         });
 
         Ok(())
@@ -537,7 +573,7 @@ impl ProcessManager {
                         subject_id: process.subject_key,
                         subject_kind: Some(process.subject_kind),
                         task_id: process.task_id,
-                        workflow_id: None,
+                        workflow_id: process.resume_workflow_id.take(),
                         workflow_ref: Some(process.workflow_ref),
                         workflow_status: Some(WorkflowStatus::Failed),
                         schedule_id: process.schedule_id,
@@ -560,7 +596,7 @@ impl ProcessManager {
                             subject_id: process.subject_key,
                             subject_kind: Some(process.subject_kind),
                             task_id: process.task_id,
-                            workflow_id: None,
+                            workflow_id: process.resume_workflow_id.take(),
                             workflow_ref: Some(process.workflow_ref),
                             workflow_status: None,
                             schedule_id: process.schedule_id,
@@ -589,13 +625,29 @@ impl ProcessManager {
                     cleanup_agent_record(&process);
                     let exit_code = status.code();
                     let events = parse_runner_events(&process.stderr_lines);
-                    let workflow_id = latest_runner_workflow_id(&events);
-                    let workflow_status = latest_runner_workflow_status(&events);
+                    // Prefer the runner-reported id; fall back to the resume
+                    // target so an early exit before any event still reconciles
+                    // the known run (BU-4: prevents endless re-dispatch).
+                    let resume_target = process.resume_workflow_id.take();
+                    let workflow_id = latest_runner_workflow_id(&events).or_else(|| resume_target.clone());
+                    let mut workflow_status = latest_runner_workflow_status(&events);
                     let (success, failure_reason) = if status.success() {
                         (true, None)
                     } else {
                         (false, Some(format!("workflow runner exited unsuccessfully with status {:?}", exit_code)))
                     };
+                    // BU-4 (codex P2): a RESUME-spawned runner that exits
+                    // non-zero WITHOUT reporting a workflow status (e.g. a bad
+                    // `--workflow-id`, a plugin/startup failure, an arg parse
+                    // error — all before any `workflow_events`) must terminalize
+                    // the TARGETED run as Failed. Otherwise the projector only
+                    // blocks the task, the workflow stays Running, and the
+                    // journal-resume sweep re-dispatches it every tick
+                    // (livelock). Scoped to resume spawns so normal dispatch
+                    // behavior is byte-identical.
+                    if workflow_status.is_none() && !status.success() && resume_target.is_some() {
+                        workflow_status = Some(WorkflowStatus::Failed);
+                    }
 
                     completed.push(CompletedProcess {
                         subject_id: process.subject_key,
@@ -620,7 +672,7 @@ impl ProcessManager {
                         subject_id: process.subject_key,
                         subject_kind: Some(process.subject_kind),
                         task_id: process.task_id,
-                        workflow_id: None,
+                        workflow_id: process.resume_workflow_id.take(),
                         workflow_ref: Some(process.workflow_ref),
                         workflow_status: None,
                         schedule_id: process.schedule_id,

--- a/crates/orchestrator-daemon-runtime/src/lib.rs
+++ b/crates/orchestrator-daemon-runtime/src/lib.rs
@@ -24,11 +24,11 @@ pub use daemon::{
 };
 pub use dispatch::{
     active_workflow_subject_ids, active_workflow_task_ids, build_completion_reconciliation_plan, build_runner_command,
-    build_runner_command_from_dispatch, dispatch_capacity_for_options, execute_dispatch_plan_via_runner,
-    is_terminally_completed_workflow, ready_dispatch_limit, schedule_headroom, workflow_current_phase_id,
-    CompletedProcess, CompletedProcessReconciliation, CompletionReconciliationPlan, DispatchNotice, DispatchNoticeSink,
-    DispatchSelectionSource, DispatchWorkflowStart, DispatchWorkflowStartSummary, PlannedDispatchStart, ProcessManager,
-    TickBudget, WorkflowConcurrencyCapReached, WorkflowFailureEvent,
+    build_runner_command_from_dispatch, build_runner_command_with_resume, dispatch_capacity_for_options,
+    execute_dispatch_plan_via_runner, is_terminally_completed_workflow, ready_dispatch_limit, schedule_headroom,
+    workflow_current_phase_id, CompletedProcess, CompletedProcessReconciliation, CompletionReconciliationPlan,
+    DispatchNotice, DispatchNoticeSink, DispatchSelectionSource, DispatchWorkflowStart, DispatchWorkflowStartSummary,
+    PlannedDispatchStart, ProcessManager, TickBudget, WorkflowConcurrencyCapReached, WorkflowFailureEvent,
 };
 /// v0.5.1 P2 #6.2 round-3: daemon-side reattach client surface, exposed for
 /// integration tests and out-of-tree daemons that want to call


### PR DESCRIPTION
## What
When the durable `workflow_journal` (Postgres) backend is active, the daemon boot/steady-state orphan sweep now **resumes** in-flight workflows from the journal instead of **cancelling** them — restart/redeploy mid-task picks up where it left off.

Decision table per orphaned (past-grace, non-manual) Running run: no-journal→cancel (byte-identical to today); live runner→skip; in grace→skip; has session-id→mid-phase resume (session reattach); phase-boundary only→re-dispatch fresh runner from `current_phase`; unresumable→cancel.

Guardrails: gated on `durable_journal_active` + kill-switch off; no double-dispatch (excludes PM-active/pid-registry/live-agent subjects + within-tick dedupe + resume-before-lease); grace/manual/merge-conflict guards retained; kill-switch `ANIMUS_DAEMON_DISABLE_JOURNAL_RESUME=1` forces the old cancel path. Merges v0.6.26 (journal import).

## Caveat (follow-up)
Phase-boundary re-dispatch relies on the workflow-runner honoring `execute --workflow-id` (continue, not duplicate). If an older runner rejects it, the spawn **fails safe** (run preserved, no dup/cancel). Mid-phase resume (session reattach) is unaffected.

## Verification
build/clippy/fmt clean; 7 new reconciliation tests + journal_client/phase_session units pass; pre-existing `decision_gate::workflow_*` + config_source-dependent daemon-runtime tests fail on clean main too. codex 7 substantive rounds — all P1s fixed (duplicate-run, live-agent exclusion, livelock); round 8 didn't converge (budget), round-7 P1 re-verified against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)