### PR TITLE
fix(core): treat unknown provider-plugin tools as MCP-capable (unblocks OAuth/krisp for portal agents)

### DIFF
--- a/crates/orchestrator-cli/src/services/runtime/agent_mcp.rs
+++ b/crates/orchestrator-cli/src/services/runtime/agent_mcp.rs
@@ -888,7 +888,13 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_tool_injects_nothing() {
+    fn unknown_tool_is_treated_as_an_mcp_capable_plugin_provider() {
+        // A tool the kernel does not recognize as a built-in CLI is a provider
+        // PLUGIN (every provider ships out-of-tree now). It must assemble an
+        // MCP-capable contract so the daemon can inject the agent's MCP servers;
+        // here, with no scope selected, that is the baseline `animus` stdio
+        // server. (Previously an unknown tool built no contract at all, which
+        // silently stripped every named MCP server from plugin-provider agents.)
         let tmp = tempfile::tempdir().unwrap();
         let contract = assemble_agent_mcp_contract(
             tmp.path(),
@@ -902,8 +908,13 @@ mod tests {
             false,
             None,
         )
-        .unwrap();
-        assert!(contract.is_none(), "an unknown/unsupported tool must inject no MCP contract");
+        .unwrap()
+        .expect("an unknown tool is a plugin provider and must assemble an MCP-capable contract");
+        assert_eq!(contract.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
+        assert!(
+            contract.pointer("/mcp/stdio/command").and_then(Value::as_str).is_some(),
+            "the baseline animus stdio server must be injected for a plugin-provider agent; got {contract}"
+        );
     }
 
     #[test]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/provider_client.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/provider_client.rs
@@ -956,6 +956,65 @@ agents:
     }
 
     #[test]
+    fn plugin_provider_tool_receives_profile_scoped_mcp_servers_on_the_wire() {
+        // Regression for the OAuth/krisp bridge: a PLUGIN-provider tool (a tool
+        // name the kernel does not recognize as a built-in CLI, e.g. LaunchApp's
+        // `portal`) must still get its `--agent` profile's `mcp_servers` injected
+        // into `extras.mcp_servers`. Before the plugin-provider capability fix,
+        // `build_runtime_contract` returned `None` for such tools, so the whole
+        // contract was skipped and the agent received ZERO daemon-injected MCP
+        // servers (only whatever the provider self-wired).
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let root_str = root.to_string_lossy().into_owned();
+        let bearer_env = "ANIMUS_TEST_PORTAL_WIRE_BEARER";
+        std::env::set_var(bearer_env, "tok-portal-secret");
+        std::fs::create_dir_all(root.join(".animus")).unwrap();
+        std::fs::write(
+            root.join(".animus").join("workflows.yaml"),
+            format!(
+                r#"
+mcp_servers:
+  trading:
+    transport: http
+    url: "https://trading.example.com/mcp"
+    oauth:
+      flow: manual_bearer
+      bearer_env: {bearer_env}
+agents:
+  trader:
+    description: "Trading agent"
+    tool: portal
+    mcp_servers: [trading]
+"#
+            ),
+        )
+        .unwrap();
+
+        let _config_source_seam =
+            orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(&root);
+        let mut args = base_args(&root_str);
+        // A plugin-provider tool name unknown to the kernel's built-in CLI tables.
+        args.tool = "portal".to_string();
+        args.model = Some("z-ai/glm-5.2".to_string());
+        args.agent = Some("trader".to_string());
+        let request = session_request_from_args(&args, &root_str).expect("request builds");
+        std::env::remove_var(bearer_env);
+
+        let servers = request
+            .extras
+            .pointer("/mcp_servers")
+            .and_then(Value::as_object)
+            .expect("a plugin-provider agent's profile servers must ride extras.mcp_servers");
+        let trading = servers.get("trading").expect("the profile-scoped server is in the wire map");
+        let command = trading.get("command").and_then(Value::as_str).expect("proxy stdio entry carries command");
+        assert!(command.contains("animus-mcp-proxy"), "expected the proxy binary; got {command}");
+        assert!(trading.get("url").is_none(), "proxy entry carries no upstream url; got {trading}");
+        let serialized = serde_json::to_string(&request.extras).unwrap();
+        assert!(!serialized.contains("tok-portal-secret"), "resolved bearer must never appear: {serialized}");
+    }
+
+    #[test]
     fn agent_run_without_permission_mode_leaves_request_field_unset() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().canonicalize().unwrap();

--- a/crates/orchestrator-core/src/runtime_contract.rs
+++ b/crates/orchestrator-core/src/runtime_contract.rs
@@ -106,6 +106,28 @@ pub fn cli_capabilities_for_tool(tool: &str) -> Option<CliCapabilities> {
     }
 }
 
+/// Capabilities for a provider tool the kernel does not recognize as a built-in
+/// CLI — i.e. a provider PLUGIN (every provider ships out-of-tree as of
+/// v0.4.12). The plugin session backend spawns the provider process and
+/// advertises `supports_mcp: true` (see `PluginSessionBackend::capabilities`),
+/// so the assembled runtime contract must also mark the tool MCP-capable;
+/// otherwise the daemon skips MCP-server injection entirely and the agent
+/// never receives its profile/skill-declared servers (including OAuth-proxied
+/// ones). The launch-time flags are conservative: the kernel never spawns a
+/// plugin provider via `cli.launch`, so they only inform prompt/context
+/// heuristics.
+fn plugin_provider_capabilities() -> CliCapabilities {
+    CliCapabilities {
+        supports_file_editing: false,
+        supports_streaming: true,
+        supports_tool_use: true,
+        supports_vision: false,
+        supports_long_context: true,
+        max_context_tokens: None,
+        supports_mcp: true,
+    }
+}
+
 fn cli_capabilities_from_tool_config(config: &CliToolConfig) -> CliCapabilities {
     CliCapabilities {
         supports_file_editing: config.supports_file_editing.unwrap_or(false),
@@ -368,14 +390,36 @@ pub fn build_runtime_contract(
     mcp_agent_id: Option<&str>,
 ) -> Option<Value> {
     let normalized = normalized_tool(tool);
-    let launch = build_cli_launch_contract(&normalized, model_id, prompt, resume_plan, command_override)?;
-    let capabilities = cli_capabilities_for_tool(&normalized)?;
+    let launch = build_cli_launch_contract(&normalized, model_id, prompt, resume_plan, command_override);
+    let capabilities = cli_capabilities_for_tool(&normalized);
+
+    // Resolve the CLI shape. A tool the kernel recognizes as a built-in CLI has
+    // BOTH a launch-table entry and a capability-table entry. A tool it does NOT
+    // recognize is a provider PLUGIN: the plugin session backend spawns it and
+    // advertises `supports_mcp`, and the kernel never launches it via
+    // `cli.launch`. Give such a tool a generic MCP-capable capability set with
+    // NO `cli.launch` block so the daemon still assembles a runtime contract and
+    // injects the agent's profile/skill MCP servers. Without this the whole
+    // contract is `None` and a plugin-provider agent (e.g. `tool: portal`)
+    // receives ZERO daemon-injected MCP servers — only whatever the provider
+    // self-wires. Downstream `/cli/launch` mutators are all `if let Some(..)`, so
+    // an absent launch block is safe.
+    let (launch, capabilities) = match (launch, capabilities) {
+        (Some(launch), Some(capabilities)) => (Some(launch), capabilities),
+        // Unknown to both tables → provider plugin. MCP-capable, no cli.launch.
+        (None, None) => (None, plugin_provider_capabilities()),
+        // Known to exactly one table is a partial/non-CLI built-in entry;
+        // preserve the historical "unsupported" (None) result.
+        _ => return None,
+    };
     let enforce_mcp_only = mcp_endpoint.is_some() && capabilities.supports_mcp;
 
     let mut cli = serde_json::Map::new();
     cli.insert("name".to_string(), json!(normalized));
     cli.insert("capabilities".to_string(), json!(capabilities));
-    cli.insert("launch".to_string(), launch);
+    if let Some(launch) = launch {
+        cli.insert("launch".to_string(), launch);
+    }
 
     if let Some(plan) = resume_plan {
         cli.insert(
@@ -466,6 +510,35 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(allowed_prefixes.contains(&"animus."));
         assert!(allowed_prefixes.contains(&"mcp__animus__"));
+    }
+
+    #[test]
+    fn build_runtime_contract_marks_plugin_provider_tool_mcp_capable() {
+        // A provider tool the kernel does not know as a built-in CLI (every
+        // provider ships as a plugin now, e.g. LaunchApp's `portal`) must still
+        // assemble a runtime contract flagged `supports_mcp: true`, so the
+        // daemon injects the agent's profile/skill MCP servers. Regression for
+        // the OAuth/krisp bridge: without this the contract was `None` and the
+        // portal provider received zero daemon-injected MCP servers.
+        let contract = build_runtime_contract("portal", "z-ai/glm-5.2", "hi", None, None, None, None)
+            .expect("plugin-provider runtime contract should build");
+
+        assert_eq!(contract.pointer("/cli/name").and_then(Value::as_str), Some("portal"));
+        assert_eq!(contract.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
+        // The kernel never launches a plugin provider via `cli.launch`; the
+        // block is intentionally absent so downstream launch-arg mutators no-op.
+        assert!(
+            contract.pointer("/cli/launch").is_none(),
+            "plugin-provider contract must omit cli.launch; got {contract}"
+        );
+    }
+
+    #[test]
+    fn build_runtime_contract_still_none_for_partial_builtin_tools() {
+        // `custom`/`cursor`/`cline` have a capability-table entry but no
+        // launch-table entry: they must stay unsupported (None), not fall into
+        // the plugin-provider path.
+        assert!(build_runtime_contract("custom", "m", "hi", None, None, None, None).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the remaining half of TASK-272: OAuth MCP servers (krisp) never reach workflow/agent-run agents running on the **portal** provider. Diagnosed end-to-end on the live Railway portal — the OAuth proxy is fine; the daemon simply never hands krisp to the provider.

## Root cause

 resolves the tool's capabilities and launch spec purely from the **hardcoded built-in tables** ( / ). Both return  for any tool name the kernel doesn't know. Every provider ships out-of-tree now, so a custom provider-plugin tool — LaunchApp's  — hits the  path:

-  → 
-  →  (agent-run path) / the workflow runner's contract build → no 
- so  reads , the daemon **skips all MCP-server injection**, and  on the  is empty.

The portal provider self-injects only its built-in  stdio server, so every profile/skill-declared server (krisp, github, …) is silently dropped. This is inconsistent with , which already advertises .

## Evidence (live portal, Railway)

- Instrumented the deployed provider bundle:  received  only — **krisp absent from the wire request**.
- Ran  with the exact spawn args + the AI-SDK-stripped child env (): it **connects and lists krisp tools** (, , …). So the proxy + device-key token store work; the missing link is upstream — krisp is never injected.

## Fix

An unknown tool is a provider **plugin**. The plugin session backend spawns it and advertises , and the kernel never launches it via . So  now gives an unknown tool a generic MCP-capable capability set with **no  block** (all downstream  mutators are , so an absent block is safe). Known tools and partial built-ins (// — capability entry but no launch entry) keep their **exact** prior results ().

With the fix, a portal agent's krisp (oauth) server is rewritten to the  stdio entry, rides , and the provider bridges it via the (already-working) proxy.

## Tests

-  — unknown tool → , no .
-  —  stays .
-  (agent_mcp) — baseline  stdio injected.
-  (provider_client) — a  agent's OAuth profile server rides the wire as the  stdio entry, with no upstream url and no leaked bearer.
- Full  (403) + runtime-service (274) suites, fmt, and clippy pass. Codex  review (high effort): no findings.

## Deploy / rollout (NOT done here — deploys are sequenced by the maintainer)

- **New ao-cli rc** off this branch → deploy to the portal daemon. Fixes the **agent-run** path (the TASK-272 acceptance test).
- **Repin ** to the new rev + release, then bump its pin in the portal deploy. It  and calls the same , so this is required to fix the **transcript workflow** path.

## Proof note

The live  transcript-fetcher proof can't be shown pre-deploy: the fix is in the Rust daemon, so it requires the new rc to be built and deployed to the portal. The chain is otherwise proven — the wire now carries krisp (integration test) and the proxy lists krisp tools with the real spawn args (live). Once the rc is deployed, re-run  to confirm it LISTS + CALLs a krisp tool.

Part of REQUIREMENT-027 / TASK-272.