### PR TITLE
fix(orchestrator-cli): dynamic-kind subject dispatch - bare native id (no double-prefix) + mark-running root cause

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -472,8 +472,10 @@ pub(crate) async fn handle_workflow(
             let workflow_ref = args.pipeline.clone();
             // Generic BaaS subject path: resolve the subject's real kind once
             // (qualified prefix or router probe) and build a kind-correct
-            // dispatch carrying the resolved SubjectRef (kind=blog,
-            // id=blog:BLOG-001, ...) plus this run's workflow_ref / input / vars.
+            // dispatch carrying the resolved SubjectRef (kind=blog, id=BLOG-001 —
+            // the bare native id the backend keys on; a dynamic kind is NOT
+            // re-qualified, so `subject_key()` stays the clean `blog::BLOG-001`)
+            // plus this run's workflow_ref / input / vars.
             // The runner protocol requires generic (non-task/requirement)
             // subjects to travel as a `subject_dispatch`, so both the sync and
             // detached paths consume this single envelope rather than coercing

--- a/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
@@ -45,13 +45,53 @@ pub(crate) fn subject_ref_for_kind(kind: &str, id: impl Into<String>) -> Subject
     }
 }
 
+/// Build the dispatch [`SubjectRef`] for `kind`, choosing the native-id shape
+/// that keeps [`SubjectRef::subject_key()`] — the queue dedupe / daemon
+/// active-subject key — consistent across dispatch surfaces:
+///
+/// - **Built-in kinds** (`task` / `requirement` / `custom`) key on the bare `id`
+///   field, so `subject_key()` is the id verbatim. The dedicated `--task-id` /
+///   `--requirement-id` enqueue path stores (and therefore keys on) the
+///   QUALIFIED `<kind>:<native>` id, so this path keeps the qualified shape too —
+///   otherwise the same task would enqueue/dispatch under two different keys
+///   (`task:TASK-1` vs `TASK-1`) depending on the flag used, defeating dedupe.
+/// - **Dynamic kinds** key as `<kind>::<id>`, so an already-qualified native
+///   double-prefixes (`transcript::transcript:TRANSCRIPT-001`). Store the BARE
+///   native id so the key is the clean `<kind>::<native>` and the payload subject
+///   id is the bare native the backend stores.
+///
+/// The built-in vs dynamic distinction is read from `subject_key()` itself
+/// (rather than re-listing the built-in kind constants) so it stays in lockstep
+/// with the protocol's keying rule: a ref built from the qualified id whose
+/// `subject_key()` equals that qualified id keys on the bare `id` field (built-in)
+/// and is kept as-is; anything else is a dynamic kind and is rebuilt bare.
+fn subject_ref_preserving_key(kind: &str, qualified: &str, bare_native: &str) -> SubjectRef {
+    let qualified_ref = subject_ref_for_kind(kind, qualified.to_string());
+    if qualified_ref.subject_key() == qualified {
+        qualified_ref
+    } else {
+        subject_ref_for_kind(kind, bare_native.to_string())
+    }
+}
+
 /// Abstraction over the subject router used to resolve a bare id's real kind.
 /// Split out as a trait so the resolution logic is unit-testable with a stub
 /// router (no plugin processes spawned).
 #[async_trait]
 pub(crate) trait SubjectKindProbe: Send + Sync {
-    /// Concrete kinds to probe for a bare id, in priority order. The `*`
-    /// catch-all is excluded (it is not a concrete kind).
+    /// Concrete kinds to probe for a bare id, in priority order.
+    ///
+    /// The `*` catch-all is deliberately EXCLUDED. It is not a concrete kind:
+    /// resolving a bare id "under" it would build a `SubjectRef` with kind `*`
+    /// (non-dispatchable), and a backend cannot resolve a bare id through the
+    /// catch-all anyway — routing `*/get` fails (`subject '*:<id>' not found` /
+    /// `subject '<kind>:<id>' is not kind '*'`), because the wildcard is not a
+    /// real subject kind the backend serves. A runtime-declared kind that lives
+    /// ONLY behind the catch-all (e.g. `transcript`, created via a portal
+    /// `declare_kind` and absent from the plugin manifest) is therefore not
+    /// enumerable from a bare id; such subjects must be dispatched with a
+    /// qualified `<kind>:<native>` id (which routes `<kind>/get` through the
+    /// catch-all and resolves).
     fn candidate_kinds(&self) -> Vec<String>;
 
     /// `true` when `<kind>/get` resolves a subject for the qualified id.
@@ -77,11 +117,19 @@ pub(crate) async fn resolve_subject_id_ref(subject_id: &str, probe: &dyn Subject
     // typo surfaces as a clean not-found instead of a dangling dispatch.
     if let Some((kind, native)) = trimmed.split_once(':') {
         let kind = kind.trim();
-        if !kind.is_empty() && !native.trim().is_empty() {
+        let native = native.trim();
+        if !kind.is_empty() && !native.is_empty() {
+            // Existence is validated with the QUALIFIED id — the backend keys
+            // subjects as `<kind>:<native>`. The stored SubjectRef shape is then
+            // chosen to keep `subject_key()` consistent: dynamic kinds carry the
+            // bare native id (avoiding the `<kind>::<kind>:<native>` double-prefix
+            // that broke the transcript dispatch), while built-in kinds keep the
+            // qualified id for dedupe parity with the --task-id / --requirement-id
+            // path. See `subject_ref_preserving_key`.
             if !probe.subject_exists(kind, trimmed).await? {
                 return Err(not_found_error(format!("subject '{trimmed}' not found under kind '{kind}'")));
             }
-            return Ok(subject_ref_for_kind(kind, trimmed.to_string()));
+            return Ok(subject_ref_preserving_key(kind, trimmed, native));
         }
     }
 
@@ -94,14 +142,21 @@ pub(crate) async fn resolve_subject_id_ref(subject_id: &str, probe: &dyn Subject
         )));
     }
     for kind in &candidates {
+        // Probe with the QUALIFIED id (backends key subjects `<kind>:<native>`),
+        // then store the shape that keeps `subject_key()` consistent — bare native
+        // for dynamic kinds (no `<kind>::<kind>:<native>` double-prefix), qualified
+        // for built-ins (dedupe parity with the --task-id path). See
+        // `subject_ref_preserving_key`.
         let qualified = crate::qualify_subject_id(trimmed, kind);
         if probe.subject_exists(kind, &qualified).await? {
-            return Ok(subject_ref_for_kind(kind, qualified));
+            return Ok(subject_ref_preserving_key(kind, &qualified, trimmed));
         }
     }
     Err(not_found_error(format!(
         "subject id '{trimmed}' not found under any installed subject kind (probed: {}); \
-         for BaaS dynamic kinds pass a qualified id like '<kind>:{trimmed}' (e.g. 'blog:{trimmed}')",
+         for BaaS dynamic kinds pass a qualified id like '<kind>:{trimmed}' (e.g. 'blog:{trimmed}'). \
+         A runtime-declared kind served only by the '*' catch-all backend (e.g. 'transcript') is not \
+         enumerable from a bare id and MUST be passed qualified.",
         candidates.join(", ")
     )))
 }
