### PR TITLE
DB-registry discovery tier, noarch install target, health last_error clear

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
@@ -2884,6 +2884,7 @@ fn source_label(source: DiscoverySource) -> &'static str {
         DiscoverySource::ProjectLocal => "project_local",
         DiscoverySource::PluginPath => "plugin_path",
         DiscoverySource::SystemPath => "system_path",
+        DiscoverySource::DbRegistry => "db_registry",
     }
 }
 
@@ -4122,10 +4123,24 @@ const KNOWN_TARGET_TRIPLES: &[&str] = &[
     "x86_64-pc-windows-gnu",
 ];
 
+/// Filename-segment tokens that mark a platform-independent (noarch) asset. A
+/// JS-bundle plugin (a node-shebang esbuild bundle) IS the executable and runs
+/// on every triple, so it publishes ONE `<name>-noarch.tar.gz` instead of
+/// duplicating the same bytes under every triple name. Dash-prefixed so the
+/// substring match only fires on an explicit `-noarch` / `-any` segment, never
+/// an incidental substring of some other name.
+const NOARCH_SELECTION_TOKENS: &[&str] = &["-noarch", "-any"];
+
+/// Synthetic target recorded for a noarch asset in the lockfile / SHA256SUMS,
+/// so a `<name>-noarch.tar.gz` archive keys its integrity claim consistently.
+const NOARCH_TARGET: &str = "noarch";
+
 /// Derive the target triple a release asset filename targets, by scanning for a
 /// known triple substring (case-insensitive). `None` for non-archive assets
 /// (e.g. `SHA256SUMS.txt`, `.bundle`, `.sha256` sidecars) and any name with no
-/// recognizable triple.
+/// recognizable triple. A platform-independent bundle (`-noarch` / `-any`
+/// archive) maps to the synthetic [`NOARCH_TARGET`], checked only after the
+/// real triples so a triple-specific asset always wins.
 fn target_triple_from_asset_name(name: &str) -> Option<&'static str> {
     let lower = name.to_ascii_lowercase();
     // `lower` is already ASCII-lowercased, so these `ends_with` checks are
@@ -4135,7 +4150,31 @@ fn target_triple_from_asset_name(name: &str) -> Option<&'static str> {
     if !is_archive {
         return None;
     }
-    KNOWN_TARGET_TRIPLES.iter().copied().find(|triple| lower.contains(&triple.to_ascii_lowercase()))
+    if let Some(triple) =
+        KNOWN_TARGET_TRIPLES.iter().copied().find(|triple| lower.contains(&triple.to_ascii_lowercase()))
+    {
+        return Some(triple);
+    }
+    if NOARCH_SELECTION_TOKENS.iter().any(|token| lower.contains(token)) {
+        return Some(NOARCH_TARGET);
+    }
+    None
+}
+
+/// Select the release asset to install: a triple-specific asset always wins;
+/// a platform-independent (`-noarch` / `-any`) asset is the fallback used only
+/// when no triple-specific asset is present. Within each pass the `<binary>-`
+/// prefixed picker is tried first (so a multi-binary release doesn't grab a
+/// sibling), then the prefix-agnostic picker for back-compat.
+fn select_release_asset<'a>(
+    assets: &'a [GithubReleaseAsset],
+    binary_name: &str,
+    platform_tokens: &[&str],
+) -> Option<&'a GithubReleaseAsset> {
+    pick_release_asset_for_binary(assets, binary_name, platform_tokens)
+        .or_else(|| pick_release_asset(assets, platform_tokens))
+        .or_else(|| pick_release_asset_for_binary(assets, binary_name, NOARCH_SELECTION_TOKENS))
+        .or_else(|| pick_release_asset(assets, NOARCH_SELECTION_TOKENS))
 }
 
 /// Parse a release `SHA256SUMS.txt` body into per-target archive shas for the
