### PR TITLE
Budget + fleet-pause visibility in daemon health/status + budget get/set MCP tools

### DIFF
--- a/crates/orchestrator-cli/src/services/cost/budget_report.rs
+++ b/crates/orchestrator-cli/src/services/cost/budget_report.rs
@@ -1,0 +1,273 @@
+//! Read-only budget report and fleet-pause visibility helpers.
+//!
+//! Backs the `animus.budget.get` MCP tool (fleet daily cap + configured
+//! per-workflow / per-phase caps) and the operator-facing "dispatch paused"
+//! reason surfaced through `daemon health` / `daemon status`. Enforcement
+//! itself lives in [`super::daily_cap`] and [`super::scanner`]; this module
+//! only reads state and projects it into serializable views.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::daily_cap::{is_dispatch_paused, DailyCapStatus};
+
+pub(crate) const BUDGET_REPORT_SCHEMA: &str = "animus.budget.v1";
+
+/// Fleet daily spend cap rollup: configured cap, rolling-24h spend,
+/// remaining headroom, whether the cap is blown, and whether the daemon is
+/// currently suppressing new dispatch on the latch.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct DailyCapReport {
+    pub window_hours: i64,
+    pub spent_usd: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_daily_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remaining_usd: Option<f64>,
+    pub exceeded: bool,
+    /// `true` when the daemon is suppressing new dispatch on the latch.
+    pub dispatch_paused: bool,
+}
+
+/// Evaluate the fleet daily cap against the cached cost-state and the
+/// persisted dispatch latch. Cheap reads only (no live run rescan).
+///
+/// `dispatch_paused` mirrors the daemon's actual dispatch gate
+/// ([`daemon_tick_executor::dispatch_suppressed`]): the enforcement
+/// kill-switch (`ANIMUS_DAEMON_DISABLE_BUDGET_ENFORCEMENT`) wins, so a stale
+/// latch left over from a prior breach never reports as paused (nor degrades
+/// health) when enforcement is disabled and the daemon is free to dispatch.
+/// The kill-switch is read from the daemon's PERSISTED sweep status (via
+/// [`super::effective_budget_enforcement_enabled`]) so a CLI/MCP reader in a
+/// different process than the daemon still sees the daemon's real posture.
+pub(crate) fn daily_cap_report(project_root: &Path) -> DailyCapReport {
+    let state = super::load_cost_state(project_root).unwrap_or_default();
+    let status = DailyCapStatus::evaluate(project_root, &state);
+    let dispatch_paused = super::effective_budget_enforcement_enabled(project_root) && is_dispatch_paused(project_root);
+    DailyCapReport {
+        window_hours: status.window_hours,
+        spent_usd: status.spent_usd,
+        max_daily_usd: status.max_daily_usd,
+        remaining_usd: status.remaining_usd,
+        exceeded: status.exceeded,
+        dispatch_paused,
+    }
+}
+
+/// One-line operator-facing reason when the fleet daily cap has paused
+/// dispatch, or `None` when dispatch is not paused. Surfaced as a
+/// `last_error` / `degraded_reasons` entry so a latched cap is no longer a
+/// silent `healthy: true`.
+pub(crate) fn dispatch_paused_reason(project_root: &Path) -> Option<String> {
+    let report = daily_cap_report(project_root);
+    report.dispatch_paused.then(|| dispatch_paused_reason_text(&report))
+}
+
+/// Render the dispatch-paused reason from an already-evaluated report (used
+/// by callers that computed the daily-cap rollup once and want the matching
+/// message without a second state read).
+pub(crate) fn dispatch_paused_reason_text(report: &DailyCapReport) -> String {
+    match report.max_daily_usd {
+        Some(cap) => format!(
+            "fleet daily spend cap exceeded (${:.2}/${:.2} over the last {}h) — new dispatch paused; \
+             raise or clear with `animus daemon config --max-daily-usd <N>`",
+            report.spent_usd, cap, report.window_hours
+        ),
+        None => "fleet daily spend cap exceeded — new dispatch paused".to_string(),
+    }
+}
+
+/// A single configured budget ceiling (workflow- or phase-scoped).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct CapConfigView {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_cost_usd: Option<f64>,
+    pub on_exceed: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct PhaseCapView {
+    pub phase_id: String,
+    pub budget: CapConfigView,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct WorkflowCapView {
+    pub workflow_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<CapConfigView>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub phases: Vec<PhaseCapView>,
+}
+
+/// Full budget report: the fleet daily cap plus every workflow / phase that
+/// declares a non-empty [`BudgetConfig`](orchestrator_config::workflow_config::BudgetConfig).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct BudgetReport {
+    pub schema: &'static str,
+    pub daily_cap: DailyCapReport,
+    pub workflow_caps: Vec<WorkflowCapView>,
+}
+
+fn cap_view(budget: &orchestrator_config::workflow_config::BudgetConfig) -> CapConfigView {
+    CapConfigView {
+        max_tokens: budget.max_tokens,
+        max_cost_usd: budget.max_cost_usd,
+        on_exceed: budget.on_exceed.as_str().to_string(),
+    }
+}
+
+/// Build the read-only budget report for `budget_get`. Enumerates the
+/// compiled workflow config for declared per-workflow / per-phase caps and
+/// folds in the fleet daily cap. Workflows with no declared caps are
+/// omitted so the report answers "what caps are in force", not "list every
+/// workflow".
+pub(crate) fn build_budget_report(project_root: &Path) -> BudgetReport {
+    let config = orchestrator_core::load_workflow_config_or_default(project_root).config;
+    let mut workflow_caps = Vec::new();
+    for workflow in &config.workflows {
+        let budget = workflow.budget.as_ref().filter(|budget| !budget.is_empty()).map(cap_view);
+        let mut phases = Vec::new();
+        for entry in &workflow.phases {
+            if let Some(phase_budget) = entry.budget() {
+                if !phase_budget.is_empty() {
+                    phases
+                        .push(PhaseCapView { phase_id: entry.phase_id().to_string(), budget: cap_view(phase_budget) });
+                }
+            }
+        }
+        if budget.is_some() || !phases.is_empty() {
+            workflow_caps.push(WorkflowCapView { workflow_id: workflow.id.clone(), budget, phases });
+        }
+    }
+    BudgetReport { schema: BUDGET_REPORT_SCHEMA, daily_cap: daily_cap_report(project_root), workflow_caps }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::test_env_lock;
+    use protocol::test_utils::EnvVarGuard;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn arrange(tmp: &TempDir) -> (EnvVarGuard, EnvVarGuard, PathBuf) {
+        let home = EnvVarGuard::set("HOME", Some(tmp.path().to_string_lossy().as_ref()));
+        let scope = tmp.path().join("scope");
+        std::fs::create_dir_all(&scope).unwrap();
+        let override_guard = EnvVarGuard::set("ANIMUS_COST_STATE_ROOT", Some(scope.to_string_lossy().as_ref()));
+        let project_root = tmp.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        (home, override_guard, project_root)
+    }
+
+    fn write_pm_config_cap(project_root: &Path, cap: f64) {
+        let config = orchestrator_core::DaemonProjectConfig {
+            extra: std::iter::once(("max_daily_usd".to_string(), serde_json::json!(cap))).collect(),
+            ..Default::default()
+        };
+        orchestrator_core::write_daemon_project_config(project_root, &config).unwrap();
+    }
+
+    #[test]
+    fn dispatch_paused_reason_none_when_uncapped() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let (_home, _override, project_root) = arrange(&tmp);
+        assert_eq!(dispatch_paused_reason(&project_root), None, "no cap → never paused");
+    }
+
+    #[test]
+    fn dispatch_paused_reason_names_the_cap_when_latched() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let (_home, _override, project_root) = arrange(&tmp);
+        write_pm_config_cap(&project_root, 5.0);
+
+        let report = DailyCapReport {
+            window_hours: 24,
+            spent_usd: 7.5,
+            max_daily_usd: Some(5.0),
+            remaining_usd: Some(0.0),
+            exceeded: true,
+            dispatch_paused: true,
+        };
+        let text = dispatch_paused_reason_text(&report);
+        assert!(text.contains("$7.50/$5.00"), "reason names spend vs cap: {text}");
+        assert!(text.contains("dispatch paused"), "reason states the effect: {text}");
+    }
+
+    #[test]
+    fn kill_switch_suppresses_reported_dispatch_pause() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let (_home, _override, project_root) = arrange(&tmp);
+        write_pm_config_cap(&project_root, 5.0);
+
+        // Record $7 of rolling spend so the live cap check latches.
+        let now = chrono::Utc::now();
+        let mut state = super::super::CostState::default();
+        let mut workflow = super::super::WorkflowCost::new("flow", now);
+        workflow.updated_at = Some(now);
+        workflow.total_cost_usd = 7.0;
+        state.workflows.insert("wf-1".to_string(), workflow);
+        super::super::save_cost_state(&project_root, &state).unwrap();
+
+        let _on = EnvVarGuard::set(super::super::DISABLE_BUDGET_ENFORCEMENT_ENV, None);
+        assert!(daily_cap_report(&project_root).dispatch_paused, "enforcement on → latched cap pauses dispatch");
+        assert!(dispatch_paused_reason(&project_root).is_some());
+
+        // With enforcement disabled in this process (and no persisted sweep
+        // status yet) the report falls back to the env and must not claim
+        // paused / degrade health.
+        let _off = EnvVarGuard::set(super::super::DISABLE_BUDGET_ENFORCEMENT_ENV, Some("1"));
+        assert!(!daily_cap_report(&project_root).dispatch_paused, "kill-switch → never reported paused");
+        assert_eq!(dispatch_paused_reason(&project_root), None, "kill-switch → no degraded reason");
+    }
+
+    #[test]
+    fn persisted_enforcement_status_overrides_process_env() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let (_home, _override, project_root) = arrange(&tmp);
+        write_pm_config_cap(&project_root, 5.0);
+
+        let now = chrono::Utc::now();
+        let mut state = super::super::CostState::default();
+        let mut workflow = super::super::WorkflowCost::new("flow", now);
+        workflow.updated_at = Some(now);
+        workflow.total_cost_usd = 7.0;
+        state.workflows.insert("wf-1".to_string(), workflow);
+        super::super::save_cost_state(&project_root, &state).unwrap();
+
+        // Daemon (another process) recorded enforcement DISABLED, while this
+        // reader's env leaves it enabled. The persisted status must win, so a
+        // stale latch is not reported as paused.
+        let _enabled_env = EnvVarGuard::set(super::super::DISABLE_BUDGET_ENFORCEMENT_ENV, None);
+        super::super::save_budget_enforcement_status(&project_root, false).unwrap();
+        assert!(!daily_cap_report(&project_root).dispatch_paused, "persisted disabled wins over enabled env");
+
+        // Daemon recorded enforcement ENABLED → the latch is honored even if
+        // this reader's env disables it.
+        let _disabled_env = EnvVarGuard::set(super::super::DISABLE_BUDGET_ENFORCEMENT_ENV, Some("1"));
+        super::super::save_budget_enforcement_status(&project_root, true).unwrap();
+        assert!(daily_cap_report(&project_root).dispatch_paused, "persisted enabled wins over disabled env");
+    }
+
+    #[test]
+    fn budget_report_reports_daily_cap_and_no_workflow_caps_by_default() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let (_home, _override, project_root) = arrange(&tmp);
+        write_pm_config_cap(&project_root, 12.0);
+
+        let report = build_budget_report(&project_root);
+        assert_eq!(report.schema, BUDGET_REPORT_SCHEMA);
+        assert_eq!(report.daily_cap.max_daily_usd, Some(12.0));
+        assert!(!report.daily_cap.dispatch_paused);
+        assert!(report.workflow_caps.is_empty(), "no workflow YAML caps declared");
+    }
+}

