### PR TITLE
Fix queue lease to spawn drop: strip kind prefix from queued task/requirement ids (TASK-245)

### DIFF
--- a/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/build_runner_command_from_dispatch.rs
@@ -40,10 +40,10 @@ pub fn build_runner_command_with_resume(
     if let Some(subject) = dispatch.subject.as_ref() {
         match subject.to_workflow_subject() {
             protocol::orchestrator::WorkflowSubject::Task { id } => {
-                cmd.arg("--task-id").arg(id);
+                cmd.arg("--task-id").arg(strip_leading_kind_prefix(&id, subject.kind()));
             }
             protocol::orchestrator::WorkflowSubject::Requirement { id } => {
-                cmd.arg("--requirement-id").arg(id);
+                cmd.arg("--requirement-id").arg(strip_leading_kind_prefix(&id, subject.kind()));
             }
             protocol::orchestrator::WorkflowSubject::Custom { title, description } => {
                 // `to_workflow_subject()` collapses every non-task/requirement kind
@@ -107,6 +107,47 @@ pub fn build_runner_command_with_resume(
         }
     }
     cmd
+}
+
+/// Strip a redundant leading `<kind>:` prefix from a task/requirement id so the
+/// workflow runner receives the BARE id its kind-implicit `--task-id` /
+/// `--requirement-id` selectors expect.
+///
+/// Manual `queue enqueue` (and any other SubjectRouter-resolved dispatch)
+/// records the subject id in its kind-qualified form (`task:TASK-244`) — the
+/// canonical shape a consolidated BaaS backend returns. The subject backend
+/// itself, however, stores the row under the BARE id (`TASK-244`), and the
+/// runner's `--task-id` / `--requirement-id` selectors are kind-implicit: the
+/// runner infers the kind from the flag, then resolves the value via
+/// `<kind>/get`. Passing the qualified id straight through makes that lookup
+/// miss (or double-prefix to `task:task:TASK-244`), so a FRESH queue-leased
+/// dispatch fails subject resolution before it can build a run — the daemon
+/// leases the entry, the runner fails to spawn a run, and no journal_run is ever
+/// created (the lease→spawn drop). A bare manual/direct dispatch already carries
+/// the bare id and works, which is exactly the behaviour we restore here.
+///
+/// The id may be qualified with either the subject's full native kind
+/// (`animus.task:TASK-1`) or its short, user-facing alias — the trailing dotted
+/// segment (`task:TASK-1`, which is what a router-resolved `queue enqueue`
+/// records). Both denote the same kind, so a leading `<prefix>:` is stripped
+/// when `<prefix>` case-insensitively equals the subject's `kind` OR that kind's
+/// last dotted segment. A bare id (no prefix) or an unrelated `foo:` prefix (a
+/// genuine colon in a local id) passes through unchanged. Generic dynamic-kind
+/// subjects never reach this helper — they travel via `--subject-id` (kept
+/// kind-qualified) instead.
+fn strip_leading_kind_prefix<'a>(id: &'a str, kind: &str) -> &'a str {
+    let Some((prefix, rest)) = id.split_once(':') else {
+        return id;
+    };
+    if rest.is_empty() {
+        return id;
+    }
+    let short = kind.rsplit('.').next().unwrap_or(kind);
+    if prefix.eq_ignore_ascii_case(kind) || prefix.eq_ignore_ascii_case(short) {
+        rest
+    } else {
+        id
+    }
 }
 
 #[cfg(test)]
@@ -548,6 +589,91 @@ mod tests {
                 "/tmp/project",
             ]
         );