@@ -4381,20 +4420,20 @@ async fn resolve_release_install(
     // archive naming) so multi-binary releases — which publish sibling
     // `<other-bin>-<target>.tar.gz` archives in the same release — don't
     // accidentally pick a secondary binary as the primary based on GitHub's
-    // asset ordering. Fall through to the legacy prefix-agnostic picker for
-    // back-compat with releases that use a different archive base name.
-    let asset = pick_release_asset_for_binary(&release.assets, &spec.repo, platform_tokens)
-        .or_else(|| pick_release_asset(&release.assets, platform_tokens))
-        .ok_or_else(|| {
-            let available: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
-            invalid_input_error(format!(
-                "no release asset matched current platform '{}' (looked for any of: {}). Available assets in {}: [{}]",
-                current_platform_label(),
-                platform_tokens.join(", "),
-                release.tag_name,
-                available.join(", ")
-            ))
-        })?;
+    // asset ordering. Fall through to the legacy prefix-agnostic picker, then
+    // to a platform-independent `-noarch` / `-any` asset for JS-bundle plugins
+    // that publish a single cross-platform archive.
+    let asset = select_release_asset(&release.assets, &spec.repo, platform_tokens).ok_or_else(|| {
+        let available: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
+        invalid_input_error(format!(
+            "no release asset matched current platform '{}' (looked for any of: {}, or a noarch/any asset). \
+             Available assets in {}: [{}]",
+            current_platform_label(),
+            platform_tokens.join(", "),
+            release.tag_name,
+            available.join(", ")
+        ))
+    })?;
 
     // RAII staging dir — drops when `ReleaseInstall` drops. Replaces the
     // pre-fix `std::env::temp_dir().join(uuid)` that was created and
@@ -7100,6 +7139,61 @@ mod tests {
     fn current_platform_has_known_tokens() {
         let tokens = current_platform_tokens();
         assert!(!tokens.is_empty(), "no platform tokens registered for {}", current_platform_label());
+    }
+
+    // ---- noarch / platform-independent asset support (TASK-200) --------
+
+    #[test]
+    fn target_triple_from_asset_name_recognizes_noarch_archives() {
+        assert_eq!(target_triple_from_asset_name("animus-postgres-noarch.tar.gz"), Some("noarch"));
+        assert_eq!(target_triple_from_asset_name("animus-postgres-any.tgz"), Some("noarch"));
+        // A real triple always wins over the noarch fallback.
+        assert_eq!(
+            target_triple_from_asset_name("animus-postgres-x86_64-unknown-linux-gnu.tar.gz"),
+            Some("x86_64-unknown-linux-gnu"),
+        );
+        // Non-archives and `-any`/`-noarch`-free names stay unrecognized.
+        assert_eq!(target_triple_from_asset_name("SHA256SUMS.txt"), None);
+        assert_eq!(target_triple_from_asset_name("animus-company-bundle.tar.gz"), None);
+    }
+
+    #[test]
+    fn select_release_asset_falls_back_to_noarch_when_no_triple_asset() {
+        let assets = vec![asset("animus-postgres-noarch.tar.gz")];
+        // Platform tokens that match nothing here — the noarch bundle is the fallback.
+        let tokens: &[&str] = &["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"];
+        let picked =
+            select_release_asset(&assets, "animus-postgres", tokens).expect("noarch fallback must be selected");
+        assert_eq!(picked.name, "animus-postgres-noarch.tar.gz");
+    }
+
+    #[test]
+    fn select_release_asset_prefers_triple_specific_over_noarch() {
+        let assets =
+            vec![asset("animus-postgres-noarch.tar.gz"), asset("animus-postgres-x86_64-unknown-linux-gnu.tar.gz")];
+        let tokens: &[&str] = &["x86_64-unknown-linux-gnu", "linux-x86_64"];
+        let picked = select_release_asset(&assets, "animus-postgres", tokens).expect("triple asset must be selected");
+        assert_eq!(
+            picked.name, "animus-postgres-x86_64-unknown-linux-gnu.tar.gz",
+            "a triple-specific asset must win over the noarch fallback"
+        );
+    }
+
+    #[test]
+    fn select_release_asset_returns_none_when_neither_triple_nor_noarch() {
+        let assets = vec![asset("animus-postgres-x86_64-apple-darwin.tar.gz")];
+        let tokens: &[&str] = &["x86_64-unknown-linux-gnu"];
+        assert!(select_release_asset(&assets, "animus-postgres", tokens).is_none());
+    }
+
+    #[test]
+    fn parse_sha256sums_keys_noarch_archive() {
+        let body = "abc123def4567890abc123def4567890abc123def4567890abc123def4567890  animus-postgres-noarch.tar.gz\n";
+        let parsed = parse_sha256sums_for_targets(body, "animus-postgres");
+        assert_eq!(
+            parsed.get("noarch").map(String::as_str),
+            Some("abc123def4567890abc123def4567890abc123def4567890abc123def4567890"),
+        );
     }
 
     #[test]

--- a/crates/orchestrator-daemon-runtime/src/daemon/run_daemon.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/run_daemon.rs
@@ -1165,6 +1165,7 @@ fn discover_plugins_for_daemon<H: DaemonRunHooks>(
                         DiscoverySource::ProjectLocal => "project_local",
                         DiscoverySource::PluginPath => "plugin_path",
                         DiscoverySource::SystemPath => "system_path",
+                        DiscoverySource::DbRegistry => "db_registry",
                     },
                     path: p.path.display().to_string(),
                 })

