### PR TITLE
chore(protocol): v0.6.28 — reconcile PluginKind drift (green protocol-drift CI)

### DIFF
--- a/.github/workflows/protocol-drift.yml
+++ b/.github/workflows/protocol-drift.yml
@@ -47,7 +47,7 @@ jobs:
       # when a new standalone release ships; the in-tree crate is expected
       # to match the surface at this tag (modulo entries the test's
       # `expected_in_tree_only` allowlist documents as pending-release).
-      STANDALONE_TAG: v0.1.13
+      STANDALONE_TAG: v0.1.27
 
     steps:
       - name: Checkout ao-cli (in-tree protocol)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/crates/animus-plugin-protocol/src/lib.rs
+++ b/crates/animus-plugin-protocol/src/lib.rs
@@ -39,6 +39,15 @@ use serde_json::Value;
 /// declares its own in [`InitializeParams::protocol_version`]. A plugin and
 /// host with the same major version are compatible. See `spec.md` for the
 /// full versioning policy.
+///
+/// Intentionally held at `1.0.0` even though the standalone crate advertises
+/// `1.1.0`: the minor bump there signals the additive kind-capability surface
+/// (`InitializeParams.init_extensions` / `InitializeResult.kind_capabilities` /
+/// `KindCapability`) that this in-tree crate does NOT yet implement (see the
+/// standalone-ahead entries in `tests/protocol_drift.rs`). Compatibility is
+/// major-version based and those fields are optional (serde-default), so a
+/// `1.0.0` in-tree host stays compatible. TODO: bump to `1.1.0` in the same
+/// in-tree protocol sync that absorbs the 1.1 surface.
 pub const PROTOCOL_VERSION: &str = "1.0.0";
 
 /// Plugin kind for LLM provider plugins (Claude, Codex, Gemini, OpenAI-compat,
@@ -116,6 +125,45 @@ pub const PLUGIN_KIND_CONVERSATION_STORE: &str = "conversation_store";
 /// the `animus-journal-protocol` crate for the `journal/*` method family.
 pub const PLUGIN_KIND_WORKFLOW_JOURNAL: &str = "workflow_journal";
 
+/// Plugin kind for workflow runner plugins (v0.5).
+///
+/// Workflow runners execute Animus workflow YAML by orchestrating phases,
+/// evaluating decision contracts, handling rework loops, and applying
+/// post-success actions. See `animus-workflow-runner-protocol` for the
+/// typed RPC surface (`workflow/execute`, `workflow/run_phase`).
+pub const PLUGIN_KIND_WORKFLOW_RUNNER: &str = "workflow_runner";
+
+/// Plugin kind for queue backend plugins (v0.5).
+///
+/// Queue plugins own a per-project priority FIFO of `SubjectDispatch`
+/// envelopes awaiting scheduling. See `animus-queue-protocol` for the typed
+/// RPC surface (`queue/enqueue`, `queue/lease`, `queue/list`, etc.).
+pub const PLUGIN_KIND_QUEUE: &str = "queue";
+
+/// Plugin kind for durable execution / step checkpointing plugins (v0.5).
+///
+/// Durable stores provide reservation-fenced step persistence so the daemon
+/// can recover from crashes without re-executing already-committed side
+/// effects. See `animus-durable-store-protocol` for the typed RPC surface
+/// (`durable/begin_step`, `durable/commit_step`, `durable/recover_in_flight`,
+/// etc.).
+pub const PLUGIN_KIND_DURABLE_STORE: &str = "durable_store";
+
+/// Plugin kind for agent memory store plugins (v0.5).
+///
+/// Memory stores provide persistent semantic memory across runs / agents /
+/// tasks. See `animus-memory-store-protocol` for the typed RPC surface
+/// (`memory/put`, `memory/get`, `memory/query`, etc.).
+pub const PLUGIN_KIND_MEMORY_STORE: &str = "memory_store";
+
+/// Plugin kind for the legacy agent-runner sidecar.
+///
+/// The agent-runner sidecar (and its `animus-agent-runner-protocol` crate)
+/// was removed in v0.5.3 — provider plugins now spawn and supervise the
+/// coding-agent CLIs end to end. This wire constant is retained only so an
+/// older `agent_runner`-kind manifest still parses to a known kind.
+pub const PLUGIN_KIND_AGENT_RUNNER: &str = "agent_runner";
+
 /// Method name for the log-storage `log/entry` notification.
 ///
 /// Emitted by any supervised plugin to forward a structured log entry to
