### PR TITLE
Retire the adhoc subject sentinel: dispatch genuinely subjectless runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "animus-actor"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "schemars",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "animus-config-protocol"
 version = "0.1.1"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-actor",
  "anyhow",
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "animus-control-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-actor",
  "animus-log-storage-protocol",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "animus-environment-protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-plugin-protocol 0.1.17",
  "schemars",
@@ -125,7 +125,7 @@ dependencies = [
 [[package]]
 name = "animus-journal-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-plugin-protocol 0.1.17",
  "anyhow",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "animus-log-storage-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-plugin-protocol 0.1.17",
  "anyhow",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "animus-plugin-protocol"
 version = "0.1.17"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "schemars",
  "serde",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "animus-session-backend"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-actor",
  "animus-plugin-protocol 0.1.17",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "animus-subject-protocol"
 version = "0.1.16"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-actor",
  "animus-plugin-protocol 0.1.17",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "animus-trigger-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-plugin-protocol 0.1.17",
  "anyhow",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "animus-workflow-runner-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-actor",
  "animus-plugin-protocol 0.1.17",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.3#f3a1d9f99dd49979e6128d5203f6743d9d000343"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.4#111eadf67a4060d6d83d93338ed3ce3858459330"
 dependencies = [
  "animus-subject-protocol 0.1.16",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ categories = ["command-line-utilities", "development-tools"]
 # animus-subject-protocol resolves to one source (no duplicate-crate type
 # mismatches). animus-plugin-protocol/runtime remain in-tree pending a
 # follow-up move.
-animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 # v0.7: environment plugin kind — EnvironmentSpec/HarnessCommand/ExecRequest wire
 # types + prepare/exec/exec_stream/teardown methods. Consumed by the routing
 # resolver + the follow-on runtime EnvironmentClient (not yet built).
-animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3", package = "protocol" }
+animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4", package = "protocol" }
 orchestrator-daemon-runtime = { path = "crates/orchestrator-daemon-runtime" }
 orchestrator-logging = { path = "crates/orchestrator-logging" }
 orchestrator-plugin-host = { path = "crates/orchestrator-plugin-host" }

--- a/crates/animus-runtime-shared/src/phase_output.rs
+++ b/crates/animus-runtime-shared/src/phase_output.rs
@@ -763,7 +763,7 @@ mod tests {
             id: workflow_id.to_string(),
             task_id: "TASK-1".to_string(),
             workflow_ref: None,
-            subject: SubjectRef::task("TASK-1".to_string()),
+            subject: Some(SubjectRef::task("TASK-1".to_string())),
             input: None,
             vars: std::collections::HashMap::new(),
             status: WorkflowStatus::Running,

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -39,9 +39,9 @@ animus-environment-protocol = { workspace = true }
 # embed subject-protocol types, so `animus-subject-protocol-wire` MUST match
 # control's rev. v0.1.26 additively adds `actor: Option<Actor>` to the control +
 # workflow-runner request types relayed by the control surface / plugin_clients.
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 animus-actor = { workspace = true }
 # Plugin protocol crates used by the plugin-host wrappers in
 # `services::plugin_clients` to dispatch `workflow/*` and `queue/*` RPCs through
@@ -51,7 +51,7 @@ animus-actor = { workspace = true }
 # NOT share `animus-subject-protocol-wire`'s rev (cargo forbids two names for one
 # package instance), so they stay a distinct rev.
 animus-queue-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.5.10" }
-animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 animus-subject-protocol-v05 = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.5.10" }
 protocol = { workspace = true }
 animus-session-backend = { workspace = true }

--- a/crates/orchestrator-cli/src/cli_types/queue_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/queue_types.rs
@@ -58,7 +58,7 @@ pub(crate) struct QueueEnqueueArgs {
     #[arg(
         long,
         group = "subject",
-        help = "Dispatch a subjectless (ad-hoc) run with NO bound subject. The workflow runs without subject-bound template vars — use for subject-less-by-design workflows (e.g. relate) fired without a target. Requires --workflow-ref. Mutually exclusive with --task-id / --requirement-id / --title / --subject-id."
+        help = "Dispatch a subjectless (ad-hoc) run with NO bound subject. The workflow runs without subject-bound template vars — use for subject-less-by-design workflows (e.g. relate) fired without a target. Requires --workflow-ref. Mutually exclusive with --task-id / --requirement-id / --title / --subject-id. NOTE: not yet supported through the installed queue plugin (its RPC protocol still requires a subject); dispatch such runs directly for now."
     )]
     pub(crate) adhoc: bool,
     #[arg(long, value_name = "TEXT", help = "Custom subject description (used with --title).")]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -88,7 +88,7 @@ fn save_workflow(
             rework_counts: HashMap::new(),
             total_reworks: 0,
             decision_history: Vec::new(),
-            subject: protocol::SubjectRef::task(task_id.to_string()),
+            subject: Some(protocol::SubjectRef::task(task_id.to_string())),
         })
         .expect("workflow should be written");
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -6,28 +6,25 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use orchestrator_core::{load_workflow_config_or_default, services::ServiceHub, workflow_ref_for_task};
-use protocol::orchestrator::{SubjectRef, SUBJECT_KIND_CUSTOM};
 use protocol::{SubjectDispatch, SubjectDispatchExt};
 
 use super::ops_workflow::resolve_requirement_workflow_ref;
 use crate::{invalid_input_error, print_ok, print_value, CliError, CliErrorKind, QueueCommand, QueueSubjectArgs};
 
-/// Build a subjectless (ad-hoc) dispatch with NO bound subject.
+/// Build a genuinely subjectless (ad-hoc) dispatch with NO bound subject.
 ///
-/// The wire [`SubjectRef`] is non-optional, so "no subject" is represented as a
-/// `custom`-kind subject carrying a UNIQUE id (`adhoc:<nanos>`) — the unique id
-/// keeps each ad-hoc run's queue `subject_key` distinct so a burst of
-/// subjectless runs (e.g. `relate` firing on repo events) is not deduped into
-/// one. The run-loop resolves this via the built-in custom subject adapter (it
-/// never hits the "no subject adapter registered" error), so a subjectless
-/// dispatch is a valid mode, not a failure. Subject-bound command phases are
-/// out of place in such a workflow and should be command-guarded / skipped.
-fn adhoc_subject_dispatch(workflow_ref: String, input: Option<serde_json::Value>) -> SubjectDispatch {
-    let unique = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
-    let mut subject = SubjectRef::new(SUBJECT_KIND_CUSTOM, format!("adhoc:{unique}"));
-    subject.title = Some("ad-hoc".to_string());
-    SubjectDispatch::for_subject_with_metadata(subject, workflow_ref, "manual-queue-enqueue", chrono::Utc::now())
-        .with_input(input)
+/// The wire subject is now optional, so "no subject" is a true absence
+/// (`SubjectDispatch::subject == None`) rather than a synthetic `custom`-kind
+/// sentinel. The run-loop binds a None subject context: subject template vars
+/// are simply absent and no subject adapter is resolved. Subject-bound command
+/// phases are out of place in such a workflow and should be command-guarded /
+/// skipped.
+///
+/// Because the dispatch carries no subject there is no `subject_key`, so the
+/// queue does not dedup subjectless runs — a burst of `relate` firings each
+/// enqueue as their own entry.
+fn subjectless_dispatch(workflow_ref: String, input: Option<serde_json::Value>) -> SubjectDispatch {
+    SubjectDispatch::subjectless(workflow_ref, "manual-queue-enqueue", chrono::Utc::now()).with_input(input)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -48,7 +45,7 @@ async fn resolve_enqueue_dispatch(
                 "--adhoc requires --workflow-ref: a subjectless run must name the workflow to dispatch.",
             )
         })?;