--- a/crates/orchestrator-plugin-host/src/db_registry.rs
+++ b/crates/orchestrator-plugin-host/src/db_registry.rs
@@ -1,0 +1,101 @@
+//! DB-registry discovery source: the desired plugin set read from the
+//! Postgres `plugin_registry` table served by the animus-postgres BaaS.
+//!
+//! # Bootstrap paradox
+//!
+//! The plugin that reads the registry is itself the DB-backend plugin, so it
+//! cannot be gated on the registry it serves. The DB tier is therefore
+//! OPT-IN: the daemon wires a [`PluginRegistrySource`] into
+//! [`crate::PluginDiscovery`] only AFTER the bootstrap DB-backend plugin has
+//! completed its handshake (kernel + animus-postgres + `DATABASE_URL` arrive
+//! from the thin-image bootstrap tier). Until a source is wired, discovery
+//! runs the file/dir tiers alone and the DB tier is a no-op — so a fresh boot
+//! never deadlocks waiting on a registry that isn't reachable yet.
+//!
+//! # Seam
+//!
+//! `orchestrator-plugin-host` takes NO Postgres dependency. The actual SQL
+//! (and the exact `plugin_registry` column types, still being finalized on the
+//! BaaS side) live behind [`PluginRegistrySource`] in a daemon-side adapter.
+//! This module only defines the stable in-kernel contract the discovery tier
+//! consumes plus a [`StaticRegistrySource`] used by tests and as the pre-schema
+//! stub adapter.
+
+use anyhow::Result;
+
+/// One desired-plugin row from the Postgres `plugin_registry` table.
+///
+/// Mirrors the BaaS schema `{name, version, source, sha256, target, enabled,
+/// scope}`. Resolution keys off `name` (resolved against the binary present on
+/// the volume) and `enabled`; the remaining fields carry provenance/integrity
+/// metadata the adapter and any future verification pass can act on without a
+/// second registry read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbRegistryEntry {
+    /// Canonical plugin name, matching the installed binary file name in the
+    /// plugin install dir (e.g. `animus-subject-default`, `animus-postgres`).
+    pub name: String,
+    /// Pinned release version, when the registry records one.
+    pub version: Option<String>,
+    /// Install source descriptor (e.g. a `git+tag` release coordinate).
+    pub source: Option<String>,
+    /// Expected sha256 of the installed artifact, when recorded.
+    pub sha256: Option<String>,
+    /// Target triple the row pins, or `noarch`/`any` for a platform-independent
+    /// bundle. `None` means "whatever is installed on the volume".
+    pub target: Option<String>,
+    /// Whether the plugin should be loaded. Disabled rows are skipped by the
+    /// discovery tier.
+    pub enabled: bool,
+    /// Optional plugin scope tag (flavor / project scope) carried through from
+    /// the registry row. Advisory; the scope FILTER still applies downstream.
+    pub scope: Option<String>,
+}
+
+impl DbRegistryEntry {
+    /// Construct an enabled entry with only a name set — the common shape for
+    /// tests and for a minimal registry row.
+    pub fn enabled(name: impl Into<String>) -> Self {
+        Self { name: name.into(), version: None, source: None, sha256: None, target: None, enabled: true, scope: None }
+    }
+}
+
+/// Read side of the DB-backed plugin registry.
+///
+/// Implemented by a daemon-side adapter that queries the Postgres
+/// `plugin_registry` through the already-running DB-backend plugin. Kept as a
+/// trait so the SQL/schema can evolve behind this seam without touching
+/// discovery, and so `orchestrator-plugin-host` stays Postgres-free.
+pub trait PluginRegistrySource: Send + Sync {
+    /// Return the desired plugin set. An error propagates to the discovery
+    /// caller as a [`crate::DiscoveryWarning`]: the DB tier degrades to a
+    /// no-op rather than sinking the whole discovery run.
+    fn desired_plugins(&self) -> Result<Vec<DbRegistryEntry>>;
+}
+
+/// In-memory [`PluginRegistrySource`] backing tests and the pre-schema stub
+/// adapter. Holds a fixed row set (or a canned error) so the discovery-tier
+/// wiring can be exercised without a live Postgres.
+#[derive(Debug, Clone)]
+pub struct StaticRegistrySource {
+    result: std::result::Result<Vec<DbRegistryEntry>, String>,
+}
+
+impl StaticRegistrySource {
+    /// A source that returns `entries` on every read.
+    pub fn new(entries: Vec<DbRegistryEntry>) -> Self {
+        Self { result: Ok(entries) }
+    }
+
+    /// A source whose read always fails with `message` — models the DB being
+    /// unreachable so the graceful-degrade path can be tested.
+    pub fn failing(message: impl Into<String>) -> Self {
+        Self { result: Err(message.into()) }
+    }
+}
+
+impl PluginRegistrySource for StaticRegistrySource {
+    fn desired_plugins(&self) -> Result<Vec<DbRegistryEntry>> {
+        self.result.clone().map_err(|message| anyhow::anyhow!(message))
+    }
+}