@@ -179,6 +227,17 @@ pub enum PluginKind {
     WorkflowJournal,
     /// Generic custom plugin. See [`PLUGIN_KIND_CUSTOM`].
     Custom,
+    /// Workflow runner plugin (v0.5). See [`PLUGIN_KIND_WORKFLOW_RUNNER`].
+    WorkflowRunner,
+    /// Queue backend plugin (v0.5). See [`PLUGIN_KIND_QUEUE`].
+    Queue,
+    /// Durable execution / step checkpointing plugin (v0.5).
+    /// See [`PLUGIN_KIND_DURABLE_STORE`].
+    DurableStore,
+    /// Agent memory store plugin (v0.5). See [`PLUGIN_KIND_MEMORY_STORE`].
+    MemoryStore,
+    /// Agent-runner sidecar plugin (v0.5). See [`PLUGIN_KIND_AGENT_RUNNER`].
+    AgentRunner,
     /// Any kind not understood by this crate version. Preserves the wire
     /// string so unknown roles round-trip and so hosts that recognize the
     /// role can still dispatch on the string.
@@ -199,6 +258,11 @@ impl PluginKind {
             PluginKind::ConversationStore => PLUGIN_KIND_CONVERSATION_STORE,
             PluginKind::WorkflowJournal => PLUGIN_KIND_WORKFLOW_JOURNAL,
             PluginKind::Custom => PLUGIN_KIND_CUSTOM,
+            PluginKind::WorkflowRunner => PLUGIN_KIND_WORKFLOW_RUNNER,
+            PluginKind::Queue => PLUGIN_KIND_QUEUE,
+            PluginKind::DurableStore => PLUGIN_KIND_DURABLE_STORE,
+            PluginKind::MemoryStore => PLUGIN_KIND_MEMORY_STORE,
+            PluginKind::AgentRunner => PLUGIN_KIND_AGENT_RUNNER,
             PluginKind::Other(value) => value.as_str(),
         }
     }
