### PR TITLE
MCP OAuth: durable cache override + dead-grant reauth signal

### DIFF
--- a/crates/animus-runtime-shared/src/oauth_broker.rs
+++ b/crates/animus-runtime-shared/src/oauth_broker.rs
@@ -7,8 +7,12 @@
 //! injects into the additional MCP server entry.
 //!
 //! Tokens are cached under `~/.animus/<scope>/mcp-oauth-cache/<server>.json`
-//! with 0600 permissions on Unix. A 60s skew margin guards against clock
-//! drift and in-flight network latency.
+//! with 0600 permissions on Unix (override the directory with
+//! `ANIMUS_MCP_OAUTH_CACHE_DIR` to persist tokens on a durable volume across an
+//! ephemeral host's redeploys). A 60s skew margin guards against clock drift
+//! and in-flight network latency. When a dead refresh grant cannot be revived
+//! (cached rotation chain AND env-var seed both rejected with `invalid_grant`),
+//! the terminal error carries an explicit "re-authentication required" signal.
 //!
 //! Three flows are supported:
 //! - `client_credentials`: POSTs `grant_type=client_credentials` +
@@ -440,11 +444,11 @@ pub fn resolve_token_with_options(
                         );
                         let _ = fs::remove_file(&cache_path);
                         let mut token = fetch_refresh_token(server_name, oauth, env, client, None)
-                            .map_err(|err| wrap_resolution_error(server_name, err))?;
+                            .map_err(|err| finalize_refresh_error(server_name, err))?;
                         token.refresh_seed_sha256 = current_seed.clone();
                         token
                     }
-                    Err(err) => return Err(wrap_resolution_error(server_name, err)),
+                    Err(err) => return Err(finalize_refresh_error(server_name, err)),
                 }
             };
             token.config_fingerprint = Some(fingerprint);
@@ -593,6 +597,24 @@ fn wrap_resolution_error(server_name: &str, err: anyhow::Error) -> anyhow::Error
         err
     } else {
         anyhow!("OAuth resolution failed for `{}`: {}", server_name, message)
+    }
+}
+
+/// Terminal-error finalizer for the refresh_token flow. Wraps with the standard
+/// resolution-failure prefix and, when the failure is an explicit RFC 6749
+/// `invalid_grant` rejection — the refresh grant is revoked/expired and neither
+/// the cached rotation chain nor the env-var seed could revive it — appends an
+/// actionable re-authentication hint. This turns a dead refresh chain into a
+/// stable, greppable signal ("re-authentication required") that a connection-
+/// state reader can classify as needs-reauth rather than a transient/network
+/// failure (5xx, `invalid_client`, unreachable endpoint), which stay retryable.
+fn finalize_refresh_error(server_name: &str, err: anyhow::Error) -> anyhow::Error {
+    let needs_reauth = is_grant_rejection(&err);
+    let wrapped = wrap_resolution_error(server_name, err);
+    if needs_reauth {
+        anyhow!("{wrapped}: re-authentication required (run `animus mcp auth {server_name}`)")
+    } else {
+        wrapped
     }
 }
 
@@ -755,10 +777,27 @@ fn open_writable_secure(path: &Path) -> Result<fs::File> {
         .with_context(|| format!("failed to open OAuth cache temp file {}", path.display()))
 }
 