-        return Ok(adhoc_subject_dispatch(workflow_ref, input));
+        return Ok(subjectless_dispatch(workflow_ref, input));
     }
     match (task_id, requirement_id, title) {
         (Some(task_id), None, None) => {
@@ -218,6 +215,17 @@ pub(crate) async fn handle_queue(
 
             let run_at = args.run_at.as_deref().map(resolve_run_at).transpose()?;
 
+            // The kernel dispatch type (rc protocol) can now be subjectless, but
+            // the queue plugin RPC is still pinned to the v0.5 line for deployed
+            // queue-plugin wire compatibility, and that SubjectDispatch requires
+            // a subject. A subjectless run therefore cannot travel through the
+            // installed queue plugin yet: dispatch it directly (workflow run)
+            // until the queue protocol takes up the optional-subject 0.7 line.
+            if dispatch.subject().is_none() {
+                return Err(invalid_input_error(
+                    "subjectless (--adhoc) enqueue is not yet supported through the installed queue plugin: its queue RPC protocol still requires a subject. Dispatch the workflow directly instead.",
+                ));
+            }
             let dispatch_value =
                 serde_json::to_value(&dispatch).context("encoding subject_dispatch for queue plugin")?;
             let plugin_dispatch = serde_json::from_value(dispatch_value)
@@ -816,10 +824,11 @@ mod tests {
         .await
         .expect("adhoc dispatch builds");
         assert_eq!(dispatch.workflow_ref, "relate");
-        // Custom kind so the built-in custom subject adapter resolves it — the
-        // run-loop never hits "no subject adapter registered".
-        assert_eq!(dispatch.subject.kind(), SUBJECT_KIND_CUSTOM);
-        assert!(dispatch.subject.id().starts_with("adhoc:"), "ad-hoc id: {}", dispatch.subject.id());
+        // Genuinely subjectless: the dispatch carries NO subject at all (not a
+        // synthetic custom sentinel). The run-loop binds a None subject context.
+        assert!(dispatch.subject().is_none(), "subjectless dispatch must have no subject");
+        assert_eq!(dispatch.subject_id(), None);
+        assert_eq!(dispatch.subject_kind(), None);
     }
 
     #[tokio::test]
@@ -843,14 +852,16 @@ mod tests {
     }
 
     #[test]
-    fn adhoc_subject_dispatches_have_distinct_subject_keys() {
-        // A burst of subjectless runs must not collapse to one queue entry: each
-        // ad-hoc dispatch carries a unique subject id, so the queue subject_key
-        // stays distinct (the `relate`-storm dedup regression).
-        let a = adhoc_subject_dispatch("relate".to_string(), None);
-        std::thread::sleep(std::time::Duration::from_nanos(10));
-        let b = adhoc_subject_dispatch("relate".to_string(), None);
-        assert_ne!(a.subject.subject_key(), b.subject.subject_key());
+    fn subjectless_dispatches_have_no_subject_key() {
+        // A subjectless dispatch carries no subject, so it has no queue
+        // subject_key. With nothing to key on, the queue does not dedup a burst
+        // of subjectless runs (e.g. a `relate` storm) into one entry.
+        let a = subjectless_dispatch("relate".to_string(), None);
+        let b = subjectless_dispatch("relate".to_string(), None);
+        assert_eq!(a.subject_key(), None);
+        assert_eq!(b.subject_key(), None);
+        assert!(a.subject().is_none());
+        assert!(b.subject().is_none());
     }
 
     #[tokio::test]

--- a/crates/orchestrator-cli/src/services/operations/ops_queue/control_routing.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue/control_routing.rs
@@ -513,7 +513,7 @@ mod tests {
             "manual-queue-enqueue-via-control",
             Utc::now(),
         );
-        assert_eq!(song.to_workflow_run_input().subject().kind(), "song");
+        assert_eq!(song.to_workflow_run_input().subject().unwrap().kind(), "song");
 
         // Canonical task subjects still round-trip as tasks.
         let task = SubjectDispatch::for_subject_with_metadata(
@@ -522,6 +522,6 @@ mod tests {
             "src",
             Utc::now(),
         );
-        assert_eq!(task.to_workflow_run_input().subject().kind(), protocol::orchestrator::SUBJECT_KIND_TASK);
+        assert_eq!(task.to_workflow_run_input().subject().unwrap().kind(), protocol::orchestrator::SUBJECT_KIND_TASK);
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
@@ -183,7 +183,7 @@ pub(crate) async fn handle_workflow_execute(
                 project_terminal_workflow_result(
                     hub.clone(),
                     project_root,
-                    reloaded.subject.id(),
+                    reloaded.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                     Some(reloaded.task_id.as_str()),
                     reloaded.workflow_ref.as_deref(),
                     Some(reloaded.id.as_str()),

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -158,12 +158,17 @@ async fn resolve_workflow_run_dispatch_from_input(
         ..
     } = input;
     let effective_task_id = subject
-        .task_id()
+        .as_ref()
+        .and_then(|s| s.task_id())
         .filter(|id| !id.is_empty())
         .map(|s| s.to_string())
         .or_else(|| (!flat_task_id.is_empty()).then_some(flat_task_id));
-    let effective_requirement_id =
-        subject.requirement_id().filter(|id| !id.is_empty()).map(|s| s.to_string()).or(flat_requirement_id);
+    let effective_requirement_id = subject
+        .as_ref()
+        .and_then(|s| s.requirement_id())
+        .filter(|id| !id.is_empty())
+        .map(|s| s.to_string())
+        .or(flat_requirement_id);
     if let Some(id) = effective_task_id {
         // See `resolve_workflow_run_dispatch`: try in-tree task store first, then
         // fall back to subject_resolver so plugin-owned tasks dispatch correctly.
@@ -209,7 +214,7 @@ async fn resolve_workflow_run_dispatch_from_input(
         )
         .with_input(input))
         .map(|dispatch| dispatch.with_vars(vars))
-    } else {
+    } else if let Some(subject) = subject {
         Ok(protocol::SubjectDispatch::for_custom(
             subject.title.unwrap_or_else(|| subject.id.clone()),
             subject.description.unwrap_or_default(),
@@ -218,6 +223,15 @@ async fn resolve_workflow_run_dispatch_from_input(
             "manual-cli-run",
         ))
         .map(|dispatch| dispatch.with_vars(vars))
+    } else {
+        // No task/requirement/custom subject: a genuinely subjectless run.
+        Ok(protocol::SubjectDispatch::subjectless(
+            workflow_ref.unwrap_or_else(|| default_project_workflow_ref(project_root)),
+            "manual-cli-run",
+            Utc::now(),
+        )
+        .with_input(input)
+        .with_vars(vars))
     }
 }
 
@@ -1175,7 +1189,7 @@ mod tests {
         .await
         .expect("dispatch should resolve");
 
-        assert_eq!(dispatch.subject_id(), task.id);
+        assert_eq!(dispatch.subject_id(), Some(task.id.as_str()));
         assert_eq!(dispatch.workflow_ref, orchestrator_core::workflow_ref_for_task(&task));
         assert_eq!(dispatch.trigger_source, "manual-cli-run");
     }
@@ -1206,7 +1220,7 @@ mod tests {
         .await
         .expect("legacy input should resolve");
 
-        assert_eq!(dispatch.subject_id(), task.id);
+        assert_eq!(dispatch.subject_id(), Some(task.id.as_str()));
         assert_eq!(dispatch.workflow_ref, orchestrator_core::workflow_ref_for_task(&task));
     }
 
@@ -1278,7 +1292,7 @@ mod tests {
             .await
             .expect("legacy raw payload should resolve");
 
-        assert_eq!(dispatch.subject_id(), task.id);
+        assert_eq!(dispatch.subject_id(), Some(task.id.as_str()));
         assert_eq!(dispatch.input, Some(serde_json::json!({"k":"v"})));
     }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
@@ -91,28 +91,34 @@ pub(crate) fn workflow_execute_request_for_existing(
     // rebuild one from the persisted record (authoritative for workflow_ref /
     // input / vars). Task / requirement / custom keep the existing convenience
     // fields untouched.
-    let kind = workflow.subject.kind();
-    let subject_dispatch =
-        if kind == SUBJECT_KIND_TASK || kind == SUBJECT_KIND_REQUIREMENT || kind == SUBJECT_KIND_CUSTOM {
-            None
-        } else {
-            Some(
-                SubjectDispatch::for_subject_with_metadata(
-                    workflow.subject.clone(),
-                    workflow.workflow_ref.clone().unwrap_or_default(),
-                    "reattach-detached-runner",
-                    workflow.started_at,
+    // A subjectless run reattaches with NO subject at all: no subject_dispatch
+    // and no convenience fields, so the runner resumes it subjectless.
+    let subject_dispatch = match workflow.subject.as_ref() {
+        None => None,
+        Some(subject) => {
+            let kind = subject.kind();
+            if kind == SUBJECT_KIND_TASK || kind == SUBJECT_KIND_REQUIREMENT || kind == SUBJECT_KIND_CUSTOM {
+                None
+            } else {
+                Some(
+                    SubjectDispatch::for_subject_with_metadata(
+                        subject.clone(),
+                        workflow.workflow_ref.clone().unwrap_or_default(),
+                        "reattach-detached-runner",
+                        workflow.started_at,
+                    )
+                    .with_input(workflow.input.clone())
+                    .with_vars(workflow.vars.clone()),
                 )
-                .with_input(workflow.input.clone())
-                .with_vars(workflow.vars.clone()),
-            )
-        };
+            }
+        }
+    };
     workflow_proto::WorkflowExecuteRequest {
         workflow_id: Some(workflow.id.clone()),
         subject_dispatch,
         subject_ref: None,
-        task_id: workflow.subject.task_id().map(str::to_string),
-        requirement_id: workflow.subject.requirement_id().map(str::to_string),
+        task_id: workflow.subject.as_ref().and_then(|s| s.task_id()).map(str::to_string),
+        requirement_id: workflow.subject.as_ref().and_then(|s| s.requirement_id()).map(str::to_string),
         title: None,
         description: None,
         workflow_ref: workflow.workflow_ref.clone(),
@@ -309,7 +315,7 @@ pub(crate) async fn start_workflow_with_runner(
         project_terminal_workflow_result(
             hub.clone(),
             project_root,
-            workflow.subject.id(),
+            workflow.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
             Some(workflow.task_id.as_str()),
             workflow.workflow_ref.as_deref(),
             Some(workflow.id.as_str()),
@@ -367,7 +373,7 @@ pub(crate) async fn resume_workflow_with_runner(
     // concurrent runner for the same record.
     match orchestrator_daemon_runtime::agent_record::scan_orphans_for_project(Path::new(project_root)) {
         Ok(report) => {
-            let subject_id = existing.subject.id();
+            let subject_id = existing.subject.as_ref().map(|s| s.id()).unwrap_or_default();
             let daemon_owned = report.detected.iter().any(|agent| {
                 agent.subject_id == subject_id
                     || (!existing.task_id.is_empty() && agent.task_id.as_deref() == Some(existing.task_id.as_str()))
@@ -689,7 +695,7 @@ pub(crate) async fn approve_manual_phase(
                     project_terminal_workflow_result(
                         hub.clone(),
                         project_root,
-                        reloaded.subject.id(),
+                        reloaded.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                         Some(reloaded.task_id.as_str()),
                         reloaded.workflow_ref.as_deref(),
                         Some(reloaded.id.as_str()),
@@ -707,7 +713,7 @@ pub(crate) async fn approve_manual_phase(
                     project_terminal_workflow_result(
                         hub.clone(),
                         project_root,
-                        reloaded.subject.id(),
+                        reloaded.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                         Some(reloaded.task_id.as_str()),
                         reloaded.workflow_ref.as_deref(),
                         Some(reloaded.id.as_str()),
@@ -733,7 +739,7 @@ pub(crate) async fn approve_manual_phase(
     project_terminal_workflow_result(
         hub.clone(),
         project_root,
-        final_workflow.subject.id(),
+        final_workflow.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
         Some(final_workflow.task_id.as_str()),
         final_workflow.workflow_ref.as_deref(),
         Some(final_workflow.id.as_str()),
@@ -785,7 +791,7 @@ pub(crate) async fn reject_manual_phase(
     project_terminal_workflow_result(
         hub.clone(),
         project_root,
-        updated.subject.id(),
+        updated.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
         Some(updated.task_id.as_str()),
         updated.workflow_ref.as_deref(),
         Some(updated.id.as_str()),
@@ -1291,7 +1297,7 @@ workflows:
             rework_counts: std::collections::HashMap::new(),
             total_reworks: 0,
             decision_history: Vec::new(),
-            subject: protocol::orchestrator::SubjectRef::new("blog", "blog:BLOG-001"),
+            subject: Some(protocol::orchestrator::SubjectRef::new("blog", "blog:BLOG-001")),
         };
 
         let request = super::workflow_execute_request_for_existing(&workflow);
@@ -1300,8 +1306,8 @@ workflows:
         assert_eq!(request.task_id, None);
         assert_eq!(request.requirement_id, None);
         let dispatch = request.subject_dispatch.expect("generic kind must carry subject_dispatch");
-        assert_eq!(dispatch.subject.kind(), "blog");
-        assert_eq!(dispatch.subject.id(), "blog:BLOG-001");
+        assert_eq!(dispatch.subject.as_ref().unwrap().kind(), "blog");
+        assert_eq!(dispatch.subject.as_ref().map(|s| s.id()).unwrap_or_default(), "blog:BLOG-001");
         assert_eq!(dispatch.workflow_ref, "draft-post");
     }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/prompt.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/prompt.rs
@@ -57,7 +57,7 @@ struct ResolvedPromptContext {
     workflow_id: String,
     workflow_id_is_preview: bool,
     workflow_ref: String,
-    subject: SubjectRef,
+    subject: Option<SubjectRef>,
     subject_title: String,
     subject_description: String,
     execution_cwd: String,
@@ -121,7 +121,7 @@ async fn render_existing_workflow_prompts(
                 rework_context: existing_workflow_rework_context(&workflow, &phase_id),
                 pipeline_vars: context.workflow_vars.clone(),
                 dispatch_input: context.input.as_ref().map(Value::to_string),
-                schedule_input: schedule_prompt_input(&context.subject, context.input.as_ref()),
+                schedule_input: schedule_prompt_input(context.subject.as_ref(), context.input.as_ref()),
             };
             let rendered = render_phase_prompt_with_skills(
                 project_root,
@@ -129,7 +129,7 @@ async fn render_existing_workflow_prompts(
                     project_root,
                     execution_cwd: &context.execution_cwd,
                     workflow_id: &context.workflow_id,
-                    subject_id: context.subject.id(),
+                    subject_id: context.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                     subject_title: &context.subject_title,
                     subject_description: &context.subject_description,
                     phase_id: &phase_id,
@@ -167,7 +167,7 @@ async fn render_ad_hoc_prompts(
                 rework_context: args.rework_context.clone(),
                 pipeline_vars: context.workflow_vars.clone(),
                 dispatch_input: context.input.as_ref().map(Value::to_string),
-                schedule_input: schedule_prompt_input(&context.subject, context.input.as_ref()),
+                schedule_input: schedule_prompt_input(context.subject.as_ref(), context.input.as_ref()),
             };
             let rendered = render_phase_prompt_with_skills(
                 project_root,
@@ -175,7 +175,7 @@ async fn render_ad_hoc_prompts(
                     project_root,
                     execution_cwd: &context.execution_cwd,
                     workflow_id: &context.workflow_id,
-                    subject_id: context.subject.id(),
+                    subject_id: context.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                     subject_title: &context.subject_title,
                     subject_description: &context.subject_description,
                     phase_id: &phase_id,
@@ -221,20 +221,28 @@ async fn resolve_existing_workflow_context(
     hub: Arc<dyn ServiceHub>,
     project_root: &str,
 ) -> Result<ResolvedPromptContext> {
-    let resolved = hub
-        .subject_resolver()
-        .resolve_subject_context(&workflow.subject, None, None)
-        .await
-        .with_context(|| format!("failed to resolve subject context for workflow '{}'", workflow.id))?;
-    let execution_cwd = ensure_execution_cwd(hub, project_root, &workflow.subject, &resolved).await?;
+    // A subjectless workflow has no subject to resolve: render with absent
+    // subject vars and fall back to the project root as the execution cwd.
+    let (subject_title, subject_description, execution_cwd) = match workflow.subject.as_ref() {
+        Some(subject) => {
+            let resolved = hub
+                .subject_resolver()
+                .resolve_subject_context(subject, None, None)
+                .await
+                .with_context(|| format!("failed to resolve subject context for workflow '{}'", workflow.id))?;
+            let execution_cwd = ensure_execution_cwd(hub, project_root, subject, &resolved).await?;
+            (resolved.subject_title, resolved.subject_description, execution_cwd)
+        }
+        None => (String::new(), String::new(), project_root.to_string()),
+    };
 
     Ok(ResolvedPromptContext {
         workflow_id: workflow.id.clone(),
         workflow_id_is_preview: false,
         workflow_ref,
         subject: workflow.subject.clone(),
-        subject_title: resolved.subject_title,
-        subject_description: resolved.subject_description,
+        subject_title,
+        subject_description,
         execution_cwd,
         workflow_vars: workflow.vars.clone(),
         input: workflow.input.clone(),
@@ -291,7 +299,7 @@ async fn resolve_ad_hoc_context(
         workflow_id: Uuid::new_v4().to_string(),
         workflow_id_is_preview: true,
         workflow_ref,
-        subject,
+        subject: Some(subject),
         subject_title: resolved.subject_title,
         subject_description: resolved.subject_description,
         execution_cwd,
@@ -328,8 +336,8 @@ fn existing_workflow_rework_context(workflow: &OrchestratorWorkflow, phase_id: &
         .map(|record| record.reason.clone())
 }
 
-fn schedule_prompt_input(subject: &SubjectRef, input: Option<&Value>) -> Option<String> {
-    if subject.id().starts_with("schedule:") {
+fn schedule_prompt_input(subject: Option<&SubjectRef>, input: Option<&Value>) -> Option<String> {
+    if subject.is_some_and(|s| s.id().starts_with("schedule:")) {
         return input.map(Value::to_string);
     }
     None
@@ -559,9 +567,12 @@ mod tests {
     #[test]
     fn schedule_prompt_input_only_applies_to_schedule_subjects() {
         let input = serde_json::json!({"window":"nightly"});
-        assert_eq!(schedule_prompt_input(&SubjectRef::task("TASK-1".to_string()), Some(&input),), None);
+        assert_eq!(schedule_prompt_input(Some(&SubjectRef::task("TASK-1".to_string())), Some(&input)), None);
         assert_eq!(
-            schedule_prompt_input(&SubjectRef::custom("schedule:nightly".to_string(), String::new()), Some(&input),),
+            schedule_prompt_input(
+                Some(&SubjectRef::custom("schedule:nightly".to_string(), String::new())),
+                Some(&input)
+            ),
             Some("{\"window\":\"nightly\"}".to_string())
         );
     }

--- a/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
@@ -277,9 +277,9 @@ mod tests {
         let subject_ref = subject_ref_for_kind("blog", "blog:BLOG-001");
         let dispatch =
             SubjectDispatch::for_subject_with_metadata(subject_ref, "draft-post", "manual-queue-enqueue", Utc::now());
-        assert_eq!(dispatch.subject_kind(), "blog");
-        assert_eq!(dispatch.to_workflow_run_input().subject().kind(), "blog");
-        assert_eq!(dispatch.to_workflow_run_input().subject().id(), "blog:BLOG-001");
+        assert_eq!(dispatch.subject_kind(), Some("blog"));
+        assert_eq!(dispatch.to_workflow_run_input().subject().unwrap().kind(), "blog");
+        assert_eq!(dispatch.to_workflow_run_input().subject().unwrap().id(), "blog:BLOG-001");
     }
 
     #[test]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -113,7 +113,7 @@ pub async fn recover_orphaned_running_workflows(
         }
         if active_subject_ids.contains(&workflow.id)
             || externally_active_workflows.contains(&workflow.id)
-            || active_subject_ids.contains(workflow.subject.id())
+            || workflow.subject.as_ref().is_some_and(|s| active_subject_ids.contains(s.id()))
         {
             continue;
         }
@@ -138,7 +138,7 @@ pub async fn recover_orphaned_running_workflows(
             info!(
                 actor = protocol::ACTOR_DAEMON,
                 workflow_id = %workflow.id,
-                subject_id = %workflow.subject.id(),
+                subject_id = %workflow.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                 task_id = %workflow.task_id,
                 current_phase = workflow.current_phase.as_deref().unwrap_or_default(),
                 "preserving resumable in-flight workflow for resume (durable journal active); not cancelling"
@@ -149,7 +149,7 @@ pub async fn recover_orphaned_running_workflows(
         warn!(
             actor = protocol::ACTOR_DAEMON,
             workflow_id = %workflow.id,
-            subject_id = %workflow.subject.id(),
+            subject_id = %workflow.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
             task_id = %workflow.task_id,
             "recovering orphaned running workflow"
         );
@@ -281,13 +281,13 @@ pub(crate) async fn resumable_orphans_for_redispatch(
         }
         if active_subject_ids.contains(&workflow.id)
             || externally_active_workflows.contains(&workflow.id)
-            || active_subject_ids.contains(workflow.subject.id())
+            || workflow.subject.as_ref().is_some_and(|s| active_subject_ids.contains(s.id()))
         {
             continue;
         }
         // Skip subjects whose detached runner from a previous daemon is still
         // alive (see `live_orphan_subjects` above).
-        if live_orphan_subjects.contains(workflow.subject.id())
+        if workflow.subject.as_ref().is_some_and(|s| live_orphan_subjects.contains(s.id()))
             || (!workflow.task_id.is_empty() && live_orphan_subjects.contains(&workflow.task_id))
         {
             continue;
@@ -385,7 +385,7 @@ pub async fn reconcile_manual_phase_timeouts(hub: Arc<dyn ServiceHub>, project_r
             project_terminal_workflow_result(
                 hub.clone(),
                 project_root,
-                updated.subject.id(),
+                updated.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                 Some(updated.task_id.as_str()),
                 updated.workflow_ref.as_deref(),
                 Some(updated.id.as_str()),

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_task_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_task_dispatch.rs
@@ -47,29 +47,32 @@ pub async fn dispatch_queued_entries_via_runner(
                         continue;
                     }
                 };
-                let subject_key = dispatch.subject_key();
                 // Within-batch dedupe: the queue's `exclude_subjects` filter
                 // honors the snapshot we sent at lease time, but multiple
                 // pending entries for the same subject (different
                 // workflow_refs) can still be returned in one batch. Release
                 // the duplicate back to Pending so it runs on a later tick
-                // after the first entry's workflow finishes.
-                if plugin_owned_subject_keys.contains(&subject_key) {
-                    warn!(
-                        actor = protocol::ACTOR_DAEMON,
-                        subject_key = %subject_key,
-                        entry_id = %entry.entry_id,
-                        "queue/lease returned duplicate subject within batch; releasing extra entry back to pending"
-                    );
-                    release_leased_entry_to_pending(
-                        project_root_path,
-                        &entry.entry_id,
-                        "within-batch-duplicate-subject",
-                    )
-                    .await;
-                    continue;
+                // after the first entry's workflow finishes. A subjectless
+                // dispatch has no subject_key and is never deduped — each
+                // subjectless run is its own entry.
+                if let Some(subject_key) = dispatch.subject_key() {
+                    if plugin_owned_subject_keys.contains(&subject_key) {
+                        warn!(
+                            actor = protocol::ACTOR_DAEMON,
+                            subject_key = %subject_key,
+                            entry_id = %entry.entry_id,
+                            "queue/lease returned duplicate subject within batch; releasing extra entry back to pending"
+                        );
+                        release_leased_entry_to_pending(
+                            project_root_path,
+                            &entry.entry_id,
+                            "within-batch-duplicate-subject",
+                        )
+                        .await;
+                        continue;
+                    }
+                    plugin_owned_subject_keys.insert(subject_key);
                 }
-                plugin_owned_subject_keys.insert(subject_key);
                 leased_entry_ids.push(entry.entry_id.clone());
                 planned_starts
                     .push(PlannedDispatchStart { dispatch, selection_source: DispatchSelectionSource::DispatchQueue });
@@ -105,43 +108,40 @@ pub async fn dispatch_queued_entries_via_runner(
         }
     }
 
-    let mut notice_sink = CliDispatchNoticeSink { hard_failed_subject_keys: std::collections::HashSet::new() };
+    let mut notice_sink = CliDispatchNoticeSink { outcomes: Vec::new() };
     let summary = execute_dispatch_plan_via_runner(root, process_manager, &planned_starts, limit, &mut notice_sink);
 
-    if !leased_entry_ids.is_empty() {
-        let started_keys: std::collections::HashSet<String> =
-            summary.started_workflows.iter().map(|s| s.dispatch.subject_key()).collect();
-        for (idx, planned) in planned_starts.iter().enumerate() {
-            let Some(entry_id) = leased_entry_ids.get(idx) else {
-                continue;
-            };
-            let subject_key = planned.dispatch.subject_key();
-            if started_keys.contains(&subject_key) {
-                continue;
-            }
-            // Only entries whose spawn hard-failed are closed as FAILED.
-            // Entries the runner never attempted (dispatch limit reached
-            // mid-batch) or that were rejected recoverably (workflow
-            // concurrency cap) go back to Pending for the next tick —
-            // closing them would permanently drop legitimate queued work.
-            if !notice_sink.hard_failed_subject_keys.contains(&subject_key) {
+    // Reconcile each leased queue entry against its spawn outcome. Outcomes are
+    // recorded in dispatch order (one per processed entry), so they align by
+    // INDEX with `leased_entry_ids` / `planned_starts`. Correlating by position
+    // rather than subject id is what lets subjectless dispatches (which have no
+    // subject_key to key on) reconcile correctly.
+    for (idx, entry_id) in leased_entry_ids.iter().enumerate() {
+        match notice_sink.outcomes.get(idx) {
+            // Runner spawned: the entry is now Assigned to a live workflow.
+            Some(DispatchEntryOutcome::Started) => {}
+            // Recoverable defer (workflow concurrency cap) or never attempted
+            // (dispatch limit reached mid-batch): back to Pending for the next
+            // tick — closing them would permanently drop legitimate queued work.
+            Some(DispatchEntryOutcome::Deferred) | None => {
                 release_leased_entry_to_pending(project_root_path, entry_id, "spawn-deferred").await;
-                continue;
             }
-            let req = QueueCompletionRequest {
-                entry_id: entry_id.clone(),
-                status: queue_proto::completion_status::FAILED.to_string(),
-                workflow_ref: None,
-                workflow_id: None,
-            };
-            if let Err(error) = plugin_clients::call_queue_completion(project_root_path, &req).await {
-                warn!(
-                    actor = protocol::ACTOR_DAEMON,
-                    subject_key = %subject_key,
-                    entry_id = %entry_id,
-                    error = %error,
-                    "queue plugin queue/completion (spawn-failed entry) failed"
-                );
+            // Hard spawn failure: close the entry as FAILED.
+            Some(DispatchEntryOutcome::Failed) => {
+                let req = QueueCompletionRequest {
+                    entry_id: entry_id.clone(),
+                    status: queue_proto::completion_status::FAILED.to_string(),
+                    workflow_ref: None,
+                    workflow_id: None,
+                };
+                if let Err(error) = plugin_clients::call_queue_completion(project_root_path, &req).await {
+                    warn!(
+                        actor = protocol::ACTOR_DAEMON,
+                        entry_id = %entry_id,
+                        error = %error,
+                        "queue plugin queue/completion (spawn-failed entry) failed"
+                    );
+                }
             }
         }
     }
@@ -182,29 +182,40 @@ async fn release_leased_entry_to_pending(project_root_path: &std::path::Path, en
     }
 }
 
+/// Spawn outcome for a single dispatched queue entry, recorded in dispatch
+/// order so the caller can reconcile leased entries by position (subjectless
+/// dispatches have no subject_key to correlate on).
+enum DispatchEntryOutcome {
+    Started,
+    Deferred,
+    Failed,
+}
+
 struct CliDispatchNoticeSink {
-    hard_failed_subject_keys: std::collections::HashSet<String>,
+    outcomes: Vec<DispatchEntryOutcome>,
 }
 
 impl DispatchNoticeSink for CliDispatchNoticeSink {
     fn notice(&mut self, notice: DispatchNotice) {
         match notice {
+            DispatchNotice::Started { .. } => self.outcomes.push(DispatchEntryOutcome::Started),
             DispatchNotice::Failed { dispatch, error } => {
-                self.hard_failed_subject_keys.insert(dispatch.subject_key());
                 warn!(
                     actor = protocol::ACTOR_DAEMON,
-                    subject_id = %dispatch.subject_key(),
+                    subject_id = %dispatch.subject_id().unwrap_or_default(),
                     error = %error,
                     "failed to start workflow runner"
                 );
+                self.outcomes.push(DispatchEntryOutcome::Failed);
             }
             DispatchNotice::Deferred { dispatch, reason } => {
                 warn!(
                     actor = protocol::ACTOR_DAEMON,
-                    subject_id = %dispatch.subject_key(),
+                    subject_id = %dispatch.subject_id().unwrap_or_default(),
                     reason = %reason,
                     "workflow runner spawn deferred; entry returns to pending for next tick"
                 );
+                self.outcomes.push(DispatchEntryOutcome::Deferred);
             }
             _ => {}
         }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -62,19 +62,29 @@ impl CliProjectTickServices {
             if started >= limit {
                 break;
             }
-            if !dispatched_subjects.insert(workflow.subject.id().to_string()) {
-                continue;
+            // Subjectless runs carry no subject to dedup on — each is distinct.
+            if let Some(subject) = workflow.subject.as_ref() {
+                if !dispatched_subjects.insert(subject.id().to_string()) {
+                    continue;
+                }
             }
             let workflow_ref = workflow.workflow_ref.clone().unwrap_or_else(|| "standard".to_string());
             // Relay the owner actor the run bootstrapped with so the restarted
             // run scopes identically; `None` => system/global run.
             let actor = state_manager.load_workflow_actor(&workflow.id);
-            let dispatch = orchestrator_daemon_runtime::SubjectDispatch::for_subject_with_metadata(
-                workflow.subject.clone(),
-                workflow_ref,
-                "journal-resume",
-                chrono::Utc::now(),
-            )
+            let dispatch = match workflow.subject.clone() {
+                Some(subject) => orchestrator_daemon_runtime::SubjectDispatch::for_subject_with_metadata(
+                    subject,
+                    workflow_ref,
+                    "journal-resume",
+                    chrono::Utc::now(),
+                ),
+                None => orchestrator_daemon_runtime::SubjectDispatch::subjectless(
+                    workflow_ref,
+                    "journal-resume",
+                    chrono::Utc::now(),
+                ),
+            }
             .with_input(workflow.input.clone())
             .with_vars(workflow.vars.clone())
             .with_actor(actor);
@@ -91,7 +101,7 @@ impl CliProjectTickServices {
                             format!(
                                 "journal-resume: re-dispatched in-flight workflow {} (subject {}) from phase boundary {}",
                                 workflow.id,
-                                workflow.subject.id(),
+                                workflow.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
                                 workflow.current_phase.as_deref().unwrap_or("<index>")
                             ),
                         )
@@ -322,20 +332,29 @@ impl DefaultProjectTickServices for CliProjectTickServices {
             }
             DispatchNotice::Failed { dispatch, error } => {
                 self.logger
-                    .error("process", format!("failed to start runner for {}", dispatch.subject_key()))
+                    .error(
+                        "process",
+                        format!("failed to start runner for {}", dispatch.subject_key().unwrap_or_default()),
+                    )
                     .err(error)
                     .emit();
             }
             DispatchNotice::Deferred { dispatch, reason } => {
                 self.logger
-                    .info("process", format!("deferred runner spawn for {} to next tick", dispatch.subject_key()))
+                    .info(
+                        "process",
+                        format!(
+                            "deferred runner spawn for {} to next tick",
+                            dispatch.subject_key().unwrap_or_default()
+                        ),
+                    )
                     .meta(serde_json::json!({"reason": reason}))
                     .emit();
             }
             DispatchNotice::Started { dispatch, .. } => {
                 self.logger
-                    .info("queue.dispatch", format!("dispatched {}", dispatch.subject_key()))
-                    .subject(dispatch.subject_id())
+                    .info("queue.dispatch", format!("dispatched {}", dispatch.subject_key().unwrap_or_default()))
+                    .subject(dispatch.subject_id().unwrap_or_default())
                     .meta(serde_json::json!({"workflow_ref": dispatch.workflow_ref}))
                     .emit();
             }

--- a/crates/orchestrator-cli/src/services/runtime/workflow_mutation_surface/cancel_orphaned_running_workflow.rs
+++ b/crates/orchestrator-cli/src/services/runtime/workflow_mutation_surface/cancel_orphaned_running_workflow.rs
@@ -27,7 +27,7 @@ pub(crate) async fn cancel_orphaned_running_workflow(
     project_terminal_workflow_result(
         hub,
         project_root,
-        updated.subject.id(),
+        updated.subject.as_ref().map(|s| s.id()).unwrap_or_default(),
         Some(updated.task_id.as_str()),
         updated.workflow_ref.as_deref(),
         Some(updated.id.as_str()),

--- a/crates/orchestrator-core/src/services/workflow_impl.rs
+++ b/crates/orchestrator-core/src/services/workflow_impl.rs
@@ -194,7 +194,7 @@ impl WorkflowServiceApi for InMemoryServiceHub {
         let id = Uuid::new_v4().to_string();
         let workflow = {
             let mut lock = self.state.write().await;
-            let task = input.subject.task_id().and_then(|id| lock.tasks.get(id).cloned());
+            let task = input.subject.as_ref().and_then(|s| s.task_id()).and_then(|id| lock.tasks.get(id).cloned());
             let workflow_ref =
                 effective_workflow_ref(input.workflow_ref(), crate::workflow::STANDARD_WORKFLOW_REF, task.as_ref());
             let executor = WorkflowLifecycleExecutor::new(crate::resolve_phase_plan_for_workflow_ref_for_actor(
@@ -407,7 +407,7 @@ impl WorkflowServiceApi for FileServiceHub {
         // `config_source` (global∪private∪shared) contributes the default
         // workflow ref, skip guards, and phase plan. `actor = None` = global.
         let workflow_config = crate::load_workflow_config_or_default_for_actor(self.project_root.as_path(), actor);
-        let task = if let Some(task_id) = input.subject.task_id() {
+        let task = if let Some(task_id) = input.subject.as_ref().and_then(|s| s.task_id()) {
             crate::workflow::load_task(&self.project_root, task_id).ok()
         } else {
             None
@@ -426,10 +426,13 @@ impl WorkflowServiceApi for FileServiceHub {
         .with_retry_configs(retry_configs)
         .with_skip_guards(skip_guards);
         let mut workflow = executor.bootstrap(id.clone(), input.with_workflow_ref(workflow_ref));
-        if let Ok(subject_context) =
-            self.subject_resolver().resolve_subject_context(&workflow.subject, None, None).await
-        {
-            executor.skip_guarded_phases(&mut workflow, &subject_context);
+        // A subjectless run binds a None subject context: no subject to resolve,
+        // so subject template vars are simply absent and no guard phases are
+        // skipped on subject identity here.
+        if let Some(subject) = workflow.subject.clone() {
+            if let Ok(subject_context) = self.subject_resolver().resolve_subject_context(&subject, None, None).await {
+                executor.skip_guarded_phases(&mut workflow, &subject_context);
+            }
         }
 
         let manager = self.workflow_manager();
@@ -537,10 +540,11 @@ impl WorkflowServiceApi for FileServiceHub {
         .with_retry_configs(retry_configs)
         .with_skip_guards(skip_guards);
         executor.mark_current_phase_success_with_decision(&mut workflow, decision)?;
-        if let Ok(subject_context) =
-            self.subject_resolver().resolve_subject_context(&workflow.subject, None, None).await
-        {
-            executor.skip_guarded_phases(&mut workflow, &subject_context);
+        // Subjectless runs bind a None subject context (nothing to resolve).
+        if let Some(subject) = workflow.subject.clone() {
+            if let Ok(subject_context) = self.subject_resolver().resolve_subject_context(&subject, None, None).await {
+                executor.skip_guarded_phases(&mut workflow, &subject_context);
+            }
         }
         manager.save(&workflow)?;
         let mut workflow = manager.save_checkpoint(&workflow, CheckpointReason::StatusChange)?;

--- a/crates/orchestrator-core/src/workflow/journal_client.rs
+++ b/crates/orchestrator-core/src/workflow/journal_client.rs
@@ -370,16 +370,16 @@ pub(crate) fn to_journal_run(workflow: &OrchestratorWorkflow) -> Result<JournalR
     // deserialize with `subject = SubjectRef::task("")` (empty id) while the real
     // id still lives in `task_id`. Mirror the `workflow_task_id` fallback used
     // elsewhere so SQLite->plugin imports of old task runs index a non-null id.
-    let subject_id = match workflow.subject.id() {
-        "" => workflow.task_id.as_str(),
-        id => id,
+    let subject_id = match workflow.subject.as_ref().map(|s| s.id()) {
+        None | Some("") => workflow.task_id.as_str(),
+        Some(id) => id,
     };
     if !subject_id.is_empty() {
         if let Some(obj) = blob.as_object_mut() {
             obj.insert(SUBJECT_ID_BLOB_KEY.to_string(), serde_json::Value::String(subject_id.to_string()));
         }
     }
-    let kind = if workflow.subject.kind.is_empty() { None } else { Some(workflow.subject.kind.clone()) };
+    let kind = workflow.subject.as_ref().map(|s| s.kind.clone()).filter(|k| !k.is_empty());
     Ok(JournalRun {
         workflow_id: workflow.id.clone(),
         workflow_ref: workflow.workflow_ref.clone(),
@@ -833,7 +833,7 @@ mod tests {
             id: id.to_string(),
             task_id: "TASK-1".to_string(),
             workflow_ref: Some("task-default".to_string()),
-            subject: SubjectRef::task("TASK-1".to_string()),
+            subject: Some(SubjectRef::task("TASK-1".to_string())),
             input: None,
             vars: HashMap::new(),
             status: WorkflowStatus::Running,
@@ -869,7 +869,7 @@ mod tests {
         let mut wf = sample_workflow(id);
         // A generic BaaS dynamic-kind subject carries NO task_id and is
         // kind-qualified (e.g. blog:BLOG-001).
-        wf.subject = SubjectRef::new(kind, subject_id);
+        wf.subject = Some(SubjectRef::new(kind, subject_id));
         wf.task_id = String::new();
         wf.workflow_ref = Some("draft-blog".to_string());
         wf
@@ -890,8 +890,8 @@ mod tests {
         // And it must round-trip back to the same subject (the denormalized
         // mirror is stripped; the model derives the subject from `subject`).
         let back = from_journal_run(run).expect("from run");
-        assert_eq!(back.subject.kind(), "blog");
-        assert_eq!(back.subject.id(), "blog:BLOG-001");
+        assert_eq!(back.subject.as_ref().unwrap().kind(), "blog");
+        assert_eq!(back.subject.as_ref().unwrap().id(), "blog:BLOG-001");
         assert!(back.task_id.is_empty());
     }
 
@@ -914,7 +914,7 @@ mod tests {
         // The denormalized key must not break workflow deserialization.
         let back = from_journal_run(run).expect("from run with subject_id key");
         assert_eq!(back.id, "wf-blog-2");
-        assert_eq!(back.subject.id(), "blog:BLOG-002");
+        assert_eq!(back.subject.as_ref().unwrap().id(), "blog:BLOG-002");
     }
 
     #[test]

--- a/crates/orchestrator-core/src/workflow/tests.rs
+++ b/crates/orchestrator-core/src/workflow/tests.rs
@@ -15,7 +15,7 @@ fn make_workflow(status: WorkflowStatus) -> OrchestratorWorkflow {
         id: "WF-test".to_string(),
         task_id: "TASK-1".to_string(),
         workflow_ref: Some("standard-workflow".to_string()),
-        subject: SubjectRef::task("TASK-1".to_string()),
+        subject: Some(SubjectRef::task("TASK-1".to_string())),
         input: None,
         vars: std::collections::HashMap::new(),
         status,

--- a/crates/orchestrator-core/src/workflow_events.rs
+++ b/crates/orchestrator-core/src/workflow_events.rs
@@ -208,7 +208,7 @@ pub async fn dispatch_workflow_event(
 /// the default `SubjectRef::task("")` with the real id in `task_id`).
 /// Returns `None` for non-task subjects (requirements, custom).
 pub fn workflow_task_id(workflow: &OrchestratorWorkflow) -> Option<String> {
-    match workflow.subject.task_id() {
+    match workflow.subject.as_ref().and_then(|s| s.task_id()) {
         Some(id) if !id.trim().is_empty() => Some(id.to_string()),
         Some(_) => {
             let legacy = workflow.task_id.trim();

--- a/crates/orchestrator-daemon-runtime/Cargo.toml
+++ b/crates/orchestrator-daemon-runtime/Cargo.toml
@@ -27,12 +27,12 @@ animus-plugin-protocol = { workspace = true }
 # All animus-protocol git deps pin the SAME tag (v0.1.26) so the transitively
 # pulled `animus-subject-protocol` resolves to ONE source rev. v0.1.26 additively
 # adds `actor: Option<Actor>` to the control request types relayed by the daemon.
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 animus-actor = { workspace = true }
 # Subject / SubjectChangedEvent share the same v0.1.26 surface as the
 # control-protocol (one source rev so the protocol versions stay in lockstep).
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 protocol = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -51,14 +51,14 @@ interprocess = "2.4"
 protocol = { workspace = true, features = ["test-utils"] }
 tempfile = "3"
 tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "signal", "test-util", "time"] }
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3", features = ["client"] }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4", features = ["client"] }
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures-core = "0.3"
 futures-util = "0.3"
 serde_json = "1.0"
 uuid = { version = "1", features = ["v4"] }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 animus-runtime-shared = { workspace = true }
 
 [lints]

--- a/crates/orchestrator-daemon-runtime/src/dispatch/agent_record.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/agent_record.rs
@@ -96,8 +96,8 @@ pub fn build_record_with_decisions(
         agent_session_id,
         pid,
         started_at,
-        subject_id: dispatch.subject_id().to_string(),
-        subject_kind: dispatch.subject_kind().to_string(),
+        subject_id: dispatch.subject_id().unwrap_or_default().to_string(),
+        subject_kind: dispatch.subject_kind().unwrap_or_default().to_string(),
         workflow_ref: dispatch.workflow_ref.clone(),
         task_id: dispatch.task_id().map(String::from),
         command_line,
@@ -453,7 +453,7 @@ mod tests {
         let back: AgentSpawnRecord = serde_json::from_slice(&raw).unwrap();
         assert_eq!(back.agent_session_id, "agent-xyz");
         assert_eq!(back.pid, 4242);
-        assert_eq!(back.subject_id, dispatch.subject_id());
+        assert_eq!(back.subject_id, dispatch.subject_id().unwrap_or_default());
         assert_eq!(back.workflow_ref, "standard");
         assert_eq!(back.command_line, vec!["/bin/echo".to_string()]);
 
@@ -509,7 +509,7 @@ mod tests {
         let detected = &report.detected[0];
         assert_eq!(detected.agent_session_id, "agent-alive");
         assert_eq!(detected.pid, alive_pid);
-        assert_eq!(detected.subject_id, dispatch.subject_id());
+        assert_eq!(detected.subject_id, dispatch.subject_id().unwrap_or_default());
         assert_eq!(detected.workflow_ref, "standard");
         assert_eq!(detected.command_line, vec!["sleep".to_string(), "60".to_string()]);
 

--- a/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
@@ -34,36 +34,40 @@ pub fn build_runner_command_with_resume(
     let mut cmd = std::process::Command::new(resolve_workflow_runner_binary_for(Some(project_root)));
     cmd.arg("execute");
 
-    match dispatch.subject.to_workflow_subject() {
-        protocol::orchestrator::WorkflowSubject::Task { id } => {
-            cmd.arg("--task-id").arg(id);
-        }
-        protocol::orchestrator::WorkflowSubject::Requirement { id } => {
-            cmd.arg("--requirement-id").arg(id);
-        }
-        protocol::orchestrator::WorkflowSubject::Custom { title, description } => {
-            // `to_workflow_subject()` collapses every non-task/requirement kind
-            // to `Custom`, but a BaaS dynamic kind (e.g. `blog`) must NOT be
-            // dispatched as a custom title — the runner has to resolve it via
-            // `<kind>/get`. Disambiguate by the real subject kind: only the
-            // genuine built-in `custom` kind uses `--title`/`--description`; any
-            // other kind passes its qualified id via `--subject-id` so the
-            // runner resolves the subject under its real kind. (Requires the
-            // workflow_runner plugin to accept `--subject-id`; only ever emitted
-            // for dynamic kinds, so task/requirement/custom dispatch is
-            // unchanged for existing runners.)
-            if dispatch.subject.kind() == protocol::orchestrator::SUBJECT_KIND_CUSTOM {
-                cmd.arg("--title").arg(title);
-                cmd.arg("--description").arg(description);
-            } else {
-                // Qualify with the known kind when the stored id is bare so the
-                // runner resolves the exact kind (a bare native id could be
-                // re-probed to the wrong kind, or fail under a catch-all
-                // backend). Already-qualified ids (`blog:BLOG-001`) pass through.
-                let id = dispatch.subject.id();
-                let qualified =
-                    if id.contains(':') { id.to_string() } else { format!("{}:{id}", dispatch.subject.kind()) };
-                cmd.arg("--subject-id").arg(qualified);
+    // A subjectless dispatch (no bound subject) emits NO subject selector at
+    // all: the runner starts a subjectless run with subject template vars
+    // simply absent.
+    if let Some(subject) = dispatch.subject.as_ref() {
+        match subject.to_workflow_subject() {
+            protocol::orchestrator::WorkflowSubject::Task { id } => {
+                cmd.arg("--task-id").arg(id);
+            }
+            protocol::orchestrator::WorkflowSubject::Requirement { id } => {
+                cmd.arg("--requirement-id").arg(id);
+            }
+            protocol::orchestrator::WorkflowSubject::Custom { title, description } => {
+                // `to_workflow_subject()` collapses every non-task/requirement kind
+                // to `Custom`, but a BaaS dynamic kind (e.g. `blog`) must NOT be
+                // dispatched as a custom title — the runner has to resolve it via
+                // `<kind>/get`. Disambiguate by the real subject kind: only the
+                // genuine built-in `custom` kind uses `--title`/`--description`; any
+                // other kind passes its qualified id via `--subject-id` so the
+                // runner resolves the subject under its real kind. (Requires the
+                // workflow_runner plugin to accept `--subject-id`; only ever emitted
+                // for dynamic kinds, so task/requirement/custom dispatch is
+                // unchanged for existing runners.)
+                if subject.kind() == protocol::orchestrator::SUBJECT_KIND_CUSTOM {
+                    cmd.arg("--title").arg(title);
+                    cmd.arg("--description").arg(description);
+                } else {
+                    // Qualify with the known kind when the stored id is bare so the
+                    // runner resolves the exact kind (a bare native id could be
+                    // re-probed to the wrong kind, or fail under a catch-all
+                    // backend). Already-qualified ids (`blog:BLOG-001`) pass through.
+                    let id = subject.id();
+                    let qualified = if id.contains(':') { id.to_string() } else { format!("{}:{id}", subject.kind()) };
+                    cmd.arg("--subject-id").arg(qualified);
+                }
             }
         }
     }
@@ -480,7 +484,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            &dispatch.subject.to_workflow_subject(),
+            &dispatch.subject.as_ref().unwrap().to_workflow_subject(),
             &WorkflowSubject::Custom {
                 title: "schedule:nightly".to_string(),
                 description: "nightly dispatch".to_string(),

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_support.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_support.rs
@@ -136,7 +136,7 @@ pub fn active_workflow_subject_ids(workflows: &[OrchestratorWorkflow]) -> HashSe
             matches!(workflow.status, WorkflowStatus::Running | WorkflowStatus::Paused | WorkflowStatus::Pending)
                 && workflow.machine_state != orchestrator_core::WorkflowMachineState::MergeConflict
         })
-        .map(|workflow| workflow.subject.id().to_string())
+        .filter_map(|workflow| workflow.subject.as_ref().map(|s| s.id().to_string()))
         .collect()
 }
 

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_workflow_start.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_workflow_start.rs
@@ -15,7 +15,7 @@ impl DispatchWorkflowStart {
         self.dispatch.task_id()
     }
 
-    pub fn subject_id(&self) -> &str {
+    pub fn subject_id(&self) -> Option<&str> {
         self.dispatch.subject_id()
     }
 }

--- a/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
@@ -467,9 +467,9 @@ impl ProcessManager {
         });
 
         self.processes.push(WorkflowProcess {
-            subject_key: dispatch.subject_key(),
-            subject_id: dispatch.subject_id().to_string(),
-            subject_kind: dispatch.subject_kind().to_string(),
+            subject_key: dispatch.subject_key().unwrap_or_default(),
+            subject_id: dispatch.subject_id().unwrap_or_default().to_string(),
+            subject_kind: dispatch.subject_kind().unwrap_or_default().to_string(),
             task_id,
             workflow_ref,
             schedule_id,
@@ -510,7 +510,7 @@ impl ProcessManager {
             Some(root) => root.clone(),
             None => default_event_pipe_root(),
         };
-        let subject_label = dispatch.subject_id().to_string();
+        let subject_label = dispatch.subject_id().unwrap_or_default().to_string();
         // Bind synchronously on the calling thread (just a couple of
         // syscalls) and let `SubprocessEventPipe::bind_sync` spawn the
         // reader task on the current Tokio runtime. This avoids the
@@ -1043,11 +1043,11 @@ mod tests {
     #[test]
     fn subject_id_returns_correct_value_for_each_variant() {
         let task = SubjectDispatch::for_task("TASK-1", "standard");
-        assert_eq!(task.subject_id(), "TASK-1");
+        assert_eq!(task.subject_id(), Some("TASK-1"));
         assert!(task.schedule_id().is_none());
 
         let requirement = SubjectDispatch::for_requirement("REQ-1", "standard", "manual");
-        assert_eq!(requirement.subject_id(), "REQ-1");
+        assert_eq!(requirement.subject_id(), Some("REQ-1"));
         assert!(requirement.schedule_id().is_none());
 
         let custom = SubjectDispatch::for_custom(
@@ -1057,7 +1057,7 @@ mod tests {
             Some(serde_json::json!({"key":"value"})),
             "schedule",
         );
-        assert_eq!(custom.subject_id(), "schedule:nightly");
+        assert_eq!(custom.subject_id(), Some("schedule:nightly"));
         assert_eq!(custom.schedule_id(), Some("nightly"));
     }
 

--- a/crates/orchestrator-plugin-host/src/discovery.rs
+++ b/crates/orchestrator-plugin-host/src/discovery.rs
@@ -136,6 +136,7 @@ impl std::fmt::Debug for PluginDiscovery {
             .field("project_root", &self.project_root)
             .field("config_path", &self.config_path)
             .field("include_system_path", &self.include_system_path)
+            .field("probe_project_local_plugins", &self.probe_project_local_plugins)
             .field("scope", &self.scope)
             .field("db_registry", &self.db_registry.as_ref().map(|_| "<PluginRegistrySource>"))
             .finish()
@@ -623,6 +624,7 @@ impl PluginDiscovery {
                 &mut seen,
                 &cache,
                 lockfile.as_ref(),
+                scope_ref,
             );
         }
 
@@ -823,6 +825,7 @@ impl PluginDiscovery {
         seen: &mut HashSet<String>,
         cache: &ManifestCache,
         lockfile: Option<&PluginLockfile>,
+        scope: Option<&PluginScope>,
     ) {
         let install_dir = plugin_install_dir();
         let entries = match source.desired_plugins() {
@@ -872,7 +875,7 @@ impl PluginDiscovery {
             candidates.push(ProbeCandidate { name, path, source: DiscoverySource::DbRegistry });
         }
 
-        let outcomes = resolve_manifests(&candidates, cache, lockfile);
+        let outcomes = resolve_manifests(&candidates, cache, lockfile, scope);
         for (cand, outcome) in candidates.into_iter().zip(outcomes) {
             let ProbeCandidate { name, path, source } = cand;
             match outcome {
@@ -887,6 +890,20 @@ impl PluginDiscovery {
                         plugin = %name,
                         path = %path.display(),
                         "DB-registry plugin manifest probe failed: {reason}"
+                    );
+                    warnings.push(DiscoveryWarning { name, path, source, reason });
+                }
+                ProbeOutcome::SkippedOutOfScope(reason) => {
+                    // Reserve the name so a lower-precedence source can't
+                    // silently shadow this (equally out-of-scope) entry, and
+                    // surface a warning so operators understand the plugin was
+                    // located but deliberately NOT executed.
+                    seen.insert(name.clone());
+                    tracing::debug!(
+                        plugin = %name,
+                        path = %path.display(),
+                        source = ?source,
+                        "{reason}"
                     );
                     warnings.push(DiscoveryWarning { name, path, source, reason });
                 }

--- a/examples/triggers/fswatch/Cargo.toml
+++ b/examples/triggers/fswatch/Cargo.toml
@@ -14,8 +14,8 @@ name = "animus-trigger-fswatch"
 path = "src/main.rs"
 
 [dependencies]
-animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
-animus-plugin-runtime  = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.3" }
+animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
+animus-plugin-runtime  = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.4" }
 anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Re-pin animus-protocol to v0.7.0-rc.4 (optional subject end-to-end) and replace PR 299's adhoc:nanos custom-kind sentinel with a genuinely absent (None) subject.

Part of REQUIREMENT-024 (universal dispatch), TASK-204. Depends on animus-protocol PR 2 (the rc.4 dev tag).

What changed

- Re-pin: bumped all animus-protocol git-dep tags v0.7.0-rc.3 to v0.7.0-rc.4 (Cargo.toml + Cargo.lock). rc.4 makes SubjectDispatch / WorkflowRunInput / OrchestratorWorkflow carry Option&lt;SubjectRef&gt;.
- ops_queue: adhoc_subject_dispatch (which minted a unique custom-kind adhoc:nanos subject) is replaced by subjectless_dispatch, which builds SubjectDispatch::subjectless (subject = None). The PR 299 subjectless tests now assert true-None behavior: no subject, no subject id/kind, no subject_key.
- Run loop: the None subject is threaded end to end. Bootstrap and phase-success advance bind a None subject context (no subject resolution; subject template vars simply absent) instead of a sentinel id. The runner command builder emits no subject selector for a subjectless dispatch, and reattach builds a subjectless execute request.
- Call sites: adapted every Option&lt;SubjectRef&gt; site across orchestrator-core / orchestrator-cli / orchestrator-daemon-runtime. subject_id / subject_kind / subject_key now return Option; task_id / requirement_id / schedule_id thread through the Option; journal indexing, active-subject sets, and reconciliation reads fall back cleanly when the subject is absent.
- Daemon queue dedup: the within-batch lease reconciliation is now correlated by dispatch INDEX (an ordered spawn-outcome vector) instead of subject_key, so subjectless entries (which have no key) reconcile correctly.

Known limitation (deferred)

The queue plugin RPC is deliberately pinned to the v0.5 line (animus-queue-protocol / animus-subject-protocol-v05 at tag v0.5.10) for deployed-plugin wire compatibility, and that SubjectDispatch still requires a subject. A subjectless dispatch cannot serialize through it, so queue enqueue --adhoc now fails fast with a clear, actionable message and the --adhoc help notes the limitation. The direct dispatch / control path already carries subjectless runs end to end. Completing subjectless enqueue needs the queue protocol (and the deployed queue plugin) to take up the optional-subject 0.7 line; cargo forbids aliasing one animus-subject-protocol instance under two names, so that is a coordinated follow-up, not a pin bump.

Incidental base fix

release/0.7 HEAD did not compile before this change (a merge gap between PR 298's DB-registry discovery and the resolve_manifests scope parameter). To build and validate, this PR threads the plugin scope through discover_db_registry into resolve_manifests, handles the resulting SkippedOutOfScope outcome, and adds the missing probe_project_local_plugins field to the manual PluginDiscovery Debug impl (a latent clippy -D warnings failure).

Validation

- cargo build --workspace --all-targets: clean.
- cargo clippy --workspace --all-targets: clean.
- cargo fmt --check: clean.
- Tests: orchestrator-core / orchestrator-cli / orchestrator-daemon-runtime / orchestrator-plugin-host / animus-runtime-shared pass, including the new subjectless tests. Two decision-gate tests (workflow_on_verdict_routing_blocks_resume_advance, workflow_yaml_phase_definition_with_decision_contract_blocks) fail, but they fail identically on the pristine base with only the compile fix applied and touch no subject code, so they are pre-existing (a config_source YAML gating bug that was never caught because release/0.7 did not compile).