--- a/crates/orchestrator-plugin-host/src/discovery.rs
+++ b/crates/orchestrator-plugin-host/src/discovery.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use animus_plugin_protocol::PluginManifest;
@@ -8,6 +9,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use tokio::io::AsyncReadExt;
 
+use crate::db_registry::PluginRegistrySource;
 use crate::host::PLUGIN_BASE_ENV_ALLOWLIST;
 use crate::lockfile::PluginLockfile;
 use crate::manifest_cache::ManifestCache;
@@ -29,6 +31,11 @@ pub enum DiscoverySource {
     ProjectLocal,
     PluginPath,
     SystemPath,
+    /// The desired plugin set read from the Postgres `plugin_registry` served
+    /// by the animus-postgres BaaS. Opt-in — only active once the daemon wires
+    /// a [`PluginRegistrySource`] AFTER the bootstrap DB-backend plugin is up
+    /// (see [`crate::db_registry`]).
+    DbRegistry,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -84,12 +91,27 @@ struct PluginsConfig {
     providers: BTreeMap<String, PluginConfigEntry>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct PluginDiscovery {
     project_root: Option<PathBuf>,
     config_path: Option<PathBuf>,
     include_system_path: bool,
     scope: Option<PluginScope>,
+    db_registry: Option<Arc<dyn PluginRegistrySource>>,
+}
+
+// Manual Debug: `dyn PluginRegistrySource` is not `Debug`, so the derive can't
+// apply. The source is rendered as an opaque presence marker.
+impl std::fmt::Debug for PluginDiscovery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginDiscovery")
+            .field("project_root", &self.project_root)
+            .field("config_path", &self.config_path)
+            .field("include_system_path", &self.include_system_path)
+            .field("scope", &self.scope)
+            .field("db_registry", &self.db_registry.as_ref().map(|_| "<PluginRegistrySource>"))
+            .finish()
+    }
 }
 
 /// A binary the discovery walker found and now needs a manifest for.
@@ -322,6 +344,21 @@ impl PluginDiscovery {
         self
     }
 
+    /// Wire the DB-backed plugin registry ([`PluginRegistrySource`]) as an
+    /// additional discovery tier. The tier resolves the desired plugin set
+    /// recorded in the Postgres `plugin_registry` against the binaries present
+    /// on the volume.
+    ///
+    /// Bootstrap paradox: the daemon must call this ONLY after the bootstrap
+    /// DB-backend plugin is up (the plugin that serves the registry can't be
+    /// gated on the registry). When this builder is not called, discovery runs
+    /// the file/dir tiers alone and the DB tier is a no-op. See
+    /// [`crate::db_registry`].
+    pub fn with_db_registry(mut self, source: Arc<dyn PluginRegistrySource>) -> Self {
+        self.db_registry = Some(source);
+        self
+    }
+
     pub fn discover(&self) -> Result<Vec<DiscoveredPlugin>> {
         Ok(self.discover_with_warnings()?.0)
     }
@@ -397,6 +434,24 @@ impl PluginDiscovery {
         }
 
         self.discover_configured(&mut discovered, &mut warnings, &mut seen, &cache, lockfile.as_ref())?;
+
+        // DB-registry tier: the desired plugin set recorded in the Postgres
+        // `plugin_registry`, resolved against binaries on the volume. Opt-in
+        // and gated on the bootstrap paradox — only active once the daemon has
+        // wired a source (i.e. after the bootstrap DB-backend plugin is up).
+        // Runs after the explicit/project registry tiers (so a hand-pinned
+        // config entry still wins) and before the unconditional global-dir
+        // scan.
+        if let Some(source) = self.db_registry.clone() {
+            self.discover_db_registry(
+                source.as_ref(),
+                &mut discovered,
+                &mut warnings,
+                &mut seen,
+                &cache,
+                lockfile.as_ref(),
+            );
+        }
 
         // Scan the global plugin install dir unconditionally. This is the
         // canonical destination for `animus plugin install` and the
@@ -579,6 +634,92 @@ impl PluginDiscovery {
             }
         };
         self.discover_from_config(config, DiscoverySource::ProjectLocal, discovered, warnings, seen, cache, lockfile);