@@ -212,7 +267,9 @@ mod tests {
         let probe = StubProbe::new(&["task"], &[("blog", "blog:BLOG-001")]);
         let r = resolve_subject_id_ref("blog:BLOG-001", &probe).await.expect("qualified resolves");
         assert_eq!(r.kind(), "blog");
-        assert_eq!(r.id(), "blog:BLOG-001");
+        // The native id is stored BARE (not the qualified input): the backend
+        // keys on the bare id and `subject_key()` re-qualifies dynamic kinds.
+        assert_eq!(r.id(), "BLOG-001");
     }
 
     #[tokio::test]
@@ -220,7 +277,29 @@ mod tests {
         let probe = StubProbe::new(&[], &[("task", "task:TASK-1")]);
         let r = resolve_subject_id_ref("task:TASK-1", &probe).await.expect("qualified task resolves");
         assert_eq!(r.kind(), SUBJECT_KIND_TASK);
+        // Built-in kinds keep the QUALIFIED id so `subject_key()` matches the
+        // dedicated `--task-id` enqueue path (dedupe parity): a built-in's
+        // subject_key is the bare id field, so it is not double-prefixed.
         assert_eq!(r.id(), "task:TASK-1");
+        assert_eq!(r.subject_key(), "task:TASK-1");
+    }
+
+    #[tokio::test]
+    async fn qualified_dynamic_id_stores_bare_native_id_without_double_prefix() {
+        // Regression: enqueuing `transcript:TRANSCRIPT-001` used to build a
+        // SubjectRef whose id kept the qualified prefix, so `subject_key()`
+        // emitted the double-prefixed `transcript::transcript:TRANSCRIPT-001`
+        // into the queue item + dispatch payload. The ref must carry the bare
+        // native id + kind, yielding the clean queue key `transcript::TRANSCRIPT-001`.
+        let probe = StubProbe::new(
+            &["task", "requirement", "blog", "knowledge"],
+            &[("transcript", "transcript:TRANSCRIPT-001")],
+        );
+        let r =
+            resolve_subject_id_ref("transcript:TRANSCRIPT-001", &probe).await.expect("qualified transcript resolves");
+        assert_eq!(r.kind(), "transcript");
+        assert_eq!(r.id(), "TRANSCRIPT-001");
+        assert_eq!(r.subject_key(), "transcript::TRANSCRIPT-001");
     }
 
     #[tokio::test]