--- a/crates/orchestrator-cli/src/services/cost/mod.rs
+++ b/crates/orchestrator-cli/src/services/cost/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod aggregator;
 pub(crate) mod breach_summary;
+pub(crate) mod budget_report;
 pub(crate) mod cap_check;
 pub(crate) mod daily_cap;
 pub(crate) mod enforcement;
@@ -15,6 +16,10 @@ pub(crate) mod scanner;
 pub(crate) use aggregator::{CostState, PhaseCost, WorkflowCost};
 #[allow(unused_imports)]
 pub(crate) use breach_summary::{summarize_breaches, BudgetBreachSummary};
+#[allow(unused_imports)]
+pub(crate) use budget_report::{
+    build_budget_report, daily_cap_report, dispatch_paused_reason, BudgetReport, DailyCapReport,
+};
 #[allow(unused_imports)]
 pub(crate) use daily_cap::{read_max_daily_usd, DailyCapStatus};
 pub(crate) use persistence::save_cost_state;
@@ -43,9 +48,21 @@ pub(crate) use persistence::{
 pub(crate) const DISABLE_BUDGET_ENFORCEMENT_ENV: &str = "ANIMUS_DAEMON_DISABLE_BUDGET_ENFORCEMENT";
 
 /// `true` when the budget-enforcement leg is enabled (kill-switch unset or
-/// not a truthy `1`/`true`).
+/// not a truthy `1`/`true`) in THIS process's environment.
 pub(crate) fn budget_enforcement_enabled() -> bool {
     !matches!(std::env::var(DISABLE_BUDGET_ENFORCEMENT_ENV).ok().as_deref(), Some("1") | Some("true"))
+}
+
+/// Effective enforcement state for a project, from the point of view of a
+/// reader that may be a different process than the daemon. The daemon's
+/// housekeeping sweep persists `enabled` (its own kill-switch reading) to
+/// scoped state each tick, so a CLI/MCP process querying budget health must
+/// trust that persisted status over its own environment — otherwise a daemon
+/// started with `ANIMUS_DAEMON_DISABLE_BUDGET_ENFORCEMENT=1` reads as
+/// enforcing from a caller that lacks the env var. Falls back to this
+/// process's env only when the daemon has not recorded a sweep yet.
+pub(crate) fn effective_budget_enforcement_enabled(project_root: &Path) -> bool {
+    load_budget_enforcement_status(project_root).map(|status| status.enabled).unwrap_or_else(budget_enforcement_enabled)
 }
 
 use std::path::Path;

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/cost_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/cost_tools.rs
@@ -17,6 +17,47 @@ fn build_cost_decisions_args(input: &CostDecisionsInput) -> Vec<String> {
     args
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
+pub(super) struct BudgetGetInput {
+    #[serde(default)]
+    pub(super) project_root: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
+pub(super) struct BudgetSetInput {
+    /// New fleet daily spend cap in USD. Omit to clear the cap (with
+    /// `clear: true`). Mutually exclusive with `clear`.
+    #[serde(default)]
+    pub(super) max_daily_usd: Option<f64>,
+    /// Clear the fleet daily spend cap (persists an explicit "uncapped"
+    /// override that also suppresses any workflow-YAML `daemon.budget` cap).
+    #[serde(default)]
+    pub(super) clear: bool,
+    #[serde(default)]
+    pub(super) project_root: Option<String>,
+}
+
+/// Build the `daemon config` args for `budget_set`, or an error message when
+/// the caller passed neither / both of `max_daily_usd` and `clear`.
+fn build_budget_set_args(input: &BudgetSetInput) -> Result<Vec<String>, String> {
+    let mut args = vec!["daemon".to_string(), "config".to_string()];
+    match (input.max_daily_usd, input.clear) {
+        (Some(_), true) => Err("pass either max_daily_usd or clear, not both".to_string()),
+        (Some(value), false) => {
+            args.push("--max-daily-usd".to_string());
+            args.push(value.to_string());
+            Ok(args)
+        }
+        (None, true) => {
+            // An explicit 0 persists as "uncapped" (see daily_cap::read_max_daily_usd).
+            args.push("--max-daily-usd".to_string());
+            args.push("0".to_string());
+            Ok(args)
+        }
+        (None, false) => Err("provide max_daily_usd (USD cap) or clear=true".to_string()),
+    }
+}
+
 #[tool_router(router = cost_tool_router, vis = "pub(super)")]
 impl AoMcpServer {
     #[tool(
@@ -28,6 +69,38 @@ impl AoMcpServer {
         let input = params.0;
         let args = build_cost_decisions_args(&input);
         self.run_tool("animus.cost.decisions", args, input.project_root).await
+    }
+
+    #[tool(
+        name = "animus.budget.get",
+        description = "Read the fleet budget posture. Purpose: See the fleet daily spend cap (max_daily_usd), today's rolling-24h spend, remaining headroom, whether the cap is exceeded, whether the daemon has paused dispatch on the cap, and every configured per-workflow / per-phase budget cap. Works offline (reads scoped cost-state + compiled workflow config; the daemon need not be running). Prerequisites: None. Example: {}. Sequencing: Use animus.budget.set to change the fleet cap; pair with animus.daemon.health to see the same daily_cap in the health snapshot.",
+        input_schema = ao_schema_for_type::<BudgetGetInput>()
+    )]
+    async fn ao_budget_get(&self, params: Parameters<BudgetGetInput>) -> Result<CallToolResult, McpError> {
+        let project_root =
+            super::daemon_inproc::resolve_project_root(&self.default_project_root, params.0.project_root);
+        let report = crate::services::cost::build_budget_report(Path::new(&project_root));
+        let payload = json!({
+            "tool": "animus.budget.get",
+            "result": serde_json::to_value(report).unwrap_or(Value::Null),
+        });
+        Ok(CallToolResult::structured(payload))
+    }
+
+    #[tool(
+        name = "animus.budget.set",
+        description = "Set or clear the fleet daily spend cap (admin). Purpose: Bound the daemon's TOTAL rolling-24h spend; when crossed the daemon pauses new dispatch until spend ages out of the window or the cap is raised. Wraps `daemon config --max-daily-usd`; hot-reloaded by the running daemon. Prerequisites: None. Example: {\"max_daily_usd\": 25.0} to cap at $25/day, or {\"clear\": true} to remove the cap. Sequencing: Use animus.budget.get to read the current cap first.",
+        input_schema = ao_schema_for_type::<BudgetSetInput>()
+    )]
+    async fn ao_budget_set(&self, params: Parameters<BudgetSetInput>) -> Result<CallToolResult, McpError> {
+        let input = params.0;
+        match build_budget_set_args(&input) {
+            Ok(args) => self.run_tool("animus.budget.set", args, input.project_root).await,
+            Err(message) => Ok(CallToolResult::structured_error(json!({
+                "tool": "animus.budget.set",
+                "error": message,
+            }))),
+        }
     }
 }
 