+    }
+
+    /// DB-registry tier: resolve the desired plugin set from a
+    /// [`PluginRegistrySource`] against binaries present in the plugin install
+    /// dir. Enabled rows whose binary is missing surface a
+    /// [`DiscoveryWarning`] (and reserve the name) so operators see the gap
+    /// instead of silently losing a plugin the DB said should be present.
+    /// A read error from the source degrades to a single warning — the daemon
+    /// must not lose every plugin because the registry read failed.
+    fn discover_db_registry(
+        &self,
+        source: &dyn PluginRegistrySource,
+        discovered: &mut Vec<DiscoveredPlugin>,
+        warnings: &mut Vec<DiscoveryWarning>,
+        seen: &mut HashSet<String>,
+        cache: &ManifestCache,
+        lockfile: Option<&PluginLockfile>,
+    ) {
+        let install_dir = plugin_install_dir();
+        let entries = match source.desired_plugins() {
+            Ok(entries) => entries,
+            Err(err) => {
+                let reason = format!("failed to read DB plugin registry: {err:#}");
+                tracing::warn!("plugin DB-registry discovery skipped: {reason}");
+                warnings.push(DiscoveryWarning {
+                    name: "plugin_registry".to_string(),
+                    path: install_dir,
+                    source: DiscoverySource::DbRegistry,
+                    reason,
+                });
+                return;
+            }
+        };
+
+        let mut candidates: Vec<ProbeCandidate> = Vec::new();
+        for entry in entries {
+            // Disabled rows are skipped entirely (not name-reserved) so a
+            // lower-precedence dir scan can still pick the binary up if it
+            // matches the scanned prefixes and the operator wants it.
+            if !entry.enabled {
+                continue;
+            }
+            let name = entry.name.trim().to_string();
+            if name.is_empty() || seen.contains(&name) {
+                continue;
+            }
+            // The installer places the correct per-target (or noarch) binary at
+            // `<install_dir>/<name>`, so resolution keys off the name; the
+            // row's `target` is advisory and only enriches the missing-binary
+            // warning.
+            let path = install_dir.join(&name);
+            if !path.exists() {
+                seen.insert(name.clone());
+                let target_note = entry.target.as_deref().map(|t| format!(" (target {t})")).unwrap_or_default();
+                let reason = format!(
+                    "DB registry lists plugin '{name}'{target_note} but no binary is present at {}",
+                    path.display()
+                );
+                tracing::warn!("plugin DB-registry discovery: {reason}");
+                warnings.push(DiscoveryWarning { name, path, source: DiscoverySource::DbRegistry, reason });
+                continue;
+            }
+            seen.insert(name.clone());
+            candidates.push(ProbeCandidate { name, path, source: DiscoverySource::DbRegistry });
+        }
+
+        let outcomes = resolve_manifests(&candidates, cache, lockfile);
+        for (cand, outcome) in candidates.into_iter().zip(outcomes) {
+            let ProbeCandidate { name, path, source } = cand;
+            match outcome {
+                ProbeOutcome::Hit(manifest) | ProbeOutcome::Probed(Ok(manifest)) => {
+                    seen.insert(name.clone());
+                    discovered.push(DiscoveredPlugin { name, path, manifest, source });
+                }
+                ProbeOutcome::Probed(Err(error)) => {
+                    seen.insert(name.clone());
+                    let reason = format!("{error:#}");
+                    tracing::warn!(
+                        plugin = %name,
+                        path = %path.display(),
+                        "DB-registry plugin manifest probe failed: {reason}"
+                    );
+                    warnings.push(DiscoveryWarning { name, path, source, reason });
+                }
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2287,5 +2428,171 @@ mod tests {
                 "manifest must match its candidate, no cross-talk between parallel probes"
             );
         }
+    }
+
+    // ---- DB-registry discovery tier (TASK-194) -------------------------
+
+    use crate::db_registry::{DbRegistryEntry, StaticRegistrySource};
+    use std::sync::Arc;
+
+    /// A subject-backend plugin name (`animus-subject-*`) is NOT matched by the
+    /// directory-scan tiers, so without the DB tier it is invisible; with a
+    /// wired registry source it is discovered and tagged `DbRegistry`.
+    #[cfg(unix)]
+    #[test]
+    fn db_registry_tier_discovers_enabled_plugin_from_volume() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _clear_plugin_path = EnvVarGuard::set("ANIMUS_PLUGIN_PATH", "");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fake_home = temp.path().join("animus-home");
+        let install_dir = fake_home.join("plugins");
+        fs::create_dir_all(&install_dir).expect("mkdir install dir");
+        let _config_dir = EnvVarGuard::set("ANIMUS_CONFIG_DIR", &fake_home);
+        let _plugin_dir = EnvVarGuard::set("ANIMUS_PLUGIN_DIR", &install_dir);
+
+        let plugin_path = install_dir.join("animus-subject-default");
+        write_executable_plugin(&plugin_path, "animus-subject-default");
+
+        let empty_config = temp.path().join("empty-plugins.yaml");
+        fs::write(&empty_config, "plugins: {}\n").expect("write empty config");
+
+        // Without a wired source the plugin is invisible (bootstrap paradox:
+        // the DB tier is off until the daemon opts in).
+        let (without_db, _) =
+            PluginDiscovery::new().with_config_path(&empty_config).discover_with_warnings().expect("discover");
+        assert!(
+            without_db.iter().all(|p| p.name != "animus-subject-default"),
+            "subject plugin must not be discovered without the DB tier, got {without_db:?}"
+        );
+
+        let source = Arc::new(StaticRegistrySource::new(vec![DbRegistryEntry::enabled("animus-subject-default")]));
+        let (discovered, warnings) = PluginDiscovery::new()
+            .with_config_path(&empty_config)
+            .with_db_registry(source)
+            .discover_with_warnings()
+            .expect("discover");
+
+        assert!(warnings.is_empty(), "expected zero warnings, got {warnings:?}");
+        let row = discovered
+            .iter()
+            .find(|p| p.name == "animus-subject-default")
+            .expect("DB-registry tier must discover the enabled plugin");
+        assert_eq!(row.source, DiscoverySource::DbRegistry);
+        assert_eq!(row.path, plugin_path);
+    }
+
+    /// Disabled rows are skipped; enabled rows whose binary is absent from the
+    /// volume surface a warning instead of being silently dropped.
+    #[cfg(unix)]
+    #[test]
+    fn db_registry_tier_skips_disabled_and_warns_on_missing_binary() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _clear_plugin_path = EnvVarGuard::set("ANIMUS_PLUGIN_PATH", "");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fake_home = temp.path().join("animus-home");
+        let install_dir = fake_home.join("plugins");
+        fs::create_dir_all(&install_dir).expect("mkdir install dir");
+        let _config_dir = EnvVarGuard::set("ANIMUS_CONFIG_DIR", &fake_home);
+        let _plugin_dir = EnvVarGuard::set("ANIMUS_PLUGIN_DIR", &install_dir);
+
+        let empty_config = temp.path().join("empty-plugins.yaml");
+        fs::write(&empty_config, "plugins: {}\n").expect("write empty config");
+
+        let disabled = DbRegistryEntry { enabled: false, ..DbRegistryEntry::enabled("animus-subject-disabled") };
+        let missing =
+            DbRegistryEntry { target: Some("noarch".to_string()), ..DbRegistryEntry::enabled("animus-postgres") };
+        let source = Arc::new(StaticRegistrySource::new(vec![disabled, missing]));
+
+        let (discovered, warnings) = PluginDiscovery::new()
+            .with_config_path(&empty_config)
+            .with_db_registry(source)
+            .discover_with_warnings()
+            .expect("discover");
+
+        assert!(discovered.is_empty(), "no binaries on the volume, nothing to discover, got {discovered:?}");
+        assert_eq!(warnings.len(), 1, "only the enabled-but-missing row warns, got {warnings:?}");
+        assert_eq!(warnings[0].name, "animus-postgres");
+        assert_eq!(warnings[0].source, DiscoverySource::DbRegistry);
+        assert!(warnings[0].reason.contains("noarch"), "warning should carry the target, got {}", warnings[0].reason);
+        assert!(warnings[0].reason.contains("no binary is present"));
+    }
+
+    /// A read failure from the registry source degrades to a single warning —
+    /// the other tiers (here, the global-dir scan) still resolve.
+    #[cfg(unix)]
+    #[test]
+    fn db_registry_read_error_degrades_to_warning_without_sinking_discovery() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _clear_plugin_path = EnvVarGuard::set("ANIMUS_PLUGIN_PATH", "");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fake_home = temp.path().join("animus-home");
+        let install_dir = fake_home.join("plugins");
+        fs::create_dir_all(&install_dir).expect("mkdir install dir");
+        let _config_dir = EnvVarGuard::set("ANIMUS_CONFIG_DIR", &fake_home);
+        let _plugin_dir = EnvVarGuard::set("ANIMUS_PLUGIN_DIR", &install_dir);
+
+        // A prefixed plugin that the unconditional global-dir scan still finds.
+        let scanned = install_dir.join("animus-provider-scanned");
+        write_executable_plugin(&scanned, "animus-provider-scanned");
+
+        let empty_config = temp.path().join("empty-plugins.yaml");
+        fs::write(&empty_config, "plugins: {}\n").expect("write empty config");
+
+        let source = Arc::new(StaticRegistrySource::failing("connection refused"));
+        let (discovered, warnings) = PluginDiscovery::new()
+            .with_config_path(&empty_config)
+            .with_db_registry(source)
+            .discover_with_warnings()
+            .expect("discover");
+
+        assert!(
+            discovered.iter().any(|p| p.name == "animus-provider-scanned"),
+            "file/dir tiers must still resolve when the DB read fails, got {discovered:?}"
+        );
+        let db_warning = warnings
+            .iter()
+            .find(|w| w.source == DiscoverySource::DbRegistry)
+            .expect("DB read error must surface a warning");
+        assert!(db_warning.reason.contains("connection refused"), "unexpected reason: {}", db_warning.reason);
+    }
+
+    /// A hand-pinned explicit config entry outranks the DB tier: the DB row's
+    /// name is already reserved by the higher-precedence tier, so it does not
+    /// re-add or shadow it.
+    #[cfg(unix)]
+    #[test]
+    fn explicit_config_takes_precedence_over_db_registry() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _clear_plugin_dir = EnvVarGuard::set("ANIMUS_PLUGIN_DIR", "");
+        let _clear_plugin_path = EnvVarGuard::set("ANIMUS_PLUGIN_PATH", "");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _config_dir = EnvVarGuard::set("ANIMUS_CONFIG_DIR", temp.path().join("animus-home"));
+
+        let plugin = temp.path().join("configured-subject");
+        write_executable_plugin(&plugin, "animus-subject-default");
+
+        let config_path = temp.path().join("plugins.yaml");
+        fs::write(
+            &config_path,
+            format!("plugins:\n  animus-subject-default:\n    binary: {}\n", plugin.to_string_lossy()),
+        )
+        .expect("write config");
+
+        let source = Arc::new(StaticRegistrySource::new(vec![DbRegistryEntry::enabled("animus-subject-default")]));
+        let (discovered, warnings) = PluginDiscovery::new()
+            .with_config_path(&config_path)
+            .with_db_registry(source)
+            .discover_with_warnings()
+            .expect("discover");
+
+        assert!(warnings.is_empty(), "expected zero warnings, got {warnings:?}");
+        let rows: Vec<&DiscoveredPlugin> = discovered.iter().filter(|p| p.name == "animus-subject-default").collect();
+        assert_eq!(rows.len(), 1, "name must dedupe to a single entry across tiers, got {rows:?}");
+        assert_eq!(rows[0].source, DiscoverySource::ExplicitConfig, "explicit config must outrank the DB tier");
+        assert_eq!(rows[0].path, plugin);
     }
 }