@@ -236,7 +315,10 @@ mod tests {
         let probe = StubProbe::new(&["task", "blog"], &[("blog", "blog:BLOG-001")]);
         let r = resolve_subject_id_ref("BLOG-001", &probe).await.expect("bare blog resolves");
         assert_eq!(r.kind(), "blog");
-        assert_eq!(r.id(), "blog:BLOG-001");
+        // Bare native id: the probe validates the qualified form but the ref
+        // stores the bare id so `subject_key()` does not double-prefix.
+        assert_eq!(r.id(), "BLOG-001");
+        assert_eq!(r.subject_key(), "blog::BLOG-001");
     }
 
     #[tokio::test]
@@ -244,7 +326,29 @@ mod tests {
         let probe = StubProbe::new(&["task", "blog"], &[("task", "task:TASK-9")]);
         let r = resolve_subject_id_ref("TASK-9", &probe).await.expect("bare task resolves");
         assert_eq!(r.kind(), SUBJECT_KIND_TASK);
+        // Built-in: keep the qualified id so `subject_key()` matches the
+        // dedicated `--task-id` path (dedupe parity).
         assert_eq!(r.id(), "task:TASK-9");
+        assert_eq!(r.subject_key(), "task:TASK-9");
+    }
+
+    #[tokio::test]
+    async fn bare_dynamic_id_only_behind_catch_all_is_unresolvable_with_hint() {
+        // A runtime-declared kind served ONLY by the `*` catch-all (e.g.
+        // `transcript`) is NOT in the concrete candidate set (it is absent from
+        // the plugin manifest), and the catch-all cannot resolve a bare id. The
+        // resolver must surface an actionable not-found telling the caller to
+        // pass the qualified form, rather than mis-resolving under `task`.
+        let probe = StubProbe::new(
+            &["task", "requirement", "blog", "knowledge"],
+            &[("transcript", "transcript:TRANSCRIPT-001")],
+        );
+        let err = resolve_subject_id_ref("TRANSCRIPT-001", &probe).await.expect_err("bare catch-all kind unresolvable");
+        let msg = err.to_string();
+        assert!(msg.contains("not found"), "got: {msg}");
+        assert!(msg.contains(":TRANSCRIPT-001"), "hint suggests the qualified `<kind>:<native>` form: {msg}");
+        assert!(msg.contains("catch-all"), "hint explains the catch-all limitation: {msg}");
+        assert_eq!(crate::classify_cli_error_kind(&err), crate::CliErrorKind::NotFound);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the custom/dynamic-kind subject dispatch bug cluster from TASK-256, found live on rc.6 while dispatching the transcript workflow on transcript:TRANSCRIPT-001. Task and requirement dispatch already run end to end; these defects are specific to custom/dynamic kinds dispatched via --subject-id.

## Root causes (with live container evidence)

Bug 1 - double-prefixed subject id. resolve_subject_id_ref, on a qualified kind:native input, kept the qualified value as the SubjectRef native id. SubjectRef::subject_key() re-qualifies a dynamic kind as kind::id, so enqueuing transcript:TRANSCRIPT-001 stored the queue-item subject_id as transcript::transcript:TRANSCRIPT-001 (confirmed in the live queue_item row) and left the payload subject id qualified. The bare-id probe path had the same latent defect (blog::blog:BLOG-1).

Bug 2 - bare-id kind probe cannot see runtime dynamic kinds. The subject router serves the manifest kinds [*, task, requirement, blog, knowledge]; runtime-declared kinds like transcript live only in the backend subject_kind registry and are served via the * catch-all, so they are absent from the probe candidate set. Container tests confirm the catch-all cannot resolve a bare id: routing */get returns "subject '*:TRANSCRIPT-001' not found" and a qualified id under * returns "is not kind '*'". Only concrete kind routing (e.g. transcript/get) resolves. A bare dynamic id therefore cannot be probed and must be passed qualified; including * in the probe would incorrectly resolve the subject to kind * (non-dispatchable). This is now documented on the probe, and the not-found hint says so.

Bug 3 - mark-running fails for custom kinds (PROVEN ROOT CAUSE). The workflow mark-running command is "animus subject status --id {{subject_id}} --status in-progress". The workflow runner renders {{subject_id}} as the BARE native id. animus subject status with a bare id and no --kind then falls back to default_subject_kind = task, so it routes task/status for a transcript and the backend rejects it. Container evidence from the prod volume - the 4 mark-running retry dirs of a prior transcript run each contain:

    (using default kind 'task'; pass --kind or set default_subject_kind ...)
    error: subject call 'task/status' failed (-32602): id 'TRANSCRIPT-001' is a 'transcript' subject, not 'task'

For a task subject the same bare-id + default-task path is coincidentally correct, which is why mark-running works for tasks but fails for every dynamic kind. Running the command directly in the prod container confirms: the clean qualified id (animus subject status --id transcript:TRANSCRIPT-001 --status in-progress) succeeds and exits 0 instantly; the bare id fails as above; the double-prefixed id returns a clean not_found. None of them hang - the ~100s / 0-events reap seen on rc.6 is a separate intermittent runner issue that also hit task runs (several run-task runs were reaped at mark-running with 0 events while a sibling run-task completed with 12 events).

The {{subject_id}} render lives in the out-of-tree workflow runner (animus-workflow-runner-default; phase_command.rs uses context.subject_id). Making mark-running execute for custom kinds requires rendering {{subject_id}} kind-qualified (transcript:TRANSCRIPT-001, which the CLI already resolves correctly - see resolve_kind_for_id and the prod success above) or making the workflow command kind-aware (--kind {{subject_kind}}). This PR makes the dispatched subject id clean (bug 1) so the runner receives a well-formed subject; the render fix is a follow-up in the runner repo.

## Changes (orchestrator-cli)

- resolve_subject_id_ref: store the bare native id for dynamic kinds (clean queue key transcript::TRANSCRIPT-001, bare payload subject id) on both the explicit-kind and bare-probe paths. The backend keys subjects on the bare id (subjects.id = 'BLOG-001', with kind a separate column) and resolves both bare and qualified forms, so this matches the backend's canonical shape; build_runner_command still re-qualifies for the runner, so the runner-facing --subject-id is unchanged.
- New subject_ref_preserving_key helper keeps built-in kinds (task/requirement/custom) on the qualified id so subject_key() stays in parity with the dedicated --task-id / --requirement-id enqueue path (queue dedupe + daemon active-subject exclusion). The built-in vs dynamic split is derived from subject_key() itself, not a duplicated kind list.
- Documented why the bare-id probe excludes the * catch-all and why runtime catch-all kinds must be passed qualified.

## Tests

- qualified + bare dynamic paths assert bare native ids and clean subject keys (transcript::TRANSCRIPT-001, blog::BLOG-001).
- built-in paths assert qualified-id dedupe parity (task:TASK-1, task:TASK-9).
- new regression for the transcript double-prefix and for an unresolvable bare catch-all id.
- cargo test -p orchestrator-cli (1318 tests) green; fmt + clippy clean; codex self-vet run (round-1 P2 on built-in dedupe parity fixed; round-2 P1 about downstream needing qualified ids reviewed and refuted with DB evidence - the backend keys on bare ids and re-qualifies where needed, and its suggested fix would reintroduce the double-prefix).

Refs TASK-256.