@@ -46,5 +119,27 @@ mod tests {
         let input = CostDecisionsInput { since: Some("7d".to_string()), project_root: Some("/repo".to_string()) };
         let args = build_cost_decisions_args(&input);
         assert_eq!(args, vec!["cost".to_string(), "decisions".to_string(), "--since".to_string(), "7d".to_string(),]);
+    }
+
+    #[test]
+    fn budget_set_args_wires_max_daily_usd() {
+        let input = BudgetSetInput { max_daily_usd: Some(25.0), clear: false, project_root: None };
+        let args = build_budget_set_args(&input).expect("valid");
+        assert_eq!(args, vec!["daemon", "config", "--max-daily-usd", "25"]);
+    }
+
+    #[test]
+    fn budget_set_args_clear_persists_zero() {
+        let input = BudgetSetInput { max_daily_usd: None, clear: true, project_root: None };
+        let args = build_budget_set_args(&input).expect("valid");
+        assert_eq!(args, vec!["daemon", "config", "--max-daily-usd", "0"]);
+    }
+
+    #[test]
+    fn budget_set_args_rejects_empty_and_conflicting_input() {
+        let empty = BudgetSetInput::default();
+        assert!(build_budget_set_args(&empty).is_err(), "neither cap nor clear must error");
+        let both = BudgetSetInput { max_daily_usd: Some(10.0), clear: true, project_root: None };
+        assert!(build_budget_set_args(&both).is_err(), "cap + clear together must error");
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon.rs
@@ -26,6 +26,10 @@ pub(super) fn build_daemon_config_set_args(input: &DaemonConfigSetInput) -> Vec<
     push_opt_usize(&mut args, "--max-tasks-per-tick", input.max_tasks_per_tick);
     push_opt_num(&mut args, "--stale-threshold-hours", input.stale_threshold_hours);
     push_opt_num(&mut args, "--phase-timeout-secs", input.phase_timeout_secs);
+    if let Some(max_daily_usd) = input.max_daily_usd {
+        args.push("--max-daily-usd".to_string());
+        args.push(max_daily_usd.to_string());
+    }
     push_opt(&mut args, "--notification-config-json", input.notification_config_json.clone());
     push_opt(&mut args, "--notification-config-file", input.notification_config_file.clone());
     if input.clear_notification_config {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inproc.rs
@@ -6,10 +6,11 @@ use serde_json::{json, Value};
 use std::path::Path;
 
 use crate::services::runtime::{
-    canonicalize_lossy, overlay_runtime_pause, read_daemon_pid, remove_daemon_pid, set_daemon_pid,
+    canonicalize_lossy, overlay_budget_health, overlay_daily_cap_status, overlay_runtime_pause, read_daemon_pid,
+    remove_daemon_pid, set_daemon_pid,
 };
 
-fn resolve_project_root(default_root: &str, override_value: Option<String>) -> String {
+pub(super) fn resolve_project_root(default_root: &str, override_value: Option<String>) -> String {
     let candidate = override_value
         .as_deref()
         .map(str::trim)
@@ -27,9 +28,11 @@ pub(super) async fn daemon_status_inproc(default_project_root: &str, project_roo
         match client.daemon_status().await {
             Ok(response) => {
                 // Wire types are pinned out-of-tree; overlay the pause state
-                // so MCP consumers see it too (matches the CLI's JSON path).
+                // and fleet daily-cap flags so MCP consumers see them too
+                // (matches the CLI's JSON path).
                 let mut value = serde_json::to_value(response)?;
                 overlay_runtime_pause(&mut value, &project_root);
+                overlay_daily_cap_status(&mut value, &project_root);
                 return Ok(value);
             }
             Err(err) if orchestrator_daemon_runtime::control::is_method_unavailable(&err) => {
@@ -71,6 +74,7 @@ pub(super) async fn daemon_health_inproc(default_project_root: &str, project_roo
                 if let Some(map) = value.as_object_mut() {
                     map.insert("healthy".to_string(), Value::Bool(healthy));
                 }
+                overlay_budget_health(&mut value, &project_root);
                 overlay_runtime_pause(&mut value, &project_root);
                 return Ok(value);
             }
@@ -88,7 +92,9 @@ pub(super) async fn daemon_health_inproc(default_project_root: &str, project_roo
         remove_daemon_pid(&project_root);
         let _ = set_daemon_pid(&project_root, None);
     }
-    Ok(serde_json::to_value(health)?)
+    let mut value = serde_json::to_value(health)?;
+    overlay_budget_health(&mut value, &project_root);
+    Ok(value)
 }
 
 pub(super) async fn daemon_agents_inproc(default_project_root: &str, project_root: Option<String>) -> Result<Value> {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inputs.rs
@@ -77,6 +77,11 @@ pub(super) struct DaemonConfigSetInput {
     pub(super) stale_threshold_hours: Option<u64>,
     #[serde(default)]
     pub(super) phase_timeout_secs: Option<u64>,
+    /// Fleet daily spend cap in USD. A non-positive value (e.g. `0`)
+    /// persists as an explicit "uncapped" override. Hot-reloaded by the
+    /// running daemon's cost layer.
+    #[serde(default)]
+    pub(super) max_daily_usd: Option<f64>,
     #[serde(default)]
     pub(super) notification_config_json: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_tools.rs
@@ -143,7 +143,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.daemon.config-set",
-        description = "Update daemon configuration. Purpose: Persist daemon automation settings and runtime-reconfigurable settings (pool_size, interval_secs, max_tasks_per_tick, stale_threshold_hours, phase_timeout_secs, notification_config_json, notification_config_file, clear_notification_config). Runtime settings are hot-reloaded by the running daemon without restart. Prerequisites: None. Example: {\"pool_size\": 4, \"interval_secs\": 10}. Sequencing: Use animus.daemon.config to read current values first.",
+        description = "Update daemon configuration. Purpose: Persist daemon automation settings and runtime-reconfigurable settings (pool_size, interval_secs, max_tasks_per_tick, stale_threshold_hours, phase_timeout_secs, max_daily_usd, notification_config_json, notification_config_file, clear_notification_config). Runtime settings are hot-reloaded by the running daemon without restart. For the fleet daily spend cap prefer animus.budget.set. Prerequisites: None. Example: {\"pool_size\": 4, \"interval_secs\": 10}. Sequencing: Use animus.daemon.config to read current values first.",
         input_schema = ao_schema_for_type::<DaemonConfigSetInput>()
     )]
     async fn ao_daemon_config_set(&self, params: Parameters<DaemonConfigSetInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
@@ -130,6 +130,7 @@ pub(crate) async fn handle_daemon_status_command(project_root: &str, json: bool)
                     // consumers can tell a paused runtime from an active one.
                     let mut value = serde_json::to_value(&response)?;
                     overlay_runtime_pause(&mut value, project_root);
+                    overlay_daily_cap_status(&mut value, project_root);
                     return print_value(value, true);
                 }
                 Err(err) if orchestrator_daemon_runtime::control::is_method_unavailable(&err) => {
@@ -172,50 +173,72 @@ pub(crate) async fn handle_daemon_status_command(project_root: &str, json: bool)
 /// it cannot compute the paused/active split — see
 /// [`crate::services::cost::breach_summary`]).
 #[derive(serde::Serialize)]
-struct BudgetHealthSlice {
+pub(crate) struct BudgetHealthSlice {
     enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     last_sweep_at: Option<String>,
     breaches: crate::services::cost::BudgetBreachSummary,
     /// Fleet daily spend cap: configured cap, today's rolling-24h spend,
     /// remaining headroom, and whether new dispatch is currently paused.
-    daily_cap: BudgetHealthDailyCap,
+    daily_cap: crate::services::cost::DailyCapReport,
 }
 
-#[derive(serde::Serialize)]
-struct BudgetHealthDailyCap {
-    window_hours: i64,
-    spent_usd: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_daily_usd: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    remaining_usd: Option<f64>,
-    exceeded: bool,
-    /// `true` when the daemon is suppressing new dispatch on the latch.
-    dispatch_paused: bool,
-}
-
-fn budget_health_slice(project_root: &str) -> BudgetHealthSlice {
+pub(crate) fn budget_health_slice(project_root: &str) -> BudgetHealthSlice {
     let path = Path::new(project_root);
     let status = crate::services::cost::load_budget_enforcement_status(path);
     let records = crate::services::cost::read_decision_records(path).unwrap_or_default();
     // Cheap reads only on the health path: the cached cost-state JSON for
     // the spend rollup and the persisted latch — no live run rescan.
-    let cost_state = crate::services::cost::load_cost_state(path).unwrap_or_default();
-    let cap_status = crate::services::cost::DailyCapStatus::evaluate(path, &cost_state);
-    let dispatch_paused = crate::services::cost::daily_cap::is_dispatch_paused(path);
     BudgetHealthSlice {
         enabled: status.as_ref().map(|s| s.enabled).unwrap_or_else(crate::services::cost::budget_enforcement_enabled),
         last_sweep_at: status.map(|s| s.last_sweep_at.to_rfc3339()),
         breaches: crate::services::cost::summarize_breaches(&records, None),
-        daily_cap: BudgetHealthDailyCap {
-            window_hours: cap_status.window_hours,
-            spent_usd: cap_status.spent_usd,
-            max_daily_usd: cap_status.max_daily_usd,
-            remaining_usd: cap_status.remaining_usd,
-            exceeded: cap_status.exceeded,
-            dispatch_paused,
-        },
+        daily_cap: crate::services::cost::daily_cap_report(path),
+    }
+}
+
+/// Merge the budget-enforcement slice into a daemon-health JSON object so
+/// MCP / CLI consumers see the fleet daily cap alongside the pinned wire
+/// fields. When the daily cap has latched (`dispatch_paused`), also surface
+/// a `last_error` (only if the wire path did not already set one) and append
+/// a `degraded_reasons` entry — so a paused fleet is no longer a silent
+/// `healthy: true`.
+pub(crate) fn overlay_budget_health(value: &mut serde_json::Value, project_root: &str) {
+    let slice = budget_health_slice(project_root);
+    let paused_reason = slice
+        .daily_cap
+        .dispatch_paused
+        .then(|| crate::services::cost::budget_report::dispatch_paused_reason_text(&slice.daily_cap));
+    let Some(map) = value.as_object_mut() else { return };
+    if let Ok(slice_value) = serde_json::to_value(&slice) {
+        map.insert("budget_enforcement".to_string(), slice_value);
+    }
+    if let Some(reason) = paused_reason {
+        // Do not clobber a wire `last_error` (e.g. a supervisor-disabled
+        // plugin message); only fill it when absent so the cap reason is
+        // still visible on the offline snapshot path.
+        if map.get("last_error").and_then(serde_json::Value::as_str).is_none() {
+            map.insert("last_error".to_string(), serde_json::Value::String(reason.clone()));
+        }
+        let reasons = map.entry("degraded_reasons").or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        if let Some(array) = reasons.as_array_mut() {
+            if !array.iter().any(|entry| entry.as_str() == Some(reason.as_str())) {
+                array.push(serde_json::Value::String(reason));
+            }
+        }
+    }
+}
+
+/// Merge the compact fleet-pause flags into a daemon-status JSON object.
+/// `daemon status` carries only liveness on the wire, so surface
+/// `dispatch_paused` + `daily_cap_exceeded` there too — the fleet cap
+/// latches while the daemon is still running, which is exactly when an
+/// operator checks status.
+pub(crate) fn overlay_daily_cap_status(value: &mut serde_json::Value, project_root: &str) {
+    let report = crate::services::cost::daily_cap_report(Path::new(project_root));
+    if let Some(map) = value.as_object_mut() {
+        map.insert("dispatch_paused".to_string(), serde_json::Value::Bool(report.dispatch_paused));
+        map.insert("daily_cap_exceeded".to_string(), serde_json::Value::Bool(report.exceeded));
     }
 }
 
@@ -234,6 +257,17 @@ fn render_budget_health_human(slice: &BudgetHealthSlice) {
     } else {
         println!("  breaches in last 24h: 0");
     }
+    let cap = &slice.daily_cap;
+    if cap.dispatch_paused {
+        println!("  dispatch: PAUSED (fleet daily cap exceeded — new work suppressed until spend ages out or the cap is raised)");
+    }
+    if let Some(max) = cap.max_daily_usd {
+        let remaining = cap.remaining_usd.unwrap_or(0.0);
+        println!(
+            "  daily cap: ${:.2} spent / ${:.2} cap (${:.2} remaining, {}h window)",
+            cap.spent_usd, max, remaining, cap.window_hours
+        );
+    }
 }
 
 pub(crate) async fn handle_daemon_health_command(project_root: &str, json: bool) -> Result<()> {
@@ -248,8 +282,8 @@ pub(crate) async fn handle_daemon_health_command(project_root: &str, json: bool)
                     let mut value = serde_json::to_value(&response)?;
                     if let Some(map) = value.as_object_mut() {
                         map.insert("healthy".to_string(), serde_json::Value::Bool(healthy));
-                        map.insert("budget_enforcement".to_string(), serde_json::to_value(&budget)?);
                     }
+                    overlay_budget_health(&mut value, project_root);
                     overlay_runtime_pause(&mut value, project_root);
                     return print_value(value, true);
                 }
@@ -277,9 +311,7 @@ pub(crate) async fn handle_daemon_health_command(project_root: &str, json: bool)
         return Ok(());
     }
     let mut value = serde_json::to_value(&health)?;
-    if let Some(map) = value.as_object_mut() {
-        map.insert("budget_enforcement".to_string(), serde_json::to_value(&budget)?);
-    }
+    overlay_budget_health(&mut value, project_root);
     print_value(value, json)
 }
 
@@ -2171,6 +2203,82 @@ mod tests {
         let slice = budget_health_slice(project_root.to_string_lossy().as_ref());
         assert!(!slice.enabled, "persisted disabled flag wins over env default");
         assert!(slice.last_sweep_at.is_some());
+    }
+
+    #[test]
+    fn overlay_budget_health_surfaces_latched_daily_cap() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", Some(tmp.path().to_string_lossy().as_ref()));
+        let state_root = tmp.path().join("scope");
+        std::fs::create_dir_all(&state_root).unwrap();
+        let _override = EnvVarGuard::set("ANIMUS_COST_STATE_ROOT", Some(state_root.to_string_lossy().as_ref()));
+        let project_root = tmp.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+
+        // Configure a $5 fleet cap and record $7 of rolling spend so the cap
+        // reads as exceeded (is_dispatch_paused's live check latches).
+        let config = orchestrator_core::DaemonProjectConfig {
+            extra: std::iter::once(("max_daily_usd".to_string(), serde_json::json!(5.0))).collect(),
+            ..Default::default()
+        };
+        orchestrator_core::write_daemon_project_config(&project_root, &config).unwrap();
+        let mut cost_state = crate::services::cost::CostState::default();
+        let now = chrono::Utc::now();
+        let mut workflow = crate::services::cost::WorkflowCost::new("flow", now);
+        workflow.updated_at = Some(now);
+        workflow.total_cost_usd = 7.0;
+        cost_state.workflows.insert("wf-1".to_string(), workflow);
+        crate::services::cost::save_cost_state(&project_root, &cost_state).unwrap();
+
+        // A healthy-looking base snapshot with no last_error, as the offline
+        // path produces before the overlay runs.
+        let mut value = serde_json::json!({ "healthy": true, "status": "Running" });
+        overlay_budget_health(&mut value, project_root.to_string_lossy().as_ref());
+
+        let daily_cap = value.pointer("/budget_enforcement/daily_cap").expect("daily_cap present");
+        assert_eq!(daily_cap.get("dispatch_paused").and_then(serde_json::Value::as_bool), Some(true));
+        assert_eq!(daily_cap.get("exceeded").and_then(serde_json::Value::as_bool), Some(true));
+        let last_error = value.get("last_error").and_then(serde_json::Value::as_str).expect("last_error filled");
+        assert!(last_error.contains("dispatch paused"), "last_error names the pause: {last_error}");
+        let reasons =
+            value.get("degraded_reasons").and_then(serde_json::Value::as_array).expect("degraded_reasons array");
+        assert!(reasons.iter().any(|r| r.as_str().is_some_and(|s| s.contains("dispatch paused"))));
+    }
+
+    #[test]
+    fn overlay_budget_health_leaves_existing_last_error_intact() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", Some(tmp.path().to_string_lossy().as_ref()));
+        let state_root = tmp.path().join("scope");
+        std::fs::create_dir_all(&state_root).unwrap();
+        let _override = EnvVarGuard::set("ANIMUS_COST_STATE_ROOT", Some(state_root.to_string_lossy().as_ref()));
+        let project_root = tmp.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+
+        let config = orchestrator_core::DaemonProjectConfig {
+            extra: std::iter::once(("max_daily_usd".to_string(), serde_json::json!(5.0))).collect(),
+            ..Default::default()
+        };
+        orchestrator_core::write_daemon_project_config(&project_root, &config).unwrap();
+        let mut cost_state = crate::services::cost::CostState::default();
+        let now = chrono::Utc::now();
+        let mut workflow = crate::services::cost::WorkflowCost::new("flow", now);
+        workflow.updated_at = Some(now);
+        workflow.total_cost_usd = 7.0;
+        cost_state.workflows.insert("wf-1".to_string(), workflow);
+        crate::services::cost::save_cost_state(&project_root, &cost_state).unwrap();
+
+        // A wire snapshot that already carries a last_error (e.g. a
+        // supervisor-disabled plugin) must not be clobbered by the cap reason.
+        let mut value = serde_json::json!({ "healthy": true, "last_error": "plugin X disabled" });
+        overlay_budget_health(&mut value, project_root.to_string_lossy().as_ref());
+        assert_eq!(value.get("last_error").and_then(serde_json::Value::as_str), Some("plugin X disabled"));
+        // The cap reason still lands in degraded_reasons so it is not lost.
+        let reasons =
+            value.get("degraded_reasons").and_then(serde_json::Value::as_array).expect("degraded_reasons array");
+        assert!(reasons.iter().any(|r| r.as_str().is_some_and(|s| s.contains("dispatch paused"))));
     }
 
     #[test]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/control_routing.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/control_routing.rs
@@ -129,6 +129,13 @@ impl DaemonOpsRouting for DaemonOpsRoutingImpl {
         if let Some(reason) = plugin_process_cap_degraded_reason() {
             reasons.push(reason);
         }
+        // Fleet daily-cap latch: when the daemon has paused dispatch because
+        // the rolling-24h spend cap is blown it otherwise reports
+        // `healthy: true` and stops leasing silently. Surface it as a
+        // degraded reason so `daemon health` last_error names the pause.
+        if let Some(reason) = crate::services::cost::dispatch_paused_reason(&self.project_root) {
+            reasons.push(reason);
+        }
 
         let (status, last_error) = if wire_status == DaemonHealthStatus::Healthy && !reasons.is_empty() {
             (DaemonHealthStatus::Degraded, Some(reasons.join("; ")))

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -7,13 +7,14 @@ For the full parameter table, see [MCP Tools Reference](../reference/mcp-tools.m
 
 ## Overview
 
-Animus currently exposes **91 built-in MCP tools** across these families:
+Animus currently exposes **93 built-in MCP tools** across these families:
 
 | Group | Tools | Purpose |
 |---|---:|---|
 | `animus.agent.*` | 12 | Agent profiles, runs, memory, agent messaging, and blocking human-in-the-loop questions/approvals |
 | `animus.daemon.*` | 12 | Daemon lifecycle, health, events, config, and the `observe` observability front-door |
 | `animus.cost.*` | 1 | Budget-cap breach inspection from the scoped breach log |
+| `animus.budget.*` | 2 | Read the fleet budget posture (daily cap, rolling spend, per-workflow/phase caps) and set/clear the fleet daily spend cap |
 | `animus.subject.*` | 8 | Task, requirement, and external subject backends, including bulk create/update |
 | `animus.workflow.*` | 22 | Workflow execution, control (incl. gate approve/reject), definition inspection, and config write-back (`config.set` + entity `agent-set`/`workflow-set`/`*-remove`) |
 | `animus.queue.*` | 7 | Dispatch queue inspection and mutation |
@@ -26,7 +27,7 @@ Animus currently exposes **91 built-in MCP tools** across these families:
 | `animus.tools.*` | 2 | Tool discovery over the live registry: ranked keyword search plus a grouped one-line catalog |
 
 **Tool discovery.** When you are unsure which tool fits an intent — or your
-context budget is too tight to carry all 91 schemas — start with
+context budget is too tight to carry all 93 schemas — start with
 `animus.tools.search` (e.g. `{"query": "pause workflow"}`). It searches the
 server's live registry (tool names, descriptions, and parameter names), ranks
 matches (name hits outrank description hits outrank parameter hits; an exact

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -21,7 +21,7 @@ Practical walkthroughs for day-to-day Animus operations.
 
 ## MCP & Agent Integration
 
-- **[Working with Animus via MCP Tools](agents.md)** -- Complete guide to all 91 built-in MCP tools: JSON examples, common workflows, sequencing tips, pagination, and batch operations.
+- **[Working with Animus via MCP Tools](agents.md)** -- Complete guide to all 93 built-in MCP tools: JSON examples, common workflows, sequencing tips, pagination, and batch operations.
 
 ## Extending Animus
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,4 +9,4 @@ lastUpdated: false
 
 <Landing />
 
-<!-- details: 91 built-in MCP tools for subject management, workflow control, plugin operations, output inspection, and runtime state mutations. Agents act through tools, not code. -->
+<!-- details: 93 built-in MCP tools for subject management, workflow control, plugin operations, output inspection, and runtime state mutations. Agents act through tools, not code. -->

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,14 +1,14 @@
 # MCP Tools Reference
 
 All MCP tools exposed by `animus mcp serve`. The current top-level server
-registers 91 built-in tools across daemon, cost, queue, agent, output,
+registers 93 built-in tools across daemon, cost, queue, agent, output,
 workflow, plugin, skill, subject, logs, tool-discovery, and top-level memory families. These
 tools allow AI agents to interact with the Animus orchestrator over the Model
 Context Protocol. Each tool wraps an `animus` CLI command, accepting JSON input
 and returning structured results.
 
-That headline 91 counts the full management-mode surface. A default
-agent-injected server (`animus mcp serve` without `--management`) exposes 89:
+That headline 93 counts the full management-mode surface. A default
+agent-injected server (`animus mcp serve` without `--management`) exposes 91:
 the two `animus.interactions.*` management tools are gated behind
 `--management` so an agent can never list or answer its own pending approvals.
 
@@ -134,16 +134,18 @@ approval gate stays human-only.
 | `animus.daemon.agents` | List currently running agent tasks and their status | `project_root` |
 | `animus.daemon.logs` | Read recent daemon log entries | `limit`, `search`, `project_root` |
 | `animus.daemon.config` | Read current daemon automation settings | `project_root` |
-| `animus.daemon.config-set` | Update daemon runtime settings and notification config | `pool_size` (alias: `max_agents`), `interval_secs`, `max_tasks_per_tick`, `stale_threshold_hours`, `phase_timeout_secs`, `notification_config_json`, `notification_config_file`, `clear_notification_config`, `project_root` |
+| `animus.daemon.config-set` | Update daemon runtime settings and notification config | `pool_size` (alias: `max_agents`), `interval_secs`, `max_tasks_per_tick`, `stale_threshold_hours`, `phase_timeout_secs`, `max_daily_usd`, `notification_config_json`, `notification_config_file`, `clear_notification_config`, `project_root` |
 | `animus.daemon.observe` | Routing front-door over the existing observability surfaces: returns the merged, chronological window of daemon events + logs (or routes to a single `source`). Non-streaming — always returns and never follows live. Works offline (reads scoped event/log history; the daemon need not be running) | `since`, `source` (`logs`/`events`/`stream`/`workflow`), `workflow_id`, `limit`, `project_root` |
 
 ---
 
-## Cost & Budget (1 tool)
+## Cost & Budget (3 tools)
 
 | Tool | Description | Key Parameters |
 |---|---|---|
 | `animus.cost.decisions` | List recorded budget-cap breaches from the scoped breach log. Works offline (reads the scoped breach log; the daemon need not be running) | `since`, `project_root` |
+| `animus.budget.get` | Read the fleet budget posture: fleet daily spend cap, today's rolling-24h spend, remaining headroom, whether the cap is exceeded, whether dispatch is paused on the cap, and every configured per-workflow / per-phase budget cap. Works offline | `project_root` |
+| `animus.budget.set` | Set or clear the fleet daily spend cap (admin). Wraps `daemon config --max-daily-usd`; hot-reloaded by the running daemon | `max_daily_usd`, `clear`, `project_root` |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the silent-failure where a latched fleet daily spend cap pauses dispatch but daemon_health / daemon_status still report healthy:true. The cap state previously lived only in cost summary; it is now visible everywhere an operator or agent checks daemon health, and there are read/set MCP tools for the fleet budget. Enforcement itself is unchanged — only read + visibility were missing. Implements TASK-232 (REQUIREMENT-027), and completes the TASK-211 degraded/last_error surface for the daily cap.

## Scope 1 — visibility

- New cost::budget_report module: a daily_cap rollup (cap, rolling-24h spend, remaining, exceeded, dispatch_paused) plus a one-line dispatch-paused reason, and a full budget report (fleet cap + configured per-workflow / per-phase caps).
- dispatch_paused mirrors the daemon's real dispatch gate: it honors the ANIMUS_DAEMON_DISABLE_BUDGET_ENFORCEMENT kill-switch, read from the daemon's PERSISTED sweep status so a CLI/MCP reader running in a different process than the daemon still sees the daemon's true posture (not its own env).
- Live daemon health (control_routing) folds a latched cap into degraded_reasons + last_error, flipping the wire status Healthy to Degraded.
- MCP daemon_health / daemon_status and their CLI commands overlay budget_enforcement (with daily_cap); the offline health path also overlays last_error / degraded_reasons, and status surfaces dispatch_paused / daily_cap_exceeded.
- Human daemon health output prints the daily cap line and a PAUSED banner.

## Scope 2 — budget read/set MCP

- animus.budget.get: fleet max_daily_usd + rolling spend + remaining + exceeded + dispatch_paused + configured per-workflow/phase caps (works offline).
- animus.budget.set (admin): wraps daemon config --max-daily-usd. {max_daily_usd} sets the cap; {clear:true} uncaps (persists an explicit 0 override). Rejects empty / conflicting input.
- max_daily_usd added to the daemon config-set MCP input for parity with the existing CLI flag.

## Docs

- docs/reference/mcp-tools.md: Cost and Budget table now lists budget.get / budget.set, config-set gains max_daily_usd, built-in tool count 91 to 93.
- docs/guides/agents.md family table + count, docs/index.md, docs/guides/index.md counts updated.

## Verification

- cargo build, clippy (all-targets, clean), fmt: pass on orchestrator-cli.
- cargo test -p orchestrator-cli: 1256 pass. The only 2 failures (decision_gate::workflow_on_verdict_routing_blocks_resume_advance, workflow_yaml_phase_definition_with_decision_contract_blocks) are pre-existing on release/0.7 (confirmed failing with these changes stashed) and are unrelated to this work.
- New tests: budget_report daily-cap reason / report / kill-switch / persisted-status-override, budget set arg builder, and daemon-health overlay visibility (latched cap surfaces daily_cap + last_error + degraded_reasons; existing wire last_error is not clobbered).
- Codex review (model_reasoning_effort=high): no findings after iterating; two P2/P3 findings from earlier rounds (kill-switch honoring, docs family table) fixed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
