### PR TITLE
feat(subject): v0.6.29 — BaaS dynamic-kind enqueue/run (--subject-id)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/cli_types/mod.rs
+++ b/crates/orchestrator-cli/src/cli_types/mod.rs
@@ -245,6 +245,59 @@ mod tests {
     }
 
     #[test]
+    fn queue_enqueue_accepts_subject_id() {
+        let cli = Cli::try_parse_from(["animus", "queue", "enqueue", "--subject-id", "blog:BLOG-001"])
+            .expect("queue enqueue --subject-id should parse");
+        match cli.command {
+            Command::Queue { command: QueueCommand::Enqueue(args) } => {
+                assert_eq!(args.subject_id.as_deref(), Some("blog:BLOG-001"));
+                assert!(args.task_id.is_none());
+            }
+            other => panic!("expected queue enqueue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn queue_enqueue_subject_id_conflicts_with_kind_flags() {
+        for other in [["--task-id", "TASK-1"], ["--requirement-id", "REQ-1"], ["--title", "x"]] {
+            let error = Cli::try_parse_from([
+                "animus",
+                "queue",
+                "enqueue",
+                "--subject-id",
+                "blog:BLOG-001",
+                other[0],
+                other[1],
+            ])
+            .expect_err("--subject-id must be mutually exclusive with the kind flags");
+            assert_eq!(error.kind(), ErrorKind::ArgumentConflict, "flag {}: {error}", other[0]);
+        }
+    }
+
+    #[test]
+    fn workflow_run_accepts_subject_id() {
+        let cli = Cli::try_parse_from(["animus", "workflow", "run", "--subject-id", "blog:BLOG-001"])
+            .expect("workflow run --subject-id should parse");
+        match cli.command {
+            Command::Workflow { command: WorkflowCommand::Run(args) } => {
+                assert_eq!(args.subject_id.as_deref(), Some("blog:BLOG-001"));
+                assert!(args.task_id.is_none());
+            }
+            other => panic!("expected workflow run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workflow_run_subject_id_conflicts_with_kind_flags() {
+        for other in [["--task-id", "TASK-1"], ["--requirement-id", "REQ-1"], ["--title", "x"]] {
+            let error =
+                Cli::try_parse_from(["animus", "workflow", "run", "--subject-id", "blog:BLOG-001", other[0], other[1]])
+                    .expect_err("--subject-id must be mutually exclusive with the kind flags");
+            assert_eq!(error.kind(), ErrorKind::ArgumentConflict, "flag {}: {error}", other[0]);
+        }
+    }
+
+    #[test]
     fn daemon_metrics_bare_defaults_to_display() {
         let cli = Cli::try_parse_from(["animus", "daemon", "metrics"]).expect("bare daemon metrics should parse");
         match cli.command {

--- a/crates/orchestrator-cli/src/cli_types/queue_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/queue_types.rs
@@ -48,6 +48,13 @@ pub(crate) struct QueueEnqueueArgs {
         help = "Custom subject title for ad-hoc dispatches. Mutually exclusive with --task-id / --requirement-id."
     )]
     pub(crate) title: Option<String>,
+    #[arg(
+        long = "subject-id",
+        value_name = "SUBJECT_ID",
+        group = "subject",
+        help = "Generic subject to enqueue for any kind (BaaS dynamic kinds like blog/post). Accepts a qualified id (blog:BLOG-001 — kind trusted; the recommended form) or a bare id (BLOG-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form). Mutually exclusive with --task-id / --requirement-id / --title."
+    )]
+    pub(crate) subject_id: Option<String>,
     #[arg(long, value_name = "TEXT", help = "Custom subject description (used with --title).")]
     pub(crate) description: Option<String>,
     #[arg(long = "workflow-ref", value_name = "WORKFLOW_REF", help = "Optional YAML workflow reference override.")]

--- a/crates/orchestrator-cli/src/cli_types/workflow_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/workflow_types.rs
@@ -287,6 +287,13 @@ pub(crate) struct WorkflowRunArgs {
     pub(crate) requirement_id: Option<String>,
     #[arg(long, value_name = "TITLE", group = "subject", help = "Custom workflow title for freeform execution.")]
     pub(crate) title: Option<String>,
+    #[arg(
+        long = "subject-id",
+        value_name = "SUBJECT_ID",
+        group = "subject",
+        help = "Generic subject to run the workflow for, any kind (BaaS dynamic kinds like blog/post). Accepts a qualified id (blog:BLOG-001 — kind trusted; the recommended form) or a bare id (BLOG-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form). Mutually exclusive with --task-id / --requirement-id / --title."
+    )]
+    pub(crate) subject_id: Option<String>,
     #[arg(long, value_name = "TEXT", help = "Custom workflow description (used with --title).")]
     pub(crate) description: Option<String>,
     #[arg(

--- a/crates/orchestrator-cli/src/services/operations.rs
+++ b/crates/orchestrator-cli/src/services/operations.rs
@@ -24,6 +24,7 @@ mod ops_trigger;
 mod ops_update;
 mod ops_web;
 mod ops_workflow;
+mod subject_id_dispatch;
 
 pub(crate) use ops_auth::*;
 use ops_common::*;

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_command_args.rs
@@ -5,6 +5,7 @@ pub(super) fn build_queue_enqueue_args(input: &QueueEnqueueInput) -> Vec<String>
     push_opt(&mut args, "--task-id", input.task_id.clone());
     push_opt(&mut args, "--requirement-id", input.requirement_id.clone());
     push_opt(&mut args, "--title", input.title.clone());
+    push_opt(&mut args, "--subject-id", input.subject_id.clone());
     push_opt(&mut args, "--description", input.description.clone());
     push_opt(&mut args, "--workflow-ref", input.workflow_ref.clone());
     push_opt(&mut args, "--input-json", input.input_json.clone());

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
@@ -8,6 +8,13 @@ pub(super) struct QueueEnqueueInput {
     pub(super) requirement_id: Option<String>,
     #[serde(default)]
     pub(super) title: Option<String>,
+    /// For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like
+    /// blog/post/etc.), pass `subject_id` (the kernel resolves the kind)
+    /// instead of `task_id`. Accepts a qualified id (`blog:BLOG-001` — kind
+    /// trusted) or a bare id (`BLOG-001` — kind resolved via the subject
+    /// router). Mutually exclusive with `task_id` / `requirement_id` / `title`.
+    #[serde(default)]
+    pub(super) subject_id: Option<String>,
     #[serde(default)]
     pub(super) description: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
@@ -22,7 +22,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.queue.enqueue",
-        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using a task, requirement, or custom subject plus optional workflow/input override. Prerequisites: Task subjects must exist; custom subjects require a title. Example: {\"task_id\": \"TASK-001\", \"workflow_ref\": \"ops\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
+        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using a task, requirement, custom, or arbitrary-kind subject plus optional workflow/input override. Prerequisites: Subjects must exist; custom subjects require a title. For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post/etc.), pass subject_id (the kernel resolves the kind) instead of task_id. Example: {\"task_id\": \"TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
         input_schema = ao_schema_for_type::<QueueEnqueueInput>()
     )]
     async fn ao_queue_enqueue(&self, params: Parameters<QueueEnqueueInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -865,6 +865,7 @@ fn build_queue_enqueue_args_includes_optional_fields() {
         task_id: Some("TASK-123".to_string()),
         requirement_id: None,
         title: None,
+        subject_id: None,
         description: None,
         workflow_ref: Some("ops".to_string()),
         input_json: Some("{\"mode\":\"fast\"}".to_string()),

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
@@ -32,6 +32,13 @@ pub(super) struct WorkflowRunInput {
     pub(super) requirement_id: Option<String>,
     #[serde(default)]
     pub(super) title: Option<String>,
+    /// For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like
+    /// blog/post/etc.), pass `subject_id` (the kernel resolves the kind)
+    /// instead of `task_id`. Accepts a qualified id (`blog:BLOG-001` — kind
+    /// trusted) or a bare id (`BLOG-001` — kind resolved via the subject
+    /// router). Mutually exclusive with `task_id` / `requirement_id` / `title`.
+    #[serde(default)]
+    pub(super) subject_id: Option<String>,
     #[serde(default)]
     pub(super) description: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
@@ -20,7 +20,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.workflow.run",
-        description = "Run a workflow for a task. Purpose: Execute a workflow to complete task phases automatically. Prerequisites: Task should exist (use animus.subject.get with {\"kind\":\"task\"} to verify). Example: {\"task_id\": \"TASK-001\"} or {\"task_id\": \"TASK-001\", \"workflow_ref\": \"default\"}. Sequencing: Use animus.subject.status with {\"kind\":\"task\", ...} to track progress, animus.workflow.get to monitor, and animus.workflow.pause/resume/cancel for control.",
+        description = "Run a workflow for a subject. Purpose: Execute a workflow to complete subject phases automatically. Prerequisites: Subject should exist. For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post/etc.), pass subject_id (the kernel resolves the kind) instead of task_id. Example: {\"task_id\": \"TASK-001\"} or {\"subject_id\": \"blog:BLOG-001\"} or {\"subject_id\": \"blog:BLOG-001\", \"workflow_ref\": \"draft-post\"}. Sequencing: Use animus.subject.status to track progress, animus.workflow.get to monitor, and animus.workflow.pause/resume/cancel for control.",
         input_schema = ao_schema_for_type::<WorkflowRunInput>()
     )]
     async fn ao_workflow_run(&self, params: Parameters<WorkflowRunInput>) -> Result<CallToolResult, McpError> {
@@ -30,6 +30,7 @@ impl AoMcpServer {
         push_opt(&mut args, "--task-id", input.task_id);
         push_opt(&mut args, "--requirement-id", input.requirement_id);
         push_opt(&mut args, "--title", input.title);
+        push_opt(&mut args, "--subject-id", input.subject_id);
         push_opt(&mut args, "--description", input.description);
         push_opt(&mut args, "--input-json", input.input_json);
         self.run_tool("animus.workflow.run", args, input.project_root).await

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -61,6 +61,32 @@ async fn resolve_enqueue_dispatch(
     }
 }
 
+/// Resolve a generic `--subject-id` enqueue into a kind-correct
+/// [`SubjectDispatch`]. The subject's real kind is taken from the qualified
+/// prefix or discovered by probing the installed subject backends, so a
+/// `kind=blog` subject is stored as a `blog` dispatch (and leased/resolved via
+/// `blog/get`) rather than coerced to `task`.
+async fn resolve_enqueue_dispatch_for_subject_id(
+    project_root: &str,
+    subject_id: &str,
+    workflow_ref: Option<String>,
+    input: Option<serde_json::Value>,
+) -> Result<SubjectDispatch> {
+    use super::subject_id_dispatch::{resolve_subject_id_ref, RouterSubjectProbe};
+    let probe = RouterSubjectProbe::discover(std::path::Path::new(project_root)).await?;
+    let subject_ref = resolve_subject_id_ref(subject_id, &probe).await?;
+    let workflow_ref = workflow_ref.unwrap_or_else(|| {
+        load_workflow_config_or_default(std::path::Path::new(project_root)).config.default_workflow_ref
+    });
+    Ok(SubjectDispatch::for_subject_with_metadata(
+        subject_ref,
+        workflow_ref,
+        "manual-queue-enqueue",
+        chrono::Utc::now(),
+    )
+    .with_input(input))
+}
+
 fn queue_plugin_required(operation: &str) -> anyhow::Error {
     // Same human-readable text as the previous bare `anyhow!` constructor
     // (which classified as Internal via the message fallback) — this only
@@ -109,17 +135,25 @@ pub(crate) async fn handle_queue(
         }
         QueueCommand::Enqueue(args) => {
             let input = args.input_json.clone().map(|value| serde_json::from_str(&value)).transpose()?;
-            let dispatch = resolve_enqueue_dispatch(
-                hub.clone(),
-                project_root,
-                args.task_id.clone(),
-                args.requirement_id.clone(),
-                args.title.clone(),
-                args.description.clone(),
-                args.workflow_ref.clone(),
-                input,
-            )
-            .await?;
+            let dispatch = if let Some(subject_id) = args.subject_id.clone() {
+                // Generic BaaS path: resolve the subject's real kind (qualified
+                // prefix or router probe) so a non-task/requirement subject
+                // dispatches under its own kind instead of being coerced to task.
+                resolve_enqueue_dispatch_for_subject_id(project_root, &subject_id, args.workflow_ref.clone(), input)
+                    .await?
+            } else {
+                resolve_enqueue_dispatch(
+                    hub.clone(),
+                    project_root,
+                    args.task_id.clone(),
+                    args.requirement_id.clone(),
+                    args.title.clone(),
+                    args.description.clone(),
+                    args.workflow_ref.clone(),
+                    input,
+                )
+                .await?
+            };
 
             let run_at = args.run_at.as_deref().map(resolve_run_at).transpose()?;
 

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
@@ -15,6 +15,13 @@ pub(crate) struct WorkflowExecuteArgs {
     pub(crate) task_id: Option<String>,
     pub(crate) requirement_id: Option<String>,
     pub(crate) title: Option<String>,
+    /// Generic, kind-correct subject dispatch for the BaaS `--subject-id` path.
+    /// When set (and not re-attaching to an existing workflow), it is relayed
+    /// verbatim on the runner request as `subject_dispatch` — the protocol
+    /// requires generic (non-task/requirement) subject backends to use the
+    /// dispatch envelope — so the subject resolves under its real kind via
+    /// `<kind>/get` instead of being coerced to `task`.
+    pub(crate) subject_dispatch: Option<protocol::SubjectDispatch>,
     pub(crate) description: Option<String>,
     pub(crate) workflow_ref: Option<String>,
     pub(crate) phase: Option<String>,
@@ -115,7 +122,7 @@ pub(crate) async fn handle_workflow_execute(
     } else {
         workflow_proto::WorkflowExecuteRequest {
             workflow_id: None,
-            subject_dispatch: None,
+            subject_dispatch: args.subject_dispatch.clone(),
             subject_ref: None,
             task_id: args.task_id.clone(),
             requirement_id: args.requirement_id.clone(),

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -52,6 +52,19 @@ fn print_workflow_list_table(items: &[protocol::orchestrator::OrchestratorWorkfl
     render_table(&["ID", "WORKFLOW", "STATUS", "TASK", "STARTED"], &rows);
 }
 
+/// Resolve a generic `--subject-id` value to a kind-correct [`SubjectRef`] by
+/// probing the installed subject backends (the `*` catch-all serves BaaS
+/// dynamic kinds). Qualified ids (`blog:BLOG-001`) trust the explicit kind;
+/// bare ids are resolved to their owning kind.
+async fn resolve_subject_id_ref_via_router(
+    project_root: &str,
+    subject_id: &str,
+) -> Result<protocol::orchestrator::SubjectRef> {
+    use super::subject_id_dispatch::{resolve_subject_id_ref, RouterSubjectProbe};
+    let probe = RouterSubjectProbe::discover(std::path::Path::new(project_root)).await?;
+    resolve_subject_id_ref(subject_id, &probe).await
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn resolve_workflow_run_dispatch(
     hub: Arc<dyn ServiceHub>,
@@ -443,6 +456,34 @@ pub(crate) async fn handle_workflow(
             // stripped so a foreign-kind qualifier is not silently rewritten.
             args.task_id = args.task_id.map(|id| crate::bare_task_id(&id));
             let workflow_ref = args.pipeline.clone();
+            // Generic BaaS subject path: resolve the subject's real kind once
+            // (qualified prefix or router probe) and build a kind-correct
+            // dispatch carrying the resolved SubjectRef (kind=blog,
+            // id=blog:BLOG-001, ...) plus this run's workflow_ref / input / vars.
+            // The runner protocol requires generic (non-task/requirement)
+            // subjects to travel as a `subject_dispatch`, so both the sync and
+            // detached paths consume this single envelope rather than coercing
+            // the subject to task.
+            let subject_id_dispatch = match args.subject_id.clone() {
+                Some(sid) => {
+                    let subject_ref = resolve_subject_id_ref_via_router(project_root, &sid).await?;
+                    let resolved_ref =
+                        workflow_ref.clone().unwrap_or_else(|| default_project_workflow_ref(project_root));
+                    let input = args.input_json.as_deref().map(serde_json::from_str).transpose()?;
+                    let vars = parse_workflow_vars(&args.vars)?;
+                    Some(
+                        protocol::SubjectDispatch::for_subject_with_metadata(
+                            subject_ref,
+                            resolved_ref,
+                            "manual-cli-run",
+                            Utc::now(),
+                        )
+                        .with_input(input)
+                        .with_vars(vars),
+                    )
+                }
+                None => None,
+            };
             // Transport-asserted caller identity for this run. The transport
             // (e.g. the portal) authenticates the user and passes
             // `--actor-json`; the kernel relays it verbatim to the runner /
@@ -455,6 +496,7 @@ pub(crate) async fn handle_workflow(
                     task_id: args.task_id,
                     requirement_id: args.requirement_id,
                     title: args.title,
+                    subject_dispatch: subject_id_dispatch.clone(),
                     description: args.description,
                     workflow_ref: workflow_ref.clone(),
                     phase: args.phase,
@@ -521,20 +563,28 @@ pub(crate) async fn handle_workflow(
                         }
                     }
                 }
-                let dispatch = match args.input_json {
-                    Some(raw) => resolve_workflow_run_dispatch_from_raw_input(hub.clone(), project_root, &raw).await?,
-                    None => {
-                        resolve_workflow_run_dispatch(
-                            hub.clone(),
-                            project_root,
-                            args.task_id,
-                            args.requirement_id,
-                            args.title,
-                            args.description,
-                            workflow_ref,
-                            parsed_vars,
-                        )
-                        .await?
+                let dispatch = if let Some(subject_dispatch) = subject_id_dispatch {
+                    // Generic subject: the kind-correct dispatch was built up
+                    // front; the detached runner resolves it via `<kind>/get`.
+                    subject_dispatch
+                } else {
+                    match args.input_json {
+                        Some(raw) => {
+                            resolve_workflow_run_dispatch_from_raw_input(hub.clone(), project_root, &raw).await?
+                        }
+                        None => {
+                            resolve_workflow_run_dispatch(
+                                hub.clone(),
+                                project_root,
+                                args.task_id,
+                                args.requirement_id,
+                                args.title,
+                                args.description,
+                                workflow_ref,
+                                parsed_vars,
+                            )
+                            .await?
+                        }
                     }
                 };
                 // Post-v0.5 there is no in-process executor: a bare

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
@@ -81,9 +81,35 @@ pub(crate) fn ensure_workflow_runner_plugin(project_root: &Path) -> Result<()> {
 pub(crate) fn workflow_execute_request_for_existing(
     workflow: &OrchestratorWorkflow,
 ) -> workflow_proto::WorkflowExecuteRequest {
+    use protocol::orchestrator::{SUBJECT_KIND_CUSTOM, SUBJECT_KIND_REQUIREMENT, SUBJECT_KIND_TASK};
+    use protocol::SubjectDispatch;
+    // Generic (BaaS dynamic) kinds carry no `task_id` / `requirement_id`, so
+    // the convenience-field reattach would leave the request with NO subject
+    // and the runner would fail subject resolution after the CLI already
+    // reported the workflow dispatched. The runner protocol requires
+    // non-task/requirement subjects to travel as a `subject_dispatch`, so
+    // rebuild one from the persisted record (authoritative for workflow_ref /
+    // input / vars). Task / requirement / custom keep the existing convenience
+    // fields untouched.
+    let kind = workflow.subject.kind();
+    let subject_dispatch =
+        if kind == SUBJECT_KIND_TASK || kind == SUBJECT_KIND_REQUIREMENT || kind == SUBJECT_KIND_CUSTOM {
+            None
+        } else {
+            Some(
+                SubjectDispatch::for_subject_with_metadata(
+                    workflow.subject.clone(),
+                    workflow.workflow_ref.clone().unwrap_or_default(),
+                    "reattach-detached-runner",
+                    workflow.started_at,
+                )
+                .with_input(workflow.input.clone())
+                .with_vars(workflow.vars.clone()),
+            )
+        };
     workflow_proto::WorkflowExecuteRequest {
         workflow_id: Some(workflow.id.clone()),
-        subject_dispatch: None,
+        subject_dispatch,
         subject_ref: None,
         task_id: workflow.subject.task_id().map(str::to_string),
         requirement_id: workflow.subject.requirement_id().map(str::to_string),
@@ -1238,6 +1264,45 @@ workflows:
             "reattach request must carry the task subject so the runner plugin resolves subject context"
         );
         assert_eq!(request.requirement_id, None);
+    }
+
+    #[test]
+    fn reattach_request_carries_generic_subject_dispatch_for_baas_kind() {
+        // A detached `workflow run --subject-id blog:BLOG-001` persists a
+        // generic-kind workflow record. Its reattach child must rebuild a
+        // `subject_dispatch` (the runner protocol requires it for non-task /
+        // requirement kinds) — without it the runner has no subject and fails
+        // resolution after the CLI already reported the workflow dispatched.
+        let workflow = orchestrator_core::OrchestratorWorkflow {
+            id: "wf-blog-1".to_string(),
+            task_id: String::new(),
+            workflow_ref: Some("draft-post".to_string()),
+            input: None,
+            vars: std::collections::HashMap::new(),
+            status: WorkflowStatus::Running,
+            current_phase_index: 0,
+            phases: Vec::new(),
+            machine_state: orchestrator_core::WorkflowMachineState::Idle,
+            current_phase: None,
+            started_at: chrono::Utc::now(),
+            completed_at: None,
+            failure_reason: None,
+            checkpoint_metadata: orchestrator_core::WorkflowCheckpointMetadata::default(),
+            rework_counts: std::collections::HashMap::new(),
+            total_reworks: 0,
+            decision_history: Vec::new(),
+            subject: protocol::orchestrator::SubjectRef::new("blog", "blog:BLOG-001"),
+        };
+
+        let request = super::workflow_execute_request_for_existing(&workflow);
+
+        // Convenience fields stay empty; the subject travels as a dispatch.
+        assert_eq!(request.task_id, None);
+        assert_eq!(request.requirement_id, None);
+        let dispatch = request.subject_dispatch.expect("generic kind must carry subject_dispatch");
+        assert_eq!(dispatch.subject.kind(), "blog");
+        assert_eq!(dispatch.subject.id(), "blog:BLOG-001");
+        assert_eq!(dispatch.workflow_ref, "draft-post");
     }
 
     #[tokio::test]

--- a/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
@@ -1,0 +1,292 @@
+//! Generic `--subject-id` dispatch resolution shared by `queue enqueue` and
+//! `workflow run`.
+//!
+//! The legacy enqueue/run surface only exposed `--task-id` / `--requirement-id`
+//! / `--title`, so a subject of an arbitrary BaaS dynamic kind (e.g.
+//! `kind=blog`, id `BLOG-001`) could not be dispatched: `--task-id` is
+//! validated as a *task* up front and any bare id was coerced to
+//! `SubjectRef::task(...)`, which the owning backend rejects ("id 'BLOG-001'
+//! is a 'blog' subject, not 'task'").
+//!
+//! [`resolve_subject_id_ref`] is the generic path. It accepts either a
+//! **qualified** `kind:id` (trusts the explicit kind) or a **bare** id (probes
+//! the installed subject backends through the [`SubjectKindProbe`] to discover
+//! the subject's ACTUAL kind), then builds a `SubjectRef` carrying that real
+//! kind so the downstream queue lease / runner dispatch resolves the subject
+//! via `<kind>/get` instead of `task/get`.
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use std::path::Path;
+
+use orchestrator_daemon_runtime::{resolve_subject_dispatch, SubjectPluginDispatch};
+use protocol::orchestrator::{SubjectRef, SUBJECT_KIND_REQUIREMENT, SUBJECT_KIND_TASK};
+use serde_json::{json, Value};
+
+use crate::{invalid_input_error, not_found_error};
+
+/// Catch-all wildcard a dynamic-kind subject backend declares
+/// (`subject_kind:*`). It is not a concrete kind, so it is excluded from the
+/// bare-id probe candidate set.
+const CATCH_ALL_KIND: &str = "*";
+
+/// Build a [`SubjectRef`] for an explicit kind token plus a (possibly already
+/// qualified) id. The built-in `task` / `requirement` prefixes canonicalize to
+/// their namespaced kind constants via the dedicated constructors; every other
+/// token is treated as a verbatim BaaS dynamic kind.
+pub(crate) fn subject_ref_for_kind(kind: &str, id: impl Into<String>) -> SubjectRef {
+    let id = id.into();
+    if kind.eq_ignore_ascii_case("task") || kind == SUBJECT_KIND_TASK {
+        SubjectRef::task(id)
+    } else if kind.eq_ignore_ascii_case("requirement") || kind == SUBJECT_KIND_REQUIREMENT {
+        SubjectRef::requirement(id)
+    } else {
+        SubjectRef::new(kind.to_string(), id)
+    }
+}
+
+/// Abstraction over the subject router used to resolve a bare id's real kind.
+/// Split out as a trait so the resolution logic is unit-testable with a stub
+/// router (no plugin processes spawned).
+#[async_trait]
+pub(crate) trait SubjectKindProbe: Send + Sync {
+    /// Concrete kinds to probe for a bare id, in priority order. The `*`
+    /// catch-all is excluded (it is not a concrete kind).
+    fn candidate_kinds(&self) -> Vec<String>;
+
+    /// `true` when `<kind>/get` resolves a subject for the qualified id.
+    async fn subject_exists(&self, kind: &str, qualified_id: &str) -> Result<bool>;
+}
+
+/// Resolve a `--subject-id` value to a kind-correct [`SubjectRef`].
+///
+/// - Qualified `kind:native` → trust the explicit kind, validate the subject
+///   exists under it, and build `SubjectRef::new(kind, "kind:native")`.
+/// - Bare `native` → probe each candidate kind via `<kind>/get` and build the
+///   ref for the first kind that owns the id. Errors with an actionable hint
+///   when nothing matches (e.g. a dynamic kind that is not enumerable from a
+///   bare id — the caller must pass the qualified form).
+pub(crate) async fn resolve_subject_id_ref(subject_id: &str, probe: &dyn SubjectKindProbe) -> Result<SubjectRef> {
+    let trimmed = subject_id.trim();
+    if trimmed.is_empty() {
+        return Err(invalid_input_error("--subject-id must not be empty"));
+    }
+
+    // Qualified `<kind>:<native>`: the caller named the kind explicitly. Trust
+    // it (this is the path BaaS dynamic kinds use), but validate existence so a
+    // typo surfaces as a clean not-found instead of a dangling dispatch.
+    if let Some((kind, native)) = trimmed.split_once(':') {
+        let kind = kind.trim();
+        if !kind.is_empty() && !native.trim().is_empty() {
+            if !probe.subject_exists(kind, trimmed).await? {
+                return Err(not_found_error(format!("subject '{trimmed}' not found under kind '{kind}'")));
+            }
+            return Ok(subject_ref_for_kind(kind, trimmed.to_string()));
+        }
+    }
+
+    // Bare id: discover the kind by probing each registered concrete kind.
+    let candidates = probe.candidate_kinds();
+    if candidates.is_empty() {
+        return Err(not_found_error(format!(
+            "subject id '{trimmed}' has no kind qualifier and no subject backend kinds are installed to resolve it; \
+             pass a qualified id like '<kind>:{trimmed}'"
+        )));
+    }
+    for kind in &candidates {
+        let qualified = crate::qualify_subject_id(trimmed, kind);
+        if probe.subject_exists(kind, &qualified).await? {
+            return Ok(subject_ref_for_kind(kind, qualified));
+        }
+    }
+    Err(not_found_error(format!(
+        "subject id '{trimmed}' not found under any installed subject kind (probed: {}); \
+         for BaaS dynamic kinds pass a qualified id like '<kind>:{trimmed}' (e.g. 'blog:{trimmed}')",
+        candidates.join(", ")
+    )))
+}
+
+/// Production [`SubjectKindProbe`] backed by the lazily-spawned subject router.
+/// Each `subject_exists` call routes `<kind>/get` through the installed
+/// subject_backend plugin(s); the catch-all (`*`) backend serves runtime
+/// dynamic kinds.
+pub(crate) struct RouterSubjectProbe {
+    dispatch: SubjectPluginDispatch,
+}
+
+impl RouterSubjectProbe {
+    /// Discover installed subject backends for `project_root` and build a probe
+    /// over the resulting router. No plugin is spawned until a `<kind>/get`
+    /// routes to it.
+    pub(crate) async fn discover(project_root: &Path) -> Result<Self> {
+        let resolution = resolve_subject_dispatch(project_root).await?;
+        Ok(Self { dispatch: resolution.selected })
+    }
+}
+
+/// `true` when a `<kind>/get` response carries a subject object (top-level or
+/// `{ "subject": { ... } }` wrapped) with an `id`.
+fn response_has_subject(value: &Value) -> bool {
+    if value.is_null() {
+        return false;
+    }
+    if let Some(inner) = value.get("subject") {
+        return inner.get("id").is_some();
+    }
+    value.get("id").is_some()
+}
+
+#[async_trait]
+impl SubjectKindProbe for RouterSubjectProbe {
+    fn candidate_kinds(&self) -> Vec<String> {
+        self.dispatch.kinds().iter().filter(|k| k.as_str() != CATCH_ALL_KIND).cloned().collect()
+    }
+
+    async fn subject_exists(&self, kind: &str, qualified_id: &str) -> Result<bool> {
+        use animus_plugin_protocol::error_codes;
+        // A backend rejecting the id (wrong kind, not found, bad params) is a
+        // clean "does not exist under this kind" — map to `false` so the caller
+        // tries the next candidate / emits the actionable not-found. But a
+        // genuine infrastructure fault (timeout, uninitialized / cancelled
+        // plugin) must NOT masquerade as not-found: surface it so a temporarily
+        // unhealthy backend yields an actionable error instead of silently
+        // failing to dispatch a valid subject.
+        match self.dispatch.route_call(&format!("{kind}/get"), Some(json!({ "id": qualified_id }))).await {
+            Ok(value) => Ok(response_has_subject(&value)),
+            Err(err)
+                if matches!(
+                    err.code,
+                    error_codes::TIMEOUT | error_codes::PLUGIN_NOT_INITIALIZED | error_codes::REQUEST_CANCELLED
+                ) =>
+            {
+                Err(anyhow!("subject backend for kind '{kind}' is unavailable ({}): {}", err.code, err.message))
+            }
+            Err(_) => Ok(false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Stub probe: a fixed candidate-kind list plus a map of
+    /// `(kind, qualified_id)` pairs that "exist".
+    struct StubProbe {
+        candidates: Vec<String>,
+        existing: HashMap<(String, String), bool>,
+    }
+
+    impl StubProbe {
+        fn new(candidates: &[&str], existing: &[(&str, &str)]) -> Self {
+            Self {
+                candidates: candidates.iter().map(|s| s.to_string()).collect(),
+                existing: existing.iter().map(|(k, id)| ((k.to_string(), id.to_string()), true)).collect(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SubjectKindProbe for StubProbe {
+        fn candidate_kinds(&self) -> Vec<String> {
+            self.candidates.clone()
+        }
+        async fn subject_exists(&self, kind: &str, qualified_id: &str) -> Result<bool> {
+            Ok(self.existing.get(&(kind.to_string(), qualified_id.to_string())).copied().unwrap_or(false))
+        }
+    }
+
+    #[test]
+    fn subject_ref_for_kind_canonicalizes_builtins() {
+        assert_eq!(subject_ref_for_kind("task", "task:TASK-1").kind(), SUBJECT_KIND_TASK);
+        assert_eq!(subject_ref_for_kind("requirement", "requirement:REQ-1").kind(), SUBJECT_KIND_REQUIREMENT);
+        // Dynamic kinds pass through verbatim, id preserved as-is.
+        let blog = subject_ref_for_kind("blog", "blog:BLOG-001");
+        assert_eq!(blog.kind(), "blog");
+        assert_eq!(blog.id(), "blog:BLOG-001");
+    }
+
+    #[tokio::test]
+    async fn qualified_blog_id_resolves_kind_blog() {
+        let probe = StubProbe::new(&["task"], &[("blog", "blog:BLOG-001")]);
+        let r = resolve_subject_id_ref("blog:BLOG-001", &probe).await.expect("qualified resolves");
+        assert_eq!(r.kind(), "blog");
+        assert_eq!(r.id(), "blog:BLOG-001");
+    }
+
+    #[tokio::test]
+    async fn qualified_task_id_resolves_canonical_task_kind() {
+        let probe = StubProbe::new(&[], &[("task", "task:TASK-1")]);
+        let r = resolve_subject_id_ref("task:TASK-1", &probe).await.expect("qualified task resolves");
+        assert_eq!(r.kind(), SUBJECT_KIND_TASK);
+        assert_eq!(r.id(), "task:TASK-1");
+    }
+
+    #[tokio::test]
+    async fn qualified_missing_subject_errors_not_found() {
+        let probe = StubProbe::new(&["task"], &[]);
+        let err = resolve_subject_id_ref("blog:NOPE", &probe).await.expect_err("missing should fail");
+        assert!(err.to_string().contains("not found under kind 'blog'"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn bare_blog_id_probes_to_kind_blog() {
+        // Bare id, blog is among the registered concrete kinds and owns it.
+        let probe = StubProbe::new(&["task", "blog"], &[("blog", "blog:BLOG-001")]);
+        let r = resolve_subject_id_ref("BLOG-001", &probe).await.expect("bare blog resolves");
+        assert_eq!(r.kind(), "blog");
+        assert_eq!(r.id(), "blog:BLOG-001");
+    }
+
+    #[tokio::test]
+    async fn bare_task_id_probes_to_kind_task() {
+        let probe = StubProbe::new(&["task", "blog"], &[("task", "task:TASK-9")]);
+        let r = resolve_subject_id_ref("TASK-9", &probe).await.expect("bare task resolves");
+        assert_eq!(r.kind(), SUBJECT_KIND_TASK);
+        assert_eq!(r.id(), "task:TASK-9");
+    }
+
+    #[tokio::test]
+    async fn bare_id_unresolvable_errors_with_qualified_hint() {
+        // Dynamic kind not enumerable from a bare id (only `task` registered).
+        let probe = StubProbe::new(&["task"], &[]);
+        let err = resolve_subject_id_ref("BLOG-001", &probe).await.expect_err("unresolvable should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("not found"), "got: {msg}");
+        assert!(msg.contains("blog:BLOG-001"), "hint suggests qualified form: {msg}");
+        // A bare-id miss is a not-found, not an internal error: machine callers
+        // must get the not_found exit class.
+        assert_eq!(crate::classify_cli_error_kind(&err), crate::CliErrorKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn empty_subject_id_rejected() {
+        let probe = StubProbe::new(&["task"], &[]);
+        let err = resolve_subject_id_ref("   ", &probe).await.expect_err("empty rejected");
+        assert!(err.to_string().contains("must not be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn dispatch_for_resolved_blog_subject_preserves_kind() {
+        use chrono::Utc;
+        use protocol::{SubjectDispatch, SubjectDispatchExt};
+        // Enqueuing a kind=blog subject must build a dispatch whose SubjectRef
+        // carries kind=blog (not coerced to task), so the queue lease / runner
+        // resolves it via `blog/get`.
+        let subject_ref = subject_ref_for_kind("blog", "blog:BLOG-001");
+        let dispatch =
+            SubjectDispatch::for_subject_with_metadata(subject_ref, "draft-post", "manual-queue-enqueue", Utc::now());
+        assert_eq!(dispatch.subject_kind(), "blog");
+        assert_eq!(dispatch.to_workflow_run_input().subject().kind(), "blog");
+        assert_eq!(dispatch.to_workflow_run_input().subject().id(), "blog:BLOG-001");
+    }
+
+    #[test]
+    fn response_has_subject_detects_shapes() {
+        assert!(response_has_subject(&json!({ "id": "blog:BLOG-001" })));
+        assert!(response_has_subject(&json!({ "subject": { "id": "blog:BLOG-001" } })));
+        assert!(!response_has_subject(&json!(null)));
+        assert!(!response_has_subject(&json!({ "ok": true })));
+    }
+}

--- a/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
@@ -42,8 +42,29 @@ pub fn build_runner_command_with_resume(
             cmd.arg("--requirement-id").arg(id);
         }
         protocol::orchestrator::WorkflowSubject::Custom { title, description } => {
-            cmd.arg("--title").arg(title);
-            cmd.arg("--description").arg(description);
+            // `to_workflow_subject()` collapses every non-task/requirement kind
+            // to `Custom`, but a BaaS dynamic kind (e.g. `blog`) must NOT be
+            // dispatched as a custom title — the runner has to resolve it via
+            // `<kind>/get`. Disambiguate by the real subject kind: only the
+            // genuine built-in `custom` kind uses `--title`/`--description`; any
+            // other kind passes its qualified id via `--subject-id` so the
+            // runner resolves the subject under its real kind. (Requires the
+            // workflow_runner plugin to accept `--subject-id`; only ever emitted
+            // for dynamic kinds, so task/requirement/custom dispatch is
+            // unchanged for existing runners.)
+            if dispatch.subject.kind() == protocol::orchestrator::SUBJECT_KIND_CUSTOM {
+                cmd.arg("--title").arg(title);
+                cmd.arg("--description").arg(description);
+            } else {
+                // Qualify with the known kind when the stored id is bare so the
+                // runner resolves the exact kind (a bare native id could be
+                // re-probed to the wrong kind, or fail under a catch-all
+                // backend). Already-qualified ids (`blog:BLOG-001`) pass through.
+                let id = dispatch.subject.id();
+                let qualified =
+                    if id.contains(':') { id.to_string() } else { format!("{}:{id}", dispatch.subject.kind()) };
+                cmd.arg("--subject-id").arg(qualified);
+            }
         }
     }
 
@@ -464,6 +485,64 @@ mod tests {
                 title: "schedule:nightly".to_string(),
                 description: "nightly dispatch".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn runner_command_emits_subject_id_for_generic_baas_kind() {
+        use chrono::Utc;
+        use protocol::orchestrator::SubjectRef;
+        // A queued BaaS dynamic-kind subject (kind=blog) must NOT be coerced to
+        // a custom `--title`; it travels as `--subject-id blog:BLOG-001` so the
+        // runner resolves it via `blog/get`.
+        let dispatch = SubjectDispatch::for_subject_with_metadata(
+            SubjectRef::new("blog", "blog:BLOG-001"),
+            "draft-post",
+            "queue",
+            Utc::now(),
+        );
+        let command = build_runner_command_from_dispatch(&dispatch, "/tmp/project");
+        let args = command.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "execute",
+                "--subject-id",
+                "blog:BLOG-001",
+                "--workflow-ref",
+                "draft-post",
+                "--project-root",
+                "/tmp/project",
+            ]
+        );
+    }
+
+    #[test]
+    fn runner_command_qualifies_bare_generic_subject_id_with_kind() {
+        use chrono::Utc;
+        use protocol::orchestrator::SubjectRef;
+        // A generic dispatch storing a BARE native id must be qualified with its
+        // known kind before reaching the runner, so the runner resolves the
+        // exact kind rather than re-probing a bare id.
+        let dispatch = SubjectDispatch::for_subject_with_metadata(
+            SubjectRef::new("pack.review", "REV-7"),
+            "review-flow",
+            "queue",
+            Utc::now(),
+        );
+        let command = build_runner_command_from_dispatch(&dispatch, "/tmp/project");
+        let args = command.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "execute",
+                "--subject-id",
+                "pack.review:REV-7",
+                "--workflow-ref",
+                "review-flow",
+                "--project-root",
+                "/tmp/project",
+            ]
         );
     }
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -134,7 +134,8 @@ so one bad item never corrupts its neighbors.
 
 ## Workflow Operations
 
-Use workflows to execute work for a task, a requirement, or a freeform title.
+Use workflows to execute work for a task, a requirement, a freeform title, or
+any other subject kind.
 
 ```json
 // Async run via daemon
@@ -145,6 +146,10 @@ Use workflows to execute work for a task, a requirement, or a freeform title.
 
 // Requirement-linked execution
 { "requirement_id": "REQ-001", "workflow_ref": "standard-workflow" }
+
+// BaaS dynamic kind (blog/post/etc.): pass subject_id, NOT task_id —
+// the kernel resolves the kind. Accepts qualified (blog:BLOG-001) or bare.
+{ "subject_id": "blog:BLOG-001" }
 
 // Batch-run multiple tasks (animus.workflow.run-multiple)
 {
@@ -199,6 +204,8 @@ dispatch control.
 { "pool_size": 4, "interval_secs": 10 }     // animus.daemon.config-set
 { "limit": 50 }                              // animus.daemon.events
 { "project_root": "/repo" }                  // animus.queue.list / stats
+{ "task_id": "TASK-001" }                    // animus.queue.enqueue (task)
+{ "subject_id": "blog:BLOG-001" }            // animus.queue.enqueue (BaaS dynamic kind — kernel resolves the kind)
 { "subject_id": "task:TASK-001" }            // animus.queue.hold / release / drop
 { "subject_ids": ["task:TASK-001", "task:TASK-002"] } // animus.queue.hold / release / drop (bulk)
 { "subject_ids": ["task:TASK-003", "task:TASK-001"] } // animus.queue.reorder

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -849,14 +849,29 @@ removed in v0.5.14 — `animus approval` is the only surface.
 
 ### `animus queue enqueue` (immediate + deferred dispatch)
 
-Enqueue a subject dispatch for a task, requirement, or custom title. By
-default the entry is dispatched as soon as the daemon has capacity.
+Enqueue a subject dispatch for a task, requirement, custom title, or any
+other subject kind. By default the entry is dispatched as soon as the daemon
+has capacity.
 
 ```bash
 animus queue enqueue --task-id TASK-001
 animus queue enqueue --requirement-id REQ-042 --workflow-ref ops
 animus queue enqueue --title "Investigate flaky test" --description "Fails on CI"
+animus queue enqueue --subject-id blog:BLOG-001                      # BaaS dynamic kind
 ```
+
+**Generic subjects (`--subject-id`).** For a subject that is **not**
+`kind=task`/`requirement` (a BaaS dynamic kind such as `blog`, `post`, etc.),
+use `--subject-id` instead of `--task-id`. It accepts either a **qualified**
+id (`blog:BLOG-001` — the kind before the `:` is trusted; the recommended
+form) or a **bare** id (`BLOG-001` — the kind is resolved by probing the
+installed subject backends that declare concrete kinds). A backend that
+declares only the `subject_kind:*` catch-all (a pure dynamic-kind backend)
+cannot enumerate a bare id's kind, so it requires the qualified form.
+The resolved kind is preserved in the dispatch, so the queue lease and runner
+resolve the subject via `<kind>/get` rather than coercing it to a task.
+`--subject-id` is mutually exclusive with `--task-id` / `--requirement-id` /
+`--title`.
 
 **Deferred dispatch.** `--at` schedules the entry for a future time; it stays
 queued (counted under `pending`, and broken out as `deferred` in
@@ -1791,6 +1806,16 @@ Priority is displayed in `p0`–`p3` bucket notation in all human-readable views
 is normalized to the qualified form at the CLI boundary, so both resolve the
 same subject. You do not need to run any command in `--json` mode to discover
 the id format.
+
+For subjects of an arbitrary kind (BaaS dynamic kinds like `blog`, `post`),
+`queue enqueue --subject-id` and `workflow run --subject-id` accept a
+qualified id (`blog:BLOG-001`, kind trusted — the recommended form) or a bare
+id (`BLOG-001`, kind resolved by probing installed backends that declare
+concrete kinds; a pure `subject_kind:*` catch-all backend requires the
+qualified form). The resolved kind is preserved on the dispatch so the subject
+is leased/run under its real kind (via `<kind>/get`) instead of being coerced
+to `task`. `--subject-id` is mutually exclusive with `--task-id` /
+`--requirement-id` / `--title`.
 
 ### `animus pack search` (positional query)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -188,7 +188,7 @@ bounded fetch for recent entries, not a live stream.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `animus.workflow.run` | Start a workflow for a task (async, via daemon) | `task_id`, `requirement_id`, `title`, `description`, `workflow_ref`, `input_json`, `project_root` |
+| `animus.workflow.run` | Start a workflow for a subject (async, via daemon). For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post), pass `subject_id` (the kernel resolves the kind) instead of `task_id` | `task_id`, `requirement_id`, `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `project_root` |
 | `animus.workflow.run-multiple` | Batch-run workflows for multiple tasks | `runs[]` (each: `task_id`, `workflow_ref`, `input_json`), `on_error`, `project_root` |
 | `animus.workflow.execute` | Execute a workflow synchronously (no daemon) | `task_id`, `workflow_ref`, `phase`, `model`, `tool`, `phase_timeout_secs`, `input_json`, `project_root` |
 | `animus.workflow.get` | Get full workflow state by ID | `id`, `project_root` |
@@ -224,7 +224,7 @@ bounded fetch for recent entries, not a live stream.
 |---|---|---|
 | `animus.queue.list` | List queued subject dispatches | `project_root` |
 | `animus.queue.stats` | Get aggregate queue depth and status counts | `project_root` |
-| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`) | `task_id`, `requirement_id`, `title`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
+| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post), pass `subject_id` (qualified `blog:BLOG-001` or bare `BLOG-001`; the kernel resolves the kind) instead of `task_id` | `task_id`, `requirement_id`, `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
 | `animus.queue.reorder` | Set preferred dispatch order | `subject_ids[]`, `project_root` |
 | `animus.queue.hold` | Hold one or more pending subjects from dispatch | `subject_id`, `subject_ids[]`, `project_root` |
 | `animus.queue.release` | Release one or more held subjects for dispatch | `subject_id`, `subject_ids[]`, `project_root` |


### PR DESCRIPTION
## What
Adds a generic `--subject-id` dispatch surface so BaaS dynamic-kind subjects (e.g. `kind=blog`/`BLOG-001`) can be queued + run instead of being coerced to `kind=task` (the bug behind the blog run failing: "id 'BLOG-001' is a 'blog' subject, not 'task'").

- `--subject-id` on `queue enqueue` + `workflow run` (clap `subject` group, mutually exclusive with `--task-id`/`--requirement-id`/`--title`). Qualified `blog:BLOG-001` trusts the kind; a bare id is resolved by probing the subject router's declared kinds.
- MCP `animus.queue.enqueue` + `animus.workflow.run` expose `subject_id` (agent-facing guidance: use it for non-task/requirement kinds).
- Fixed two coercion bugs: the detached **reattach** builder (generic subject reached the runner with no subject) and the daemon **queue-lease→runner command** (collapsed every non-task/requirement kind to `--title`); both now carry the kind-qualified subject.

## Follow-up (separate)
The queue-lease→runner leg emits `--subject-id`; the `animus-workflow-runner-default` `direct_execute` must accept it (→ runner v0.4.14) for the queue path. The detached `run_workflow --subject-id` / MCP path works with this release alone.

## Verification
build/clippy clean; `cargo test -p orchestrator-cli` 1245 pass / 2 pre-existing fail; the 24 daemon-runtime fails are pre-existing on clean main (phase-catalog drift). codex 6 rounds, no P1. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)