-/// Per-scope cache directory under
-/// `~/.animus/<scope>/mcp-oauth-cache/`. Returns `None` when no home
-/// directory is discoverable.
+/// Environment variable that overrides the OAuth token cache directory.
+///
+/// When set (non-empty), the cache lives directly under this directory instead
+/// of `~/.animus/<scope>/mcp-oauth-cache/`. This is a durability knob for
+/// ephemeral hosts (e.g. a Railway container whose `$HOME` is wiped on every
+/// redeploy): point it at a mounted persistent volume (`/data/...`) and the
+/// resolved access + rotated refresh tokens survive the redeploy, so an MCP
+/// connection stays authenticated without a fresh re-auth. Per-server cache
+/// filenames still namespace + hash the server name, so multiple servers share
+/// the directory without colliding.
+pub const OAUTH_CACHE_DIR_ENV: &str = "ANIMUS_MCP_OAUTH_CACHE_DIR";
+
+/// Per-scope cache directory under `~/.animus/<scope>/mcp-oauth-cache/`, or the
+/// [`OAUTH_CACHE_DIR_ENV`] override when set. Returns `None` when neither the
+/// override nor a home directory is available.
 pub fn cache_dir_for_project(project_root: &str) -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os(OAUTH_CACHE_DIR_ENV) {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
     let home = dirs::home_dir()?;
     Some(
         home.join(".animus").join(protocol::repository_scope_for_path(Path::new(project_root))).join("mcp-oauth-cache"),
@@ -1641,5 +1680,76 @@ mod tests {
         assert_eq!(client.call_count(), 2);
         let cache_path = temp.path().join(cache_filename_for_server("svc"));
         assert!(!cache_path.exists(), "cache file should not be written when cache=false");
+    }
+
+    #[test]
+    fn cache_dir_override_env_redirects_to_durable_path() {
+        // The durability knob: when ANIMUS_MCP_OAUTH_CACHE_DIR is set, the cache
+        // lives under that directory (e.g. a mounted persistent volume) instead
+        // of the ephemeral per-scope `~/.animus/<scope>/mcp-oauth-cache/`.
+        // `cache_dir_for_project` is only reached by this test, so the process-env
+        // mutation here does not race any other test.
+        let override_dir = "/data/animus-oauth-cache-override";
+        std::env::set_var(OAUTH_CACHE_DIR_ENV, override_dir);
+        let resolved = cache_dir_for_project("/some/project/root");
+        std::env::remove_var(OAUTH_CACHE_DIR_ENV);
+        assert_eq!(resolved, Some(PathBuf::from(override_dir)), "override env var must win over the home-derived path");
+    }
+
+    #[test]
+    fn dead_refresh_chain_signals_reauth_required() {
+        // Both the cached rotated refresh token AND the env-var seed are rejected
+        // with `invalid_grant`: the grant is dead and no automatic path can revive
+        // it, so the terminal error must carry the actionable re-auth signal a
+        // connection-state reader classifies as needs-reauth (not transient).
+        let oauth = refresh_config();
+        let env = StaticEnv(BTreeMap::from([("EXAMPLE_REFRESH".to_string(), "rt-original".to_string())]));
+        let client = MockClient::new(vec![
+            Ok(TokenFetchResponse {
+                access_token: "access-1".to_string(),
+                expires_in: Some(1),
+                refresh_token: Some("rt-rotated".to_string()),
+            }),
+            Err(TokenEndpointRejection {
+                token_url: "https://auth.example.com/token".to_string(),
+                status: 400,
+                oauth_error: Some("invalid_grant".to_string()),
+            }
+            .into()),
+            Err(TokenEndpointRejection {
+                token_url: "https://auth.example.com/token".to_string(),
+                status: 400,
+                oauth_error: Some("invalid_grant".to_string()),
+            }
+            .into()),
+        ]);
+        let temp = tempdir().expect("tempdir");
+
+        let _ = resolve_token("svc", &oauth, temp.path(), &env, &client).expect("first ok");
+        let err = resolve_token("svc", &oauth, temp.path(), &env, &client).unwrap_err().to_string();
+        assert!(err.contains("re-authentication required"), "dead refresh chain must signal re-auth: {err}");
+        assert!(err.contains("animus mcp auth svc"), "signal must name the re-auth command: {err}");
+        assert_eq!(
+            err.matches("OAuth resolution failed for").count(),
+            1,
+            "the resolution-failure prefix must still appear exactly once: {err}"
+        );
+    }
+
+    #[test]
+    fn transient_refresh_failure_does_not_signal_reauth() {
+        // A 5xx / transport failure is retryable, NOT a dead grant: the terminal
+        // error must NOT carry the re-auth signal (which would wrongly force a
+        // human re-login on a blip).
+        let oauth = refresh_config();
+        let env = StaticEnv(BTreeMap::from([("EXAMPLE_REFRESH".to_string(), "rt-original".to_string())]));
+        let client = MockClient::new(vec![Err(anyhow!(
+            "OAuth token endpoint https://auth.example.com/token returned status 503"
+        ))]);
+        let temp = tempdir().expect("tempdir");
+
+        let err = resolve_token("svc", &oauth, temp.path(), &env, &client).unwrap_err().to_string();
+        assert!(!err.contains("re-authentication required"), "a transient failure must not signal re-auth: {err}");
+        assert!(err.contains("svc"), "error should still name the server: {err}");
     }
 }


### PR DESCRIPTION
## Summary

Hardens the kernel OAuth broker () that resolves and caches bearer/refresh tokens for HTTP-transport MCP servers, so an MCP connection stays authenticated across an ephemeral host's redeploys (TASK-145).

Two additive changes, no behavior change for existing configs:

1. **Durable cache override** — new  env var. When set, the token cache lives under that directory instead of the ephemeral . Point it at a mounted persistent volume (e.g. Railway ) and the resolved access token plus the rotated refresh-token chain survive a redeploy, so the next resolution reuses them instead of forcing a fresh re-auth. Per-server cache filenames still namespace and hash the server name, so servers share the directory without colliding.

2. **Dead-grant reauth signal** — when a refresh grant is truly dead (the cached rotation chain AND the env-var seed are both rejected with RFC 6749 ), the terminal error now carries an explicit  signal. This lets a connection-state reader classify needs-reauth versus a transient failure (5xx, , unreachable endpoint), which stay retryable and keep the cached rotation chain.

## Refresh robustness

The existing refresh path is unchanged and already: refreshes before expiry with a 60s skew margin, serializes concurrent resolutions behind a per-cache-file advisory lock, persists rotated refresh tokens, recovers a rejected cached rotation via the env-var seed, and force-refreshes on a proxy 401. This PR only adds durable persistence of that cache and a clear terminal signal when re-auth is genuinely required.

## Tests

- 
- 
- 


running 29 tests
test oauth_broker::tests::cache_dir_override_env_redirects_to_durable_path ... ok
test oauth_broker::tests::header_map_emits_authorization_bearer ... ok
test oauth_broker::tests::cache_filename_sanitizes_path_traversal_attempts ... ok
test oauth_broker::tests::manual_bearer_flow_reads_env_var ... ok
test oauth_broker::tests::cache_disabled_bypasses_cache_read_and_write ... ok
test oauth_broker::tests::oauth_error_code_extraction_is_strict ... ok
test oauth_broker::tests::missing_env_var_returns_actionable_error ... ok
test oauth_broker::tests::refresh_token_flow_propagates_missing_client_env_error ... ok
test oauth_broker::tests::missing_expires_in_uses_short_default_ttl_not_forever ... ok
test oauth_broker::tests::dead_refresh_chain_signals_reauth_required ... ok
test oauth_broker::tests::cache_file_is_0600_on_unix ... ok
test oauth_broker::tests::client_credentials_flow_uses_cache_on_second_call ... ok
test oauth_broker::tests::resolution_errors_are_not_double_wrapped ... ok
test oauth_broker::tests::corrupt_cache_file_is_treated_as_miss_and_removed ... ok
test oauth_broker::tests::cache_filename_resists_traversal_in_resolve_token ... ok
test oauth_broker::tests::concurrent_resolutions_perform_a_single_token_fetch ... ok
test oauth_broker::tests::client_credentials_flow_writes_authorization_header ... ok
test oauth_broker::tests::non_invalid_grant_client_error_does_not_discard_cached_refresh_token ... ok
test oauth_broker::tests::legacy_cache_entry_without_seed_hash_stays_usable_and_is_migrated ... ok
test oauth_broker::tests::refresh_token_flow_uses_rotated_refresh_token_from_cache ... ok
test oauth_broker::tests::transient_refresh_failure_does_not_signal_reauth ... ok
test oauth_broker::tests::client_credentials_flow_refetches_when_expired ... ok
test oauth_broker::tests::token_endpoint_failure_returns_actionable_error ... ok
test oauth_broker::tests::rejected_cached_refresh_token_falls_back_to_env_seed_and_clears_stale_cache ... ok
test oauth_broker::tests::server_error_does_not_discard_cached_refresh_token ... ok
test oauth_broker::tests::cached_token_stays_usable_when_seed_env_is_absent ... ok
test oauth_broker::tests::cache_is_invalidated_when_oauth_config_changes ... ok
test oauth_broker::tests::reminted_refresh_seed_value_bypasses_fresh_cache ... ok
test oauth_broker::tests::force_refresh_uses_cached_rotated_refresh_token_and_persists_the_new_rotation ... ok

test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 185 filtered out; finished in 0.07s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s — 29 passed. Diff in /Users/samishukri/launchapp-dev/repos/animus-cli/worktrees/agent-v0.7.0-mcp-oauth-persist-refresh/crates/orchestrator-plugin-host/src/host.rs:1638:
         assert_eq!(redact_stderr_line("using api key: sk-abc123 now"), "using api key ***");
         assert_eq!(redact_stderr_line("Authorization: Bearer sk-xyz trailing"), "Authorization ***");
         // Multi-token / PEM value cannot leak its tail.
[31m-        assert_eq!(
(B[m[31m-            redact_stderr_line("private_key=-----BEGIN KEY----- abcd -----END KEY-----"),
(B[m[31m-            "private_key ***"
(B[m[31m-        );
(B[m[32m+        assert_eq!(redact_stderr_line("private_key=-----BEGIN KEY----- abcd -----END KEY-----"), "private_key ***");
(B[m         // Query-string credential in a URL without userinfo.
         assert_eq!(
             redact_stderr_line("cb https://h/x?client_id=a&client_secret=zzz"), clean,  clean. Codex review (high effort) returned no findings.

Paired with the portal-side fix (animus-launchapp) that persists the device secret key on the volume so the authorization_code MCP OAuth tokens (e.g. Krisp) and Drive connector tokens survive redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)