### PR TITLE
Wire subject update --title through CLI and MCP (TASK-192)

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/mod.rs
+++ b/crates/orchestrator-cli/src/cli_types/mod.rs
@@ -1440,6 +1440,24 @@ mod tests {
     }
 
     #[test]
+    fn subject_update_accepts_title_flag() {
+        // TASK-192: `animus subject update --title` must parse and land in
+        // SubjectUpdateArgs so a subject can be renamed. Before the fix clap
+        // rejected `--title` as an unknown argument.
+        let cli = Cli::try_parse_from([
+            "animus", "subject", "update", "--kind", "task", "--id", "TASK-1", "--title", "New name",
+        ])
+        .expect("subject update --title should parse");
+        match cli.command {
+            Command::Subject { command: SubjectCommand::Update(args) } => {
+                assert_eq!(args.title.as_deref(), Some("New name"));
+                assert_eq!(args.id, "TASK-1");
+            }
+            other => panic!("expected subject update command, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn crate_map_matches_live_workspace_members() {
         let mut live = live_workspace_crates();
         let mut documented = documented_workspace_crates();

--- a/crates/orchestrator-cli/src/cli_types/subject_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/subject_types.rs
@@ -148,6 +148,9 @@ pub(crate) struct SubjectUpdateArgs {
     /// kind-qualified form (e.g. `task:TASK-001`).
     #[arg(long, value_name = "ID")]
     pub id: String,
+    /// Rename the subject. Replaces the subject's title with this value.
+    #[arg(long, value_name = "TITLE")]
+    pub title: Option<String>,
     /// New normalized status.
     #[arg(long, value_name = "STATUS")]
     pub status: Option<String>,

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_command_args.rs
@@ -54,6 +54,7 @@ pub(super) fn build_subject_update_args(input: &SubjectUpdateInput) -> Vec<Strin
         "--id".to_string(),
         input.id.clone(),
     ];
+    push_opt(&mut args, "--title", input.title.clone());
     push_opt(&mut args, "--status", input.status.clone());
     push_opt(&mut args, "--priority", input.priority.clone());
     if !input.labels.is_empty() {
@@ -80,10 +81,11 @@ pub(super) fn build_subject_batch_update_item_args(kind: &str, item: &SubjectBat
     build_subject_update_args(&SubjectUpdateInput {
         kind: kind.to_string(),
         id: item.id.clone(),
+        // batch-update doesn't carry title/body fields; single-update only.
+        title: None,
         status: item.status.clone(),
         priority: item.priority.clone(),
         labels: item.labels.clone(),
-        // batch-update doesn't carry a body field; single-update only.
         body: None,
         project_root: None,
     })

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_inputs.rs
@@ -49,6 +49,9 @@ pub(super) struct SubjectCreateInput {
 pub(super) struct SubjectUpdateInput {
     pub(super) kind: String,
     pub(super) id: String,
+    /// Rename the subject. Replaces the subject's title with this value.
+    #[serde(default)]
+    pub(super) title: Option<String>,
     #[serde(default)]
     pub(super) status: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -1658,6 +1658,7 @@ fn mcp_subject_update_requires_at_least_one_field_args() {
     let input = SubjectUpdateInput {
         kind: "task".to_string(),
         id: "TASK-1".to_string(),
+        title: None,
         status: Some("in_progress".to_string()),
         priority: None,
         labels: vec![],
@@ -1676,6 +1677,38 @@ fn mcp_subject_update_requires_at_least_one_field_args() {
             "TASK-1".to_string(),
             "--status".to_string(),
             "in_progress".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn mcp_subject_update_forwards_title_flag() {
+    // The `title` input field must reach the CLI as `--title` so an MCP
+    // caller can rename a subject (TASK-192: the schema advertised `title`
+    // but the arg was never forwarded, so `animus subject update` rejected
+    // the unknown `--title`).
+    let input = SubjectUpdateInput {
+        kind: "task".to_string(),
+        id: "TASK-1".to_string(),
+        title: Some("Renamed title".to_string()),
+        status: None,
+        priority: None,
+        labels: vec![],
+        body: None,
+        project_root: None,
+    };
+    let args = build_subject_update_args(&input);
+    assert_eq!(
+        args,
+        vec![
+            "subject".to_string(),
+            "update".to_string(),
+            "--kind".to_string(),
+            "task".to_string(),
+            "--id".to_string(),
+            "TASK-1".to_string(),
+            "--title".to_string(),
+            "Renamed title".to_string(),
         ]
     );
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_subject.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_subject.rs
@@ -167,6 +167,13 @@ async fn handle_subject_update(args: SubjectUpdateArgs, project_root: &str, json
     }
     let id = crate::qualify_subject_id(&args.id, &kind);
     let mut patch = serde_json::Map::new();
+    if let Some(title) = args.title.as_deref() {
+        let title = title.trim();
+        if title.is_empty() {
+            return Err(invalid_input_error("--title must not be empty"));
+        }
+        patch.insert("title".to_string(), json!(title));
+    }
     if let Some(status) = args.status.as_deref() {
         patch.insert("status".to_string(), json!(status));
     }
@@ -181,7 +188,7 @@ async fn handle_subject_update(args: SubjectUpdateArgs, project_root: &str, json
     }
     if patch.is_empty() {
         return Err(invalid_input_error(
-            "subject update requires at least one of --status / --priority / --labels / --body",
+            "subject update requires at least one of --title / --status / --priority / --labels / --body",
         ));
     }
     let params = Some(json!({ "id": id, "patch": Value::Object(patch) }));

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -327,7 +327,7 @@ animus
 │   ├── get                  Fetch a single subject by id from the active subject_backend plugin
 │   ├── create               Create a subject through the active subject_backend plugin
 │   ├── batch-create         Create up to 100 subjects from a JSON `--file` items array; `--on-error stop|continue`; exits non-zero when any item failed (payload under `/error/details`); mirrors the `animus.subject.batch-create` MCP tool
-│   ├── update               Update a subject through the active subject_backend plugin
+│   ├── update               Update a subject through the active subject_backend plugin (`--title` renames it; `--status` / `--priority` / `--labels` / `--body`)
 │   ├── batch-update         Patch up to 100 subjects from a JSON `--file` items array; `--on-error stop|continue`; exits non-zero when any item failed (payload under `/error/details`); mirrors the `animus.subject.batch-update` MCP tool
 │   ├── next                 Return the highest-priority Ready subject for the given kind
 │   ├── status               Set the status of a subject by id through the active subject_backend

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -159,7 +159,7 @@ plugin (e.g. `linear`, `jira`, `github-issue`).
 | `animus.subject.list` | List subjects for a kind via the active `subject_backend` plugin. Returns a bounded page by default (`limit` defaults to 50; pass `limit: 0` to remove the cap); the result carries `next_cursor` (and `total` when the backend reports it) — pass `cursor` to fetch the next page. | `kind`, `status`, `limit`, `cursor`, `project_root` |
 | `animus.subject.get` | Fetch a subject by wire id (`<kind>:<native_id>`) | `kind`, `id`, `project_root` |
 | `animus.subject.create` | Create a subject through the active `subject_backend` plugin | `kind`, `title`, `priority`, `status`, `labels[]`, `body`, `project_root` |
-| `animus.subject.update` | Update a subject through the active `subject_backend` plugin | `kind`, `id`, `priority`, `status`, `labels[]`, `body`, `project_root` |
+| `animus.subject.update` | Update a subject through the active `subject_backend` plugin | `kind`, `id`, `title`, `priority`, `status`, `labels[]`, `body`, `project_root` |
 | `animus.subject.next` | Return the highest-priority Ready subject for the given kind | `kind`, `project_root` |
 | `animus.subject.status` | Set the status of a subject by id through the active `subject_backend` | `kind`, `id`, `status`, `project_root` |
 | `animus.subject.batch-create` | Create up to 100 subjects of one kind in a single call (per-item dispatch) | `kind`, `items[]` (`title`, `status`, `priority`, `labels[]`, `body`), `on_error`, `project_root` |


### PR DESCRIPTION
## Summary

The `animus.subject.update` MCP tool and the `animus subject update` CLI advertised a way to edit a subject but did not accept a title, so a caller trying to rename a subject hit a clap UnknownArgument error at parse time (`unexpected argument '--title' found`). Title edits could previously only be made through admin SQL (see TASK-192, hit while correcting an HTML-escaped title).

Root cause: `--title` was never part of the chain. The CLI `SubjectUpdateArgs` had `--status` / `--priority` / `--labels` / `--body` but no `--title`, and the MCP `SubjectUpdateInput` plus `build_subject_update_args` had no title field to forward. (Note: `--body` was already wired, contrary to the report's guess that it was also broken.)

## Fix (wire-through)

Chosen approach: wire `--title` through end to end, since the subject router forwards the update patch verbatim to the backend and the portal's animus-postgres backend accepts a title in its update patch.

- CLI: added `--title` to `SubjectUpdateArgs`; `handle_subject_update` maps it into the update patch and rejects an empty title. The at-least-one-field error message now lists `--title`.
- MCP: added a `title` field to `SubjectUpdateInput`; `build_subject_update_args` forwards it as `--title`. The batch-update item constructor sets `title: None` (batch-update is status/priority/labels only, unchanged).
- Docs: updated the subject.update parameter list in mcp-tools.md and the subject update entry in the CLI reference.

## Tests

- `subject_update_accepts_title_flag` — clap parse test: `subject update --title` lands in `SubjectUpdateArgs.title`.
- `mcp_subject_update_forwards_title_flag` — MCP arg builder forwards the title input as `--title`.
- Updated the existing `mcp_subject_update_requires_at_least_one_field_args` for the new struct field.

## Verification

- `cargo test -p orchestrator-cli` — all new tests pass; the only failures are two pre-existing environmental e2e tests (`plugin_agent_run_e2e`) that require an unbuilt `animus-provider-mock` testkit binary, unrelated to this change.
- `cargo fmt -p orchestrator-cli --check` clean, `cargo clippy -p orchestrator-cli --all-targets` clean.
- codex review --uncommitted (high reasoning): no findings.

Resolves TASK-192.