--- a/crates/orchestrator-plugin-host/src/lib.rs
+++ b/crates/orchestrator-plugin-host/src/lib.rs
@@ -1,5 +1,6 @@
 //! Stdio hosting, discovery, and routing for Animus-compatible plugins.
 
+pub mod db_registry;
 mod discovery;
 mod host;
 pub mod lockfile;
@@ -12,6 +13,7 @@ pub mod status;
 mod subject_router;
 mod transport;
 
+pub use db_registry::{DbRegistryEntry, PluginRegistrySource, StaticRegistrySource};
 pub use discovery::{
     discover_by_kind, discover_plugins, is_scanned_plugin_name, legacy_plugins_registry_path, plugin_install_dir,
     plugins_registry_path, project_plugin_install_dir, project_plugins_registry_path,

--- a/crates/orchestrator-plugin-host/src/status.rs
+++ b/crates/orchestrator-plugin-host/src/status.rs
@@ -280,11 +280,19 @@ impl PluginStatusRegistry {
 
     /// Bump `last_rpc_at` for the named plugin. Called after every successful
     /// RPC round-trip.
+    ///
+    /// A successful round-trip is definitive proof the plugin's handshake
+    /// completed and it is serving, so any `last_error` captured earlier — e.g.
+    /// a transient connection-lost recorded during the boot window before the
+    /// subject router resolved — is cleared here. Without this the stale error
+    /// latched forever and `daemon health` kept surfacing a misleading
+    /// "subject_backend unroutable" (or similar) long after the plugin came up.
     pub fn record_rpc(&self, name: &str) {
         let mut guard = self.inner.write().expect("plugin status registry poisoned");
         if let Some(entry) = guard.get_mut(name) {
             entry.last_rpc = Some(Instant::now());
             entry.last_rpc_at = Some(Utc::now());
+            entry.last_error = None;
             if matches!(entry.state, PluginRuntimeState::Discovered | PluginRuntimeState::Stopped) {
                 entry.state = PluginRuntimeState::Running;
             }
@@ -412,6 +420,33 @@ mod tests {
         assert_eq!(row.pid, None);
         let err = row.last_error.expect("last_error captured");
         assert_eq!(err.code, "ConnectionLost");
+    }
+
+    #[test]
+    fn successful_rpc_clears_latched_last_error_from_boot_window() {
+        // Regression: a transient connection-lost during the ~4s boot window
+        // latched `last_error` (e.g. "subject_backend unroutable"). Once the
+        // plugin handshake completed and it began serving RPCs, the stale
+        // error must be superseded so health stops reading as degraded.
+        let reg = PluginStatusRegistry::new();
+        reg.record_discovered("animus-subject-default", "task", None, None);
+        reg.record_spawn("animus-subject-default", Some(1));
+        reg.record_exit("animus-subject-default", Some(("ConnectionLost".into(), "subject_backend unroutable".into())));
+        assert!(
+            reg.get("animus-subject-default").expect("entry").last_error.is_some(),
+            "precondition: boot-window error is latched",
+        );
+
+        reg.record_spawn("animus-subject-default", Some(2));
+        reg.record_rpc("animus-subject-default");
+
+        let row = reg.get("animus-subject-default").expect("entry");
+        assert_eq!(row.state, PluginRuntimeState::Running);
+        assert!(
+            row.last_error.is_none(),
+            "a successful RPC round-trip must clear the stale boot-window error, got {:?}",
+            row.last_error,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Three changes on the v0.7 plugin discovery / install path. One branch, one PR.

## 1. DiscoverySource::DbRegistry tier (TASK-194)

Adds an opt-in plugin-discovery tier that resolves the desired plugin set from the Postgres plugin_registry (served by the animus-postgres BaaS) against the binaries present on the volume.

- New module crates/orchestrator-plugin-host/src/db_registry.rs defines the stable in-kernel contract: DbRegistryEntry with fields name, version, source, sha256, target, enabled, scope; a PluginRegistrySource trait (the read seam); and a StaticRegistrySource stub used by tests and as the pre-schema adapter.
- orchestrator-plugin-host takes NO Postgres dependency. The actual SQL lives behind the trait in a daemon-side adapter, to be added once the BaaS schema is finalized.
- Bootstrap paradox respected: the tier is a no-op until a source is wired via PluginDiscovery::with_db_registry, which the daemon only calls AFTER the bootstrap DB-backend plugin is up. So a fresh boot never deadlocks on a registry it cannot reach yet.
- Precedence: slots after the explicit/project registry tiers (a hand-pinned config entry still wins) and before the unconditional global-dir scan. Enabled rows whose binary is absent surface a DiscoveryWarning; a registry read error degrades to a single warning rather than sinking the whole run.

## 2. noarch / any install target (TASK-200 sub-item)

Release-asset resolution now falls back to a platform-independent asset (name-noarch.tar.gz or -any) when no triple-specific asset exists, so a JS-bundle plugin (node-shebang esbuild bundle) publishes ONE asset instead of duplicating the same bytes under every triple name.

- A triple-specific asset always wins; noarch is strictly a fallback (new select_release_asset chains the pickers).
- target_triple_from_asset_name and the SHA256SUMS parser recognize the noarch archive under a synthetic noarch target, so its integrity claim keys consistently.

## 3. Health last_error clear (cosmetic)

PluginStatusRegistry::record_rpc now clears last_error on a successful RPC round-trip. A transient connection-lost captured during the ~4s boot window (e.g. subject_backend unroutable) previously latched forever and kept daemon health reading as degraded long after the subject router resolved. A successful round-trip is definitive proof the handshake completed, so it supersedes the stale error.

## Tests / checks

Unit tests added for all three parts. cargo build, test, and clippy all pass for orchestrator-plugin-host (195 lib tests), orchestrator-cli (noarch selection + sha256sums), and orchestrator-daemon-runtime (builds; the DiscoverySource wire-label match arm updated).

## Follow-ups (need the BaaS schema finalized)

- The daemon-side PluginRegistrySource adapter that runs the actual SQL against plugin_registry (through the running DB-backend plugin) and the daemon wiring that calls with_db_registry after bootstrap are intentionally NOT in this PR, since the exact column types are still being finalized on the BaaS side. This PR lands the seam, the discovery-tier wiring, the gating, and tests.

Note: codex self-vet could not be run in this environment (codex CLI not available). All standard gates (build, test, clippy, fmt) pass.