@@ -232,6 +296,11 @@ impl From<String> for PluginKind {
             PLUGIN_KIND_CONVERSATION_STORE => PluginKind::ConversationStore,
             PLUGIN_KIND_WORKFLOW_JOURNAL => PluginKind::WorkflowJournal,
             PLUGIN_KIND_CUSTOM => PluginKind::Custom,
+            PLUGIN_KIND_WORKFLOW_RUNNER => PluginKind::WorkflowRunner,
+            PLUGIN_KIND_QUEUE => PluginKind::Queue,
+            PLUGIN_KIND_DURABLE_STORE => PluginKind::DurableStore,
+            PLUGIN_KIND_MEMORY_STORE => PluginKind::MemoryStore,
+            PLUGIN_KIND_AGENT_RUNNER => PluginKind::AgentRunner,
             _ => PluginKind::Other(value),
         }
     }

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-plugin-host/tests/protocol_drift.rs
+++ b/crates/orchestrator-plugin-host/tests/protocol_drift.rs
@@ -323,63 +323,32 @@ fn protocol_public_surface_does_not_drift_against_standalone() {
     let mut findings: Vec<DriftFinding> = Vec::new();
     diff_surfaces(&in_tree, &standalone, "", &mut findings);
 
-    // Filter out drift we *expect* between the in-tree and standalone crates
-    // because the in-tree crate is a strict superset for a few well-known
-    // additions that have not yet shipped as a standalone release. Each
-    // entry MUST be paired with a tracking note so it isn't quietly carried
+    // Filter out drift we *expect* between the in-tree and standalone crates.
+    // Each entry MUST be paired with a tracking note so it isn't quietly carried
     // forever.
+    //
+    // As of TASK-120 / BU-0 (STANDALONE_TAG bumped to v0.1.27) the two
+    // `PluginKind` enums and every other previously in-tree-only addition
+    // (env-scrub, trigger surface, log-storage, conversation_store, the typed
+    // enum mirrors, the v0.5 PluginKind variants) have been reconciled — the
+    // standalone tag now contains them, so all the old in-tree-only entries are
+    // dropped. The only remaining divergence is in the OTHER direction:
+    // standalone v0.1.27 is AHEAD of the in-tree crate on a small set of
+    // additions the kernel has not yet absorbed. They are wire-additive
+    // (new optional fields + a new struct) so an in-tree host that ignores them
+    // stays compatible; they are tracked here until a future in-tree protocol
+    // sync pulls them in.
     let expected_in_tree_only: &[&str] = &[
-        // Added in the in-tree crate post v0.1.1 to cover env-scrub + trigger
-        // protocol surface. Slated for inclusion in the next standalone tag.
-        "EnvRequirement",
-        "TriggerWatchParams",
-        "TriggerEvent",
-        "TriggerAckParams",
-        "PLUGIN_KIND_TASK_BACKEND",
-        "TRIGGER_METHOD_WATCH",
-        "TRIGGER_METHOD_EVENT",
-        "TRIGGER_METHOD_ACK",
-        // Added in the in-tree crate for the v0.4.0 log-storage plugin cut
-        // (commit #1 of the three-commit sequence). Slated for inclusion in
-        // the next standalone tag.
-        "PLUGIN_KIND_LOG_STORAGE_BACKEND",
-        "LOG_STORAGE_METHOD_ENTRY",
-        "LOG_STORAGE_METHOD_TAIL",
-        // Manifest.env_required + PluginCapabilities.projections — additions
-        // covered by the next standalone release.
-        "PluginManifest.env_required",
-        "PluginManifest.notification_buffer_size",
-        "PluginCapabilities.projections",
-        // r-protocol/r1-type-audit (2026-05): typed enum mirrors for previously
-        // stringly-typed fields. The wire shape is unchanged — these enums use
-        // serde `from = "String", into = "String"` so older plugins / hosts
-        // round-trip identically. Slated for inclusion in the next standalone
-        // tag together with the matching `kind()` accessor on `PluginManifest`
-        // / `PluginInfo` and the typed `TriggerEvent.action_hint` +
-        // `TriggerAckParams.status` fields.
-        "PluginKind",
-        "TriggerActionHint",
-        "TriggerAckStatus",
-        // p3housekeeping/j2-pluginkind-variants (2026-05): typed
-        // PluginKind variants for the two first-party plugin roles the
-        // host already dispatches by raw string — `transport_backend`
-        // (consumed by `ops_web.rs`) and `web_ui` (legacy
-        // `partition_transport_plugins` path). The wire shape is
-        // unchanged. TODO: drop these allowlist entries once the
-        // standalone `launchapp-dev/animus-protocol` repo is bumped to
-        // include both variants.
-        "PluginKind.TransportBackend",
-        "PluginKind.WebUi",
-        "PLUGIN_KIND_TRANSPORT_BACKEND",
-        "PLUGIN_KIND_WEB_UI",
-        // v0.6.4 conversation_store plugin role (per-user + shared chat history).
-        // The in-tree crate added the role + wire contract; it is ALREADY
-        // published in the standalone repo at tag v0.1.20, but STANDALONE_TAG
-        // here is still pinned to v0.1.13. Drop these two entries once
-        // STANDALONE_TAG advances to >= v0.1.20 (the PluginKind.ConversationStore
-        // variant is already covered by the blanket "PluginKind" entry above).
-        "PLUGIN_KIND_CONVERSATION_STORE",
-        "conversation_store",
+        // Standalone-ahead (v0.1.27): kind-capability negotiation on the
+        // handshake — `InitializeParams.init_extensions` (opaque host→plugin
+        // extension map), `InitializeResult.kind_capabilities` (per-kind
+        // capability declarations), and the `KindCapability` struct they
+        // reference. Not yet mirrored in the in-tree crate. TODO: absorb into
+        // `crates/animus-plugin-protocol` in a follow-up in-tree protocol sync,
+        // then drop these entries.
+        "InitializeParams.init_extensions",
+        "InitializeResult.kind_capabilities",
+        "KindCapability",
     ];
 
     let unexpected_findings: Vec<&DriftFinding> =


### PR DESCRIPTION
## What
Reconciles the two-way `PluginKind` drift so the `protocol drift check` CI goes green (it's been red on every PR).

- In-tree `animus-plugin-protocol` += `WorkflowRunner, Queue, DurableStore, MemoryStore, AgentRunner` (verbatim from standalone) — the two enums + const sets now match.
- Standalone (animus-protocol **v0.1.27**) += `WorkflowJournal`; `animus-journal-protocol` re-exports the const (single source of truth).
- `STANDALONE_TAG` v0.1.13 → **v0.1.27**; drift-test allowlist trimmed 24 → 3.
- The 3 remaining allowlist entries are legitimately *standalone-ahead* wire-additive items (`init_extensions`, `kind_capabilities`, `KindCapability`) — optional/serde-default; tracked TODO to absorb in a future in-tree protocol sync. `PROTOCOL_VERSION` stays 1.0.0 (honest — in-tree lacks the 1.1 kind-capability surface).

Git-deps stay on v0.1.26 (behavior-neutral; v0.1.27 only adds WorkflowJournal to the standalone, which ao-cli carries in-tree). Follow-up: repin all animus-protocol git-deps to v0.1.27 in a later pass.

## Verification
build/clippy/fmt clean; `cargo test -p orchestrator-plugin-host` green incl. the drift test against the v0.1.27 surface. codex 0 P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)