### PR TITLE
Deprecate --task-id/--requirement-id on dispatch in favor of --subject-id

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/queue_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/queue_types.rs
@@ -31,14 +31,14 @@ pub(crate) struct QueueEnqueueArgs {
         long,
         value_name = "TASK_ID",
         group = "subject",
-        help = "Task subject to enqueue (e.g. TASK-001). Mutually exclusive with --requirement-id / --title."
+        help = "Task subject to enqueue (e.g. TASK-001). Mutually exclusive with --requirement-id / --title. [DEPRECATED: use --subject-id task:<id>; --subject-id is the single dispatch selector]"
     )]
     pub(crate) task_id: Option<String>,
     #[arg(
         long,
         value_name = "REQ_ID",
         group = "subject",
-        help = "Requirement subject to enqueue (e.g. REQ-042). Mutually exclusive with --task-id / --title."
+        help = "Requirement subject to enqueue (e.g. REQ-042). Mutually exclusive with --task-id / --title. [DEPRECATED: use --subject-id requirement:<id>; --subject-id is the single dispatch selector]"
     )]
     pub(crate) requirement_id: Option<String>,
     #[arg(

--- a/crates/orchestrator-cli/src/cli_types/workflow_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/workflow_types.rs
@@ -280,10 +280,15 @@ pub(crate) struct WorkflowRunArgs {
         long,
         value_name = "TASK_ID",
         group = "subject",
-        help = "Task to run the workflow for. Accepts a bare id (TASK-001) or the qualified form (task:TASK-001)."
+        help = "Task to run the workflow for. Accepts a bare id (TASK-001) or the qualified form (task:TASK-001). [DEPRECATED: use --subject-id task:<id>; --subject-id is the single dispatch selector]"
     )]
     pub(crate) task_id: Option<String>,