+    }
+
+    #[test]
+    fn runner_command_strips_kind_prefix_from_queue_leased_task_id() {
+        use chrono::Utc;
+        use protocol::orchestrator::SubjectRef;
+        // Reproduces the rc.5 queue lease→spawn drop: a manual `queue enqueue`
+        // records the subject id kind-qualified (`task:TASK-244`), but the
+        // subject backend stores the row under the BARE id and the runner's
+        // kind-implicit `--task-id` resolves via `task/get`. The daemon must
+        // pass the BARE id so the FRESH runner resolves the subject and builds a
+        // run, instead of missing the lookup and dropping the leased entry with
+        // no journal_run.
+        let dispatch = SubjectDispatch::for_subject_with_metadata(
+            SubjectRef::task("task:TASK-244"),
+            "run-task",
+            "queue",
+            Utc::now(),
+        );
+        let command = build_runner_command_from_dispatch(&dispatch, "/tmp/project");
+        let args = command.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec!["execute", "--task-id", "TASK-244", "--workflow-ref", "run-task", "--project-root", "/tmp/project",]
+        );
+    }
+
+    #[test]
+    fn runner_command_strips_kind_prefix_from_queue_leased_requirement_id() {
+        use chrono::Utc;
+        use protocol::orchestrator::SubjectRef;
+        let dispatch = SubjectDispatch::for_subject_with_metadata(
+            SubjectRef::requirement("requirement:REQUIREMENT-024"),
+            "run-requirement",
+            "queue",
+            Utc::now(),
+        );
+        let command = build_runner_command_from_dispatch(&dispatch, "/tmp/project");
+        let args = command.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "execute",
+                "--requirement-id",
+                "REQUIREMENT-024",
+                "--workflow-ref",
+                "run-requirement",
+                "--project-root",
+                "/tmp/project",
+            ]
+        );
+    }
+
+    #[test]
+    fn runner_command_leaves_bare_task_id_unchanged() {
+        // A bare manual/direct dispatch (the shape that already worked) must be
+        // byte-identical after the normalization: no prefix to strip.
+        let dispatch = SubjectDispatch::for_task("TASK-777", "run-task");
+        let command = build_runner_command_from_dispatch(&dispatch, "/tmp/project");
+        let args = command.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec!["execute", "--task-id", "TASK-777", "--workflow-ref", "run-task", "--project-root", "/tmp/project"]
+        );
+    }
+
+    #[test]
+    fn strip_leading_kind_prefix_only_strips_matching_kind() {
+        use super::strip_leading_kind_prefix;
+        // Short-alias prefix stripped against the native kind (the real portal
+        // shape: kind `animus.task`, id `task:TASK-244`).
+        assert_eq!(strip_leading_kind_prefix("task:TASK-244", "animus.task"), "TASK-244");
+        assert_eq!(strip_leading_kind_prefix("requirement:REQUIREMENT-1", "animus.requirement"), "REQUIREMENT-1");
+        // Full native-kind prefix is also stripped.
+        assert_eq!(strip_leading_kind_prefix("animus.task:TASK-244", "animus.task"), "TASK-244");
+        // Case-insensitive.
+        assert_eq!(strip_leading_kind_prefix("TASK:TASK-244", "animus.task"), "TASK-244");
+        // Matching a kind with no dotted segment (bare kind == short).
+        assert_eq!(strip_leading_kind_prefix("task:TASK-244", "task"), "TASK-244");
+        // Bare id (no prefix) passes through.
+        assert_eq!(strip_leading_kind_prefix("TASK-244", "animus.task"), "TASK-244");
+        // Unrelated prefix is preserved (neither the kind nor its short form).
+        assert_eq!(strip_leading_kind_prefix("other:TASK-244", "animus.task"), "other:TASK-244");
+        // A trailing-empty value is left intact rather than yielding an empty id.
+        assert_eq!(strip_leading_kind_prefix("task:", "animus.task"), "task:");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the #1 portal blocker: an enqueued task is leased by the daemon but no journal_run is ever created, so no workflow executes on the consolidated BaaS portal (manual OR autonomous dispatch). Verified live on rc.5.

## Root cause (verified live + confirmed against the runner source)

A router-resolved  records the subject id in its kind-qualified form () — the canonical shape a BaaS backend returns. The daemon passed that value straight through to the workflow runner via .

The runner treats  VERBATIM:  then resolves it via . But the subject backend stores the row under the BARE id (), so  misses. A FRESH queue-leased dispatch therefore fails subject resolution before it can build a run — the daemon leases the entry, the runner spawns, fails to resolve, and no journal_run is created (the lease to spawn drop).

Why only the queue path broke:
- Direct dispatch already carried a bare id () and worked.
- Dynamic-kind dispatch already worked because  splits  and resolves the bare id under the parsed kind.
- Only  /  (kind-implicit selectors) received the qualified value verbatim.

Live evidence (portal DB): every queue-leased Task entry (TASK-244, TASK-246, and an earlier transcript enqueue) reached  with a lease-assigned , but zero matching  rows. Direct  created a  (bare id) and reached .

## Fix

Normalize the id in  for the Task and Requirement arms via a new  helper: strip a leading  when  case-insensitively equals the subject kind () or its short last-dotted-segment form (). Bare ids and unrelated prefixes pass through unchanged; dynamic kinds still travel via  (kept qualified).

## Scope / coordination

Scoped strictly to the spawn/dispatch call site. Does NOT touch the  or tick reconciliation legs — those in-tree-store reads are TASK-218 (separate PR, different code path: ). No overlap.

## Tests

- New unit coverage: qualified (), native-qualified (), and bare task/requirement ids; requirement variant; and direct  cases.
- 
running 14 tests
test dispatch::build_runner_command_from_dispatch::tests::plugin_workflow_runner_binary_name_uses_default_suffix ... ok
test dispatch::build_runner_command_from_dispatch::tests::strip_leading_kind_prefix_only_strips_matching_kind ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_emits_subject_id_for_generic_baas_kind ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_strips_kind_prefix_from_queue_leased_requirement_id ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_strips_kind_prefix_from_queue_leased_task_id ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_leaves_bare_task_id_unchanged ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_clears_actor_env_for_global_dispatch ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_qualifies_bare_generic_subject_id_with_kind ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_uses_subject_workflow_ref_and_input_from_dispatch ... ok
test dispatch::build_runner_command_from_dispatch::tests::runner_command_relays_actor_env_for_owner_scoped_dispatch ... ok
test dispatch::build_runner_command_from_dispatch::tests::resolve_prefers_plugin_binary_in_plugin_install_dir ... ok
test dispatch::build_runner_command_from_dispatch::tests::resolve_falls_back_to_legacy_on_path_when_no_sibling ... ok
test dispatch::build_runner_command_from_dispatch::tests::resolve_picks_new_binary_when_both_exist_alongside_current_exe ... ok
test dispatch::build_runner_command_from_dispatch::tests::resolve_falls_back_to_legacy_when_new_missing ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 284 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s passes (14/14). Pre-existing, unrelated fixture failures elsewhere in the crate ( in schedule/trigger/preflight tests) reproduce identically on the clean base.
- fmt + clippy clean on the touched crate.
- Codex  review (high reasoning): no P1/P2 findings; its exploration of the runner source confirmed  is consumed verbatim.

## Follow-up (not in this PR)

Secondary hardening worth a separate task: when a queue-leased spawn ultimately fails, the completion reconciliation currently maps it toward ; it should surface a failed/pending outcome instead of silently completing the entry.