-    #[arg(long, value_name = "REQ_ID", group = "subject", help = "Requirement id to run the workflow for.")]
+    #[arg(
+        long,
+        value_name = "REQ_ID",
+        group = "subject",
+        help = "Requirement id to run the workflow for. [DEPRECATED: use --subject-id requirement:<id>; --subject-id is the single dispatch selector]"
+    )]
     pub(crate) requirement_id: Option<String>,
     #[arg(long, value_name = "TITLE", group = "subject", help = "Custom workflow title for freeform execution.")]
     pub(crate) title: Option<String>,

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
@@ -2,8 +2,15 @@ use super::*;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct QueueEnqueueInput {
+    /// DEPRECATED: use `subject_id` instead (a task is `task:TASK-001`);
+    /// `subject_id` is the single dispatch selector. Still accepted and resolves
+    /// exactly as before, but will be removed in a future release.
     #[serde(default)]
     pub(super) task_id: Option<String>,
+    /// DEPRECATED: use `subject_id` instead (a requirement is
+    /// `requirement:REQ-042`); `subject_id` is the single dispatch selector.
+    /// Still accepted and resolves exactly as before, but will be removed in a
+    /// future release.
     #[serde(default)]
     pub(super) requirement_id: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
@@ -22,7 +22,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.queue.enqueue",
-        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using a task, requirement, custom, or arbitrary-kind subject plus optional workflow/input override. Prerequisites: Subjects must exist; custom subjects require a title. For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post/etc.), pass subject_id (the kernel resolves the kind) instead of task_id. Example: {\"task_id\": \"TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
+        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using a subject (any kind) plus optional workflow/input override. Prerequisites: Subjects must exist; custom subjects require a title. subject_id is the canonical single dispatch selector for every kind: a task is subject_id: \"task:TASK-001\", a requirement is subject_id: \"requirement:REQ-042\", a BaaS dynamic kind is subject_id: \"blog:BLOG-001\". DEPRECATED: task_id / requirement_id are still accepted (unchanged behavior) but will be removed in a future release; prefer subject_id. Example: {\"subject_id\": \"task:TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
         input_schema = ao_schema_for_type::<QueueEnqueueInput>()
     )]
     async fn ao_queue_enqueue(&self, params: Parameters<QueueEnqueueInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
@@ -26,8 +26,15 @@ pub(super) struct WorkflowListInput {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct WorkflowRunInput {
+    /// DEPRECATED: use `subject_id` instead (a task is `task:TASK-001`);
+    /// `subject_id` is the single dispatch selector. Still accepted and resolves
+    /// exactly as before, but will be removed in a future release.
     #[serde(default)]
     pub(super) task_id: Option<String>,
+    /// DEPRECATED: use `subject_id` instead (a requirement is
+    /// `requirement:REQ-042`); `subject_id` is the single dispatch selector.
+    /// Still accepted and resolves exactly as before, but will be removed in a
+    /// future release.
     #[serde(default)]
     pub(super) requirement_id: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
@@ -20,7 +20,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.workflow.run",
-        description = "Run a workflow for a subject. Purpose: Execute a workflow to complete subject phases automatically. Prerequisites: Subject should exist. For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post/etc.), pass subject_id (the kernel resolves the kind) instead of task_id. Example: {\"task_id\": \"TASK-001\"} or {\"subject_id\": \"blog:BLOG-001\"} or {\"subject_id\": \"blog:BLOG-001\", \"workflow_ref\": \"draft-post\"}. Sequencing: Use animus.subject.status to track progress, animus.workflow.get to monitor, and animus.workflow.pause/resume/cancel for control.",
+        description = "Run a workflow for a subject. Purpose: Execute a workflow to complete subject phases automatically. Prerequisites: Subject should exist. subject_id is the canonical single dispatch selector for every kind: a task is subject_id: \"task:TASK-001\", a requirement is subject_id: \"requirement:REQ-042\", a BaaS dynamic kind is subject_id: \"blog:BLOG-001\". DEPRECATED: task_id / requirement_id are still accepted (unchanged behavior) but will be removed in a future release; prefer subject_id. Example: {\"subject_id\": \"task:TASK-001\"} or {\"subject_id\": \"blog:BLOG-001\", \"workflow_ref\": \"draft-post\"}. Sequencing: Use animus.subject.status to track progress, animus.workflow.get to monitor, and animus.workflow.pause/resume/cancel for control.",
         input_schema = ao_schema_for_type::<WorkflowRunInput>()
     )]
     async fn ao_workflow_run(&self, params: Parameters<WorkflowRunInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -9,7 +9,9 @@ use orchestrator_core::{load_workflow_config_or_default, services::ServiceHub};
 use protocol::{SubjectDispatch, SubjectDispatchExt};
 
 use super::ops_workflow::resolve_requirement_workflow_ref;
-use super::subject_id_dispatch::{resolve_subject_id_ref, subject_ref_for_kind, RouterSubjectProbe, SubjectKindProbe};
+use super::subject_id_dispatch::{
+    deprecated_subject_flag_warning, resolve_subject_id_ref, subject_ref_for_kind, RouterSubjectProbe, SubjectKindProbe,
+};
 use crate::{invalid_input_error, print_ok, print_value, CliError, CliErrorKind, QueueCommand, QueueSubjectArgs};
 
 /// Build a genuinely subjectless (ad-hoc) dispatch with NO bound subject.
@@ -221,6 +223,26 @@ pub(crate) async fn handle_queue(
             Ok(())
         }
         QueueCommand::Enqueue(args) => {
+            // Deprecation notice (behavior unchanged): the legacy `--task-id` /
+            // `--requirement-id` selectors still resolve exactly as before, but
+            // `--subject-id <kind>:<id>` is now the canonical single dispatch
+            // selector. Only warn when the deprecated flag is the actual
+            // selector (i.e. `--subject-id` was not also passed). Suppressed in
+            // `--json` mode: the error/ok envelope is emitted to stderr too, so
+            // a bare warning line would corrupt the `animus.cli.v1` stream that
+            // scripted/MCP callers parse (the MCP tool schema already documents
+            // the deprecation).
+            if !json && args.subject_id.is_none() {
+                // Pass the raw selector value: the helper qualifies it with the
+                // same rule the dispatch uses, so an already-qualified id is
+                // preserved and the hint never names a different subject.
+                if let Some(id) = args.task_id.as_deref() {
+                    eprintln!("{}", deprecated_subject_flag_warning("--task-id", "task", id));
+                }
+                if let Some(id) = args.requirement_id.as_deref() {
+                    eprintln!("{}", deprecated_subject_flag_warning("--requirement-id", "requirement", id));
+                }
+            }
             let mut input = args.input_json.clone().map(|value| serde_json::from_str(&value)).transpose()?;
             inject_conversation_id_from_env(&mut input);
             let dispatch = if let Some(subject_id) = args.subject_id.clone() {

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -469,6 +469,27 @@ pub(crate) async fn handle_workflow(
             // so normalize at the CLI boundary. Only the `task:` qualifier is
             // stripped so a foreign-kind qualifier is not silently rewritten.
             args.task_id = args.task_id.map(|id| crate::bare_task_id(&id));
+            // Deprecation notice (behavior unchanged): the legacy `--task-id` /
+            // `--requirement-id` selectors still resolve exactly as before, but
+            // `--subject-id <kind>:<id>` is now the canonical single dispatch
+            // selector. Only warn when the deprecated flag is the actual
+            // selector (i.e. `--subject-id` was not also passed). Suppressed in
+            // `--json` mode: the error/ok envelope is emitted to stderr too, so
+            // a bare warning line would corrupt the `animus.cli.v1` stream that
+            // scripted/MCP callers parse (the MCP tool schema already documents
+            // the deprecation).
+            if !json && args.subject_id.is_none() {
+                use super::subject_id_dispatch::deprecated_subject_flag_warning;
+                // `args.task_id` is already bare_task_id-normalized above; the
+                // helper qualifies both selector values with the dispatch's own
+                // rule, so an already-qualified id is preserved verbatim.
+                if let Some(id) = args.task_id.as_deref() {
+                    eprintln!("{}", deprecated_subject_flag_warning("--task-id", "task", id));
+                }
+                if let Some(id) = args.requirement_id.as_deref() {
+                    eprintln!("{}", deprecated_subject_flag_warning("--requirement-id", "requirement", id));
+                }
+            }
             let workflow_ref = args.pipeline.clone();
             // Generic BaaS subject path: resolve the subject's real kind once
             // (qualified prefix or router probe) and build a kind-correct

--- a/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
@@ -45,6 +45,67 @@ pub(crate) fn subject_ref_for_kind(kind: &str, id: impl Into<String>) -> Subject
     }
 }
 
+/// Compute the `--subject-id` value that is EXACTLY equivalent to a legacy
+/// `--<kind>-id <id>` dispatch, or `None` when no direct drop-in exists.
+///
+/// A legacy `--task-id X` / `--requirement-id X` always dispatches under the
+/// built-in `kind`. The generic `--subject-id V` path instead reads the kind
+/// from the prefix before `V`'s first `:`. So the two agree only when:
+/// - `id` is bare (no `:`)                → `--subject-id <kind>:<id>`, or
+/// - `id` is qualified with the SAME kind (`task:TASK-1`) → `--subject-id <id>`.
+///
+/// When `id` carries a FOREIGN qualifier (e.g. `--task-id linear:ENG-9`, which
+/// still resolves under kind `task`), no `--subject-id` value reproduces it
+/// (the prefix would be read as kind `linear`), so this returns `None` and the
+/// caller emits a generic hint rather than a wrong, non-equivalent id.
+fn equivalent_subject_id(kind: &str, id: &str) -> Option<String> {
+    let trimmed = id.trim();
+    match trimmed.split_once(':') {
+        None => Some(format!("{}:{trimmed}", kind.trim())),
+        Some((prefix, _)) if prefix.trim().eq_ignore_ascii_case(kind.trim()) => Some(trimmed.to_string()),
+        Some(_) => None,
+    }
+}
+
+/// Build the one-line deprecation warning emitted to stderr when a dispatch
+/// surface is invoked with a legacy `--task-id` / `--requirement-id` selector
+/// (CLI) or the matching `task_id` / `requirement_id` MCP input. Returns the
+/// message so it stays unit-testable; the caller writes it to stderr.
+///
+/// `flag` is the deprecated selector name (e.g. `--task-id`), `kind` is the
+/// canonical subject kind token (`task` / `requirement`), and `id` is the
+/// selector value the dispatch actually resolves (bare or already qualified).
+/// When an exactly-equivalent `--subject-id` value exists (see
+/// [`equivalent_subject_id`]) the hint names it; for a foreign-qualified id it
+/// falls back to a generic pointer so it never suggests a different subject.
+///
+/// The hint maps the SELECTOR (subject identity): `--task-id TASK-1` and
+/// `--subject-id task:TASK-1` resolve the same subject. It intentionally does
+/// NOT promise identical DEFAULT workflow selection when `--workflow-ref` is
+/// omitted: the legacy `--requirement-id` path defaults via
+/// `resolve_requirement_workflow_ref`, and `workflow run --task-id` for an
+/// in-tree frontend task can pick `ui-ux-standard`, whereas the generic
+/// `--subject-id` path uses the project default. That asymmetry is by design
+/// (see this repo's dispatch KEY INSIGHT: task/requirement resolution is kept
+/// on its own path and is NOT rerouted through `--subject-id`), so a caller
+/// that relies on a non-default workflow should pass `--workflow-ref`.
+// TODO(codex-p2): the default workflow_ref for a bare `--subject-id` migration
+// can differ from the legacy requirement/frontend-task defaulting; equalizing
+// it would require rerouting those paths, which the task scope forbids.
+pub(crate) fn deprecated_subject_flag_warning(flag: &str, kind: &str, id: &str) -> String {
+    match equivalent_subject_id(kind, id) {
+        Some(subject_id) => format!(
+            "warning: {flag} is deprecated and will be removed in a future release; \
+             use --subject-id {subject_id} instead. \
+             --subject-id is the single dispatch selector."
+        ),
+        None => format!(
+            "warning: {flag} is deprecated and will be removed in a future release; \
+             use --subject-id (the single dispatch selector) instead of {flag}."
+        ),
+    }
+}
+
 /// Abstraction over the subject router used to resolve a bare id's real kind.
 /// Split out as a trait so the resolution logic is unit-testable with a stub
 /// router (no plugin processes spawned).
@@ -195,6 +256,42 @@ mod tests {
         async fn subject_exists(&self, kind: &str, qualified_id: &str) -> Result<bool> {
             Ok(self.existing.get(&(kind.to_string(), qualified_id.to_string())).copied().unwrap_or(false))
         }
+    }
+
+    #[test]
+    fn deprecated_subject_flag_warning_names_flag_and_canonical_form() {
+        let msg = deprecated_subject_flag_warning("--task-id", "task", "TASK-1");
+        assert!(msg.contains("deprecated"), "got: {msg}");
+        assert!(msg.contains("--subject-id task:TASK-1"), "got: {msg}");
+    }
+
+    #[test]
+    fn deprecated_subject_flag_warning_keeps_same_kind_qualifier() {
+        // `--task-id task:TASK-1` is exactly equivalent to `--subject-id
+        // task:TASK-1`, so the hint names it verbatim (no double-prefix).
+        let msg = deprecated_subject_flag_warning("--task-id", "task", "task:TASK-1");
+        assert!(msg.contains("--subject-id task:TASK-1"), "got: {msg}");
+        assert!(!msg.contains("task:task:TASK-1"), "must not double-qualify: {msg}");
+    }
+
+    #[test]
+    fn deprecated_subject_flag_warning_foreign_qualifier_gives_generic_hint() {
+        // `--task-id linear:ENG-9` still dispatches under kind=task, but no
+        // `--subject-id` value reproduces that (the prefix would be read as
+        // kind=linear), so the hint must NOT prescribe a non-equivalent id.
+        let msg = deprecated_subject_flag_warning("--task-id", "task", "linear:ENG-9");
+        assert!(msg.contains("deprecated"), "got: {msg}");
+        assert!(!msg.contains("--subject-id linear:ENG-9"), "must not suggest a foreign-kind id: {msg}");
+        assert!(!msg.contains("--subject-id task:ENG-9"), "must not re-qualify a foreign id: {msg}");
+        assert!(msg.contains("--subject-id"), "still points at the canonical selector: {msg}");
+    }
+
+    #[test]
+    fn equivalent_subject_id_maps_bare_and_same_kind_and_rejects_foreign() {
+        assert_eq!(equivalent_subject_id("task", "TASK-1").as_deref(), Some("task:TASK-1"));
+        assert_eq!(equivalent_subject_id("task", "task:TASK-1").as_deref(), Some("task:TASK-1"));
+        assert_eq!(equivalent_subject_id("requirement", "REQ-42").as_deref(), Some("requirement:REQ-42"));
+        assert_eq!(equivalent_subject_id("task", "linear:ENG-9"), None);
     }
 
     #[test]

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -859,12 +859,24 @@ other subject kind. By default the entry is dispatched as soon as the daemon
 has capacity.
 
 ```bash
-animus queue enqueue --task-id TASK-001
-animus queue enqueue --requirement-id REQ-042 --workflow-ref ops
-animus queue enqueue --title "Investigate flaky test" --description "Fails on CI"
+animus queue enqueue --subject-id task:TASK-001                      # canonical single dispatch selector
+animus queue enqueue --subject-id requirement:REQ-042 --workflow-ref ops
 animus queue enqueue --subject-id blog:BLOG-001                      # BaaS dynamic kind
+animus queue enqueue --title "Investigate flaky test" --description "Fails on CI"
 animus queue enqueue --adhoc --workflow-ref relate                   # subjectless (ad-hoc) run
+
+# DEPRECATED (still works, unchanged behavior; will be removed in a future release):
+animus queue enqueue --task-id TASK-001                              # == --subject-id task:TASK-001
+animus queue enqueue --requirement-id REQ-042                        # == --subject-id requirement:REQ-042
 ```
+
+**`--subject-id` is the canonical single dispatch selector.** The legacy
+`--task-id` / `--requirement-id` selectors are **deprecated**: they still
+accept the same values and resolve identically, but each maps directly onto
+`--subject-id` (`--task-id TASK-001` == `--subject-id task:TASK-001`;
+`--requirement-id REQ-042` == `--subject-id requirement:REQ-042`) and emits a
+one-line deprecation warning to stderr. They will be removed in a future
+release; prefer `--subject-id`.
 
 **Subjectless (ad-hoc) runs (`--adhoc`).** A workflow that finds its own
 target (or needs none) can be dispatched with NO bound subject via `--adhoc`
@@ -1835,8 +1847,8 @@ id never falls through to the `task`-favoring config default. This is what lets
 a workflow `mark-running` command (`animus subject status --id <kind>:<id>
 --status in-progress`) target the right backend without a `task` default.
 
-For subjects of an arbitrary kind (BaaS dynamic kinds like `blog`, `post`),
-`queue enqueue --subject-id` and `workflow run --subject-id` accept a
+On the dispatch surface (`queue enqueue` and `workflow run`), `--subject-id`
+is the **canonical single dispatch selector** for every kind. It accepts a
 qualified id (`blog:BLOG-001`, kind trusted — the recommended form) or a bare
 id (`BLOG-001`, kind resolved by probing installed backends that declare
 concrete kinds; a pure `subject_kind:*` catch-all backend requires the
@@ -1844,6 +1856,14 @@ qualified form). The resolved kind is preserved on the dispatch so the subject
 is leased/run under its real kind (via `<kind>/get`) instead of being coerced
 to `task`. `--subject-id` is mutually exclusive with `--task-id` /
 `--requirement-id` / `--title`.
+
+The `--task-id` / `--requirement-id` selectors on `queue enqueue` and
+`workflow run` are **deprecated** in favor of `--subject-id` (a task is
+`--subject-id task:<id>`, a requirement is `--subject-id requirement:<id>`).
+They still work with unchanged behavior but emit a one-line deprecation
+warning to stderr and will be removed in a future release. (This deprecation
+is scoped to the dispatch surface only: `workflow list --task-id` is a read
+filter and is unaffected.)
 
 ### `animus pack search` (positional query)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -190,7 +190,7 @@ bounded fetch for recent entries, not a live stream.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `animus.workflow.run` | Start a workflow for a subject (async, via daemon). For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post), pass `subject_id` (the kernel resolves the kind) instead of `task_id` | `task_id`, `requirement_id`, `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `project_root` |
+| `animus.workflow.run` | Start a workflow for a subject (async, via daemon). `subject_id` is the canonical single dispatch selector for every kind (a task is `task:TASK-001`, a requirement is `requirement:REQ-042`, a BaaS dynamic kind is `blog:BLOG-001`). DEPRECATED: `task_id` / `requirement_id` are still accepted (unchanged behavior) but will be removed in a future release; prefer `subject_id` | `subject_id`, `task_id` (deprecated), `requirement_id` (deprecated), `title`, `description`, `workflow_ref`, `input_json`, `project_root` |
 | `animus.workflow.run-multiple` | Batch-run workflows for multiple tasks | `runs[]` (each: `task_id`, `workflow_ref`, `input_json`), `on_error`, `project_root` |
 | `animus.workflow.execute` | Execute a workflow synchronously (no daemon) | `task_id`, `workflow_ref`, `phase`, `model`, `tool`, `phase_timeout_secs`, `input_json`, `project_root` |
 | `animus.workflow.get` | Get full workflow state by ID | `id`, `project_root` |
@@ -226,7 +226,7 @@ bounded fetch for recent entries, not a live stream.
 |---|---|---|
 | `animus.queue.list` | List queued subject dispatches | `project_root` |
 | `animus.queue.stats` | Get aggregate queue depth and status counts | `project_root` |
-| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post), pass `subject_id` (qualified `blog:BLOG-001` or bare `BLOG-001`; the kernel resolves the kind) instead of `task_id` | `task_id`, `requirement_id`, `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
+| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). `subject_id` is the canonical single dispatch selector for every kind (a task is `task:TASK-001`, a requirement is `requirement:REQ-042`, a BaaS dynamic kind is `blog:BLOG-001` qualified or `BLOG-001` bare). DEPRECATED: `task_id` / `requirement_id` are still accepted (unchanged behavior) but will be removed in a future release; prefer `subject_id` | `subject_id`, `task_id` (deprecated), `requirement_id` (deprecated), `title`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
 | `animus.queue.reorder` | Set preferred dispatch order | `subject_ids[]`, `project_root` |
 | `animus.queue.hold` | Hold one or more pending subjects from dispatch | `subject_id`, `subject_ids[]`, `project_root` |
 | `animus.queue.release` | Release one or more held subjects for dispatch | `subject_id`, `subject_ids[]`, `project_root` |


### PR DESCRIPTION
## Summary

Deprecates the legacy --task-id / --requirement-id selectors on the DISPATCH surface only (queue enqueue and workflow run), plus the matching task_id / requirement_id MCP tool inputs, in favor of the canonical single dispatch selector --subject-id / subject_id.

This is a deprecation-with-warning change only. Runtime dispatch behavior is unchanged: the deprecated selectors keep working and resolve exactly as before.

## What was deprecated (still works, unchanged behavior)

- CLI: queue enqueue --task-id / --requirement-id and workflow run --task-id / --requirement-id now emit a one-line deprecation warning to stderr pointing at --subject-id task:<id> / --subject-id requirement:<id>.
- clap help text for those flags is marked [DEPRECATED: use --subject-id <kind>:<id>; --subject-id is the single dispatch selector].
- MCP: QueueEnqueueInput.task_id/requirement_id and WorkflowRunInput.task_id/requirement_id JsonSchema doc-comments marked DEPRECATED; the ao_queue_enqueue and ao_workflow_run tool descriptions now present subject_id as the canonical selector.
- Docs updated: docs/reference/cli/index.md and docs/reference/mcp-tools.md.

## Mapping

- task_id  = subject_id "task:<id>"
- requirement_id = subject_id "requirement:<id>"

The shared warning helper suggests the exactly-equivalent --subject-id value for a bare or same-kind id, and falls back to a generic pointer for a foreign-qualified id (e.g. --task-id linear:ENG-9, which still resolves under kind=task) so it never names a different subject.

## What was kept (not touched)

- The existing --task-id / --requirement-id resolution code paths are left intact. Task/requirement dispatch is NOT rerouted through the generic --subject-id path, so frontend-workflow-ref auto-detection, the JSON+task_id control-wire fast path, and requirement workflow-ref resolution are all preserved, keeping behavior identical.
- Not touched: workflow list --task-id (a read filter), workflow execute, workflow run-multiple batch, and subject get/status surfaces.
- The stderr warning is suppressed in --json mode so the animus.cli.v1 stderr envelope stays parseable for scripted and MCP callers (the MCP tool schema already documents the deprecation).

## Note on default workflow selection

The deprecation hint maps the SELECTOR (subject identity). It does not promise identical DEFAULT workflow selection when --workflow-ref is omitted: the legacy requirement path and frontend-task path have their own defaulting, which is intentionally preserved on their own code paths (not rerouted). A caller relying on a non-default workflow should pass --workflow-ref. This is documented in the helper and flagged as an intentional, in-scope-forbidden-to-change asymmetry.

## Verification

- cargo fmt -p orchestrator-cli: clean
- cargo clippy -p orchestrator-cli --all-targets -- -D warnings: clean
- cargo build -p orchestrator-cli: success
- cargo test -p orchestrator-cli --bins: 1320 passed, 0 failed (includes the new deprecated_subject_flag_warning tests)
- codex review --uncommitted (model_reasoning_effort=high): 4 rounds; each surfaced P2s about the migration hint which were addressed (JSON-envelope safety, qualified-id preservation, foreign-qualifier handling); the residual workflow-ref default asymmetry is intentional per the dispatch design and documented.

Pre-existing, unrelated: two plugin_agent_run_e2e tests fail only because the animus-provider-mock testkit binary is not built in this environment.

Generated with Claude Code