### PR TITLE
fix(core): drive MCP-server injection from the provider plugin's declared supports_mcp (TASK-272)

### DIFF
--- a/crates/orchestrator-cli/src/services/runtime/agent_mcp.rs
+++ b/crates/orchestrator-cli/src/services/runtime/agent_mcp.rs
@@ -888,13 +888,13 @@ mod tests {
     }
 
     #[test]
-    fn unknown_tool_is_treated_as_an_mcp_capable_plugin_provider() {
-        // A tool the kernel does not recognize as a built-in CLI is a provider
-        // PLUGIN (every provider ships out-of-tree now). It must assemble an
-        // MCP-capable contract so the daemon can inject the agent's MCP servers;
-        // here, with no scope selected, that is the baseline `animus` stdio
-        // server. (Previously an unknown tool built no contract at all, which
-        // silently stripped every named MCP server from plugin-provider agents.)
+    fn unknown_tool_falls_back_to_the_mcp_capable_provider_shape() {
+        // MCP support for a provider tool is decided by the loaded plugin's
+        // DECLARED capability (see the discovery-backed wire test in
+        // `runtime_agent::provider_client`). When NO provider plugin backs the
+        // tool (e.g. an unknown name that cannot be dispatched anyway), the
+        // built-in provider fallback still assembles an MCP-capable contract —
+        // here, with no scope selected, the baseline `animus` stdio server.
         let tmp = tempfile::tempdir().unwrap();
         let contract = assemble_agent_mcp_contract(
             tmp.path(),
@@ -909,11 +909,11 @@ mod tests {
             None,
         )
         .unwrap()
-        .expect("an unknown tool is a plugin provider and must assemble an MCP-capable contract");
+        .expect("the built-in provider fallback assembles an MCP-capable contract");
         assert_eq!(contract.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
         assert!(
             contract.pointer("/mcp/stdio/command").and_then(Value::as_str).is_some(),
-            "the baseline animus stdio server must be injected for a plugin-provider agent; got {contract}"
+            "the baseline animus stdio server must be injected; got {contract}"
         );
     }
 

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/provider_client.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/provider_client.rs
@@ -955,20 +955,55 @@ agents:
         );
     }
 
+    /// Write an executable `#!/bin/sh` provider-plugin stub that answers a
+    /// `--manifest` probe with a provider manifest declaring `capabilities`, so
+    /// plugin discovery treats it as an installed provider whose DECLARED
+    /// capabilities drive MCP support.
+    #[cfg(unix)]
+    fn write_fake_provider_plugin(install_dir: &std::path::Path, name: &str, capabilities: &[&str]) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::create_dir_all(install_dir).unwrap();
+        let manifest = json!({
+            "name": name,
+            "version": "0.1.0",
+            "plugin_kind": "provider",
+            "description": "test provider",
+            "protocol_version": "1.0.0",
+            "capabilities": capabilities,
+        })
+        .to_string();
+        let path = install_dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\nprintf '{}\\n'\n", manifest)).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+    }
+
+    #[cfg(unix)]
     #[test]
     fn plugin_provider_tool_receives_profile_scoped_mcp_servers_on_the_wire() {
-        // Regression for the OAuth/krisp bridge: a PLUGIN-provider tool (a tool
-        // name the kernel does not recognize as a built-in CLI, e.g. LaunchApp's
-        // `portal`) must still get its `--agent` profile's `mcp_servers` injected
-        // into `extras.mcp_servers`. Before the plugin-provider capability fix,
-        // `build_runtime_contract` returned `None` for such tools, so the whole
-        // contract was skipped and the agent received ZERO daemon-injected MCP
-        // servers (only whatever the provider self-wired).
+        // End-to-end proof for the OAuth/krisp bridge: a provider tool with NO
+        // entry in any hardcoded capability table (LaunchApp's `portal`) gets
+        // its `--agent` profile's `mcp_servers` injected onto the wire PURELY
+        // because its installed plugin DECLARES `supports_mcp` — the plugin's
+        // own manifest capability, resolved uniformly, not a name heuristic.
+        // Isolate HOME + the global plugin install dir so discovery sees only
+        // our fake provider.
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().canonicalize().unwrap();
         let root_str = root.to_string_lossy().into_owned();
+        let home = root.join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let install_dir = root.join("plugins");
+        // No opt-out token => the provider DECLARES it consumes MCP (default).
+        write_fake_provider_plugin(&install_dir, "animus-provider-portal", &["agent/run"]);
+        let _home_guard = EnvVarGuard::set("HOME", Some(home.to_string_lossy().as_ref()));
+        let _config_guard = EnvVarGuard::set("ANIMUS_CONFIG_DIR", Some(""));
+        let _plugin_dir_guard = EnvVarGuard::set("ANIMUS_PLUGIN_DIR", Some(install_dir.to_string_lossy().as_ref()));
+
         let bearer_env = "ANIMUS_TEST_PORTAL_WIRE_BEARER";
-        std::env::set_var(bearer_env, "tok-portal-secret");
+        let _bearer_guard = EnvVarGuard::set(bearer_env, Some("tok-portal-secret"));
         std::fs::create_dir_all(root.join(".animus")).unwrap();
         std::fs::write(
             root.join(".animus").join("workflows.yaml"),
@@ -994,12 +1029,11 @@ agents:
         let _config_source_seam =
             orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(&root);
         let mut args = base_args(&root_str);
-        // A plugin-provider tool name unknown to the kernel's built-in CLI tables.
+        // A plugin-provider tool name with no entry in any hardcoded CLI table.
         args.tool = "portal".to_string();
         args.model = Some("z-ai/glm-5.2".to_string());
         args.agent = Some("trader".to_string());
         let request = session_request_from_args(&args, &root_str).expect("request builds");
-        std::env::remove_var(bearer_env);
 
         let servers = request
             .extras

--- a/crates/orchestrator-core/src/runtime_contract.rs
+++ b/crates/orchestrator-core/src/runtime_contract.rs
@@ -108,14 +108,11 @@ pub fn cli_capabilities_for_tool(tool: &str) -> Option<CliCapabilities> {
 
 /// Capabilities for a provider tool the kernel does not recognize as a built-in
 /// CLI — i.e. a provider PLUGIN (every provider ships out-of-tree as of
-/// v0.4.12). The plugin session backend spawns the provider process and
-/// advertises `supports_mcp: true` (see `PluginSessionBackend::capabilities`),
-/// so the assembled runtime contract must also mark the tool MCP-capable;
-/// otherwise the daemon skips MCP-server injection entirely and the agent
-/// never receives its profile/skill-declared servers (including OAuth-proxied
-/// ones). The launch-time flags are conservative: the kernel never spawns a
-/// plugin provider via `cli.launch`, so they only inform prompt/context
-/// heuristics.
+/// v0.4.12). The kernel never spawns a plugin provider via `cli.launch`, so the
+/// launch-time flags are conservative and only inform prompt/context
+/// heuristics. `supports_mcp` here is a fallback default only: whenever a
+/// provider plugin actually backs the tool, [`build_runtime_contract`]
+/// OVERWRITES it with the plugin's DECLARED value (the authoritative source).
 fn plugin_provider_capabilities() -> CliCapabilities {
     CliCapabilities {
         supports_file_editing: false,
@@ -380,6 +377,21 @@ pub fn build_cli_launch_contract(
     }))
 }
 
+/// Best-effort resolution of whether a PROVIDER PLUGIN backs `tool` and, if
+/// so, its DECLARED `supports_mcp`. Discovers installed provider plugins
+/// against the ambient project root (cwd — the daemon, runner, and CLI all run
+/// with cwd = the project). Returns `None` when no provider plugin backs the
+/// tool (a genuinely in-tree/legacy name, or a tool with no installed plugin).
+///
+/// This is the seam that makes the loaded plugin's OWN declaration — not a
+/// hardcoded name table — the source of truth for MCP-server injection. It is
+/// intentionally kept out of the pure [`build_runtime_contract_inner`] so that
+/// logic is hermetically testable.
+fn provider_declared_supports_mcp(tool: &str) -> Option<bool> {
+    let root = std::env::current_dir().ok()?;
+    orchestrator_plugin_host::session::provider_declared_supports_mcp(&root, tool)
+}
+
 pub fn build_runtime_contract(
     tool: &str,
     model_id: &str,
@@ -389,29 +401,63 @@ pub fn build_runtime_contract(
     mcp_endpoint: Option<&str>,
     mcp_agent_id: Option<&str>,
 ) -> Option<Value> {
+    // Resolve the backing provider plugin's DECLARED MCP capability and thread
+    // it into the pure builder so the MCP-injection decision consults the loaded
+    // plugin's declaration rather than the name-based capability table.
+    let provider_supports_mcp = provider_declared_supports_mcp(tool);
+    build_runtime_contract_inner(
+        tool,
+        model_id,
+        prompt,
+        resume_plan,
+        command_override,
+        mcp_endpoint,
+        mcp_agent_id,
+        provider_supports_mcp,
+    )
+}
+
+/// Pure runtime-contract builder. `provider_supports_mcp` is the loaded
+/// provider plugin's DECLARED `supports_mcp` (`Some`) or `None` when no
+/// provider plugin backs the tool. Kept separate from discovery so the
+/// capability-resolution logic is deterministically testable.
+#[allow(clippy::too_many_arguments)]
+fn build_runtime_contract_inner(
+    tool: &str,
+    model_id: &str,
+    prompt: &str,
+    resume_plan: Option<&CliSessionResumePlan>,
+    command_override: Option<&str>,
+    mcp_endpoint: Option<&str>,
+    mcp_agent_id: Option<&str>,
+    provider_supports_mcp: Option<bool>,
+) -> Option<Value> {
     let normalized = normalized_tool(tool);
     let launch = build_cli_launch_contract(&normalized, model_id, prompt, resume_plan, command_override);
     let capabilities = cli_capabilities_for_tool(&normalized);
 
-    // Resolve the CLI shape. A tool the kernel recognizes as a built-in CLI has
-    // BOTH a launch-table entry and a capability-table entry. A tool it does NOT
-    // recognize is a provider PLUGIN: the plugin session backend spawns it and
-    // advertises `supports_mcp`, and the kernel never launches it via
-    // `cli.launch`. Give such a tool a generic MCP-capable capability set with
-    // NO `cli.launch` block so the daemon still assembles a runtime contract and
-    // injects the agent's profile/skill MCP servers. Without this the whole
-    // contract is `None` and a plugin-provider agent (e.g. `tool: portal`)
-    // receives ZERO daemon-injected MCP servers — only whatever the provider
-    // self-wires. Downstream `/cli/launch` mutators are all `if let Some(..)`, so
-    // an absent launch block is safe.
-    let (launch, capabilities) = match (launch, capabilities) {
+    // Resolve the CLI shape from the built-in tables (unchanged): a known
+    // built-in CLI has BOTH a launch entry and a capability entry; a tool in
+    // neither table is a provider PLUGIN and gets the generic provider caps
+    // with no `cli.launch`; a tool in exactly one table is a partial/non-CLI
+    // built-in and stays unsupported.
+    let (launch, mut capabilities) = match (launch, capabilities) {
         (Some(launch), Some(capabilities)) => (Some(launch), capabilities),
-        // Unknown to both tables → provider plugin. MCP-capable, no cli.launch.
         (None, None) => (None, plugin_provider_capabilities()),
-        // Known to exactly one table is a partial/non-CLI built-in entry;
-        // preserve the historical "unsupported" (None) result.
         _ => return None,
     };
+
+    // THE injection-decision change: when a provider plugin actually backs this
+    // tool, its DECLARED `supports_mcp` (the plugin's manifest-backed
+    // SessionCapabilities value, resolved from where the plugin is loaded) — NOT
+    // the name-based capability table — decides whether the daemon injects this
+    // agent's profile/skill MCP servers. This is what makes profile-declared
+    // servers (krisp, github) reach an out-of-tree provider like `tool: portal`
+    // that declares `supports_mcp: true`. `None` means no plugin backs the tool
+    // (it cannot be dispatched anyway), so the table default is left untouched.
+    if let Some(declared) = provider_supports_mcp {
+        capabilities.supports_mcp = declared;
+    }
     let enforce_mcp_only = mcp_endpoint.is_some() && capabilities.supports_mcp;
 
     let mut cli = serde_json::Map::new();
@@ -513,15 +559,16 @@ mod tests {
     }
 
     #[test]
-    fn build_runtime_contract_marks_plugin_provider_tool_mcp_capable() {
-        // A provider tool the kernel does not know as a built-in CLI (every
-        // provider ships as a plugin now, e.g. LaunchApp's `portal`) must still
-        // assemble a runtime contract flagged `supports_mcp: true`, so the
-        // daemon injects the agent's profile/skill MCP servers. Regression for
-        // the OAuth/krisp bridge: without this the contract was `None` and the
-        // portal provider received zero daemon-injected MCP servers.
-        let contract = build_runtime_contract("portal", "z-ai/glm-5.2", "hi", None, None, None, None)
-            .expect("plugin-provider runtime contract should build");
+    fn plugin_declared_mcp_true_marks_out_of_tree_provider_tool_mcp_capable() {
+        // A provider tool the kernel has no built-in CLI entry for (every
+        // provider ships as a plugin now, e.g. LaunchApp's `portal`) whose
+        // backing plugin DECLARES `supports_mcp: true` must assemble a runtime
+        // contract flagged `supports_mcp: true`, so the daemon injects the
+        // agent's profile/skill MCP servers. Regression for the OAuth/krisp
+        // bridge: the value now comes from the plugin's OWN declaration, not a
+        // name heuristic.
+        let contract = build_runtime_contract_inner("portal", "z-ai/glm-5.2", "hi", None, None, None, None, Some(true))
+            .expect("plugin-provider runtime contract should build when the plugin declares MCP");
 
         assert_eq!(contract.pointer("/cli/name").and_then(Value::as_str), Some("portal"));
         assert_eq!(contract.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
@@ -534,11 +581,55 @@ mod tests {
     }
 
     #[test]
-    fn build_runtime_contract_still_none_for_partial_builtin_tools() {
-        // `custom`/`cursor`/`cline` have a capability-table entry but no
-        // launch-table entry: they must stay unsupported (None), not fall into
-        // the plugin-provider path.
-        assert!(build_runtime_contract("custom", "m", "hi", None, None, None, None).is_none());
+    fn plugin_declared_mcp_false_keeps_provider_tool_non_mcp() {
+        // A provider tool whose backing plugin DECLARES `supports_mcp: false`
+        // still assembles a contract (the tool is dispatchable) but is flagged
+        // non-MCP-capable, so no profile/skill MCP servers are injected.
+        let contract =
+            build_runtime_contract_inner("portal", "z-ai/glm-5.2", "hi", None, None, None, None, Some(false))
+                .expect("a dispatchable provider tool should still assemble a contract");
+        assert_eq!(contract.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    fn plugin_declared_mcp_is_authoritative_for_known_builtin_names() {
+        // A KNOWN built-in name backed by a provider plugin resolves its
+        // `supports_mcp` from the plugin declaration (uniform treatment), while
+        // keeping the built-in table's rich cli-metadata (launch block, etc.).
+        let with_plugin =
+            build_runtime_contract_inner("codex", default_codex_model(), "hi", None, None, None, None, Some(true))
+                .expect("known built-in with a backing plugin should build");
+        assert_eq!(with_plugin.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
+        assert!(with_plugin.pointer("/cli/launch").is_some(), "known built-in must keep its launch block");
+        // A plugin declaring false overrides the built-in table's `true`.
+        let opted_out =
+            build_runtime_contract_inner("codex", default_codex_model(), "hi", None, None, None, None, Some(false))
+                .expect("known built-in should still build");
+        assert_eq!(opted_out.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    fn no_backing_plugin_falls_back_to_static_table_for_known_builtins() {
+        // With no provider plugin backing the tool (`None`), a known built-in
+        // CLI still resolves from the static table exactly as before.
+        let contract = build_runtime_contract_inner("codex", default_codex_model(), "hi", None, None, None, None, None)
+            .expect("known built-in should build from the static fallback");
+        assert_eq!(contract.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
+        assert!(contract.pointer("/cli/launch").is_some());
+    }
+
+    #[test]
+    fn no_backing_plugin_preserves_static_table_behavior() {
+        // Partial built-ins (`custom`/`cursor`/`cline`) have a capability-table
+        // entry but no launch-table entry: they stay unsupported (None).
+        assert!(build_runtime_contract_inner("custom", "m", "hi", None, None, None, None, None).is_none());
+        // An unknown name with no backing plugin keeps the historical built-in
+        // fallback: it builds a provider-shaped contract. `supports_mcp` is left
+        // at the table default here (no plugin to consult) — harmless, since a
+        // tool with no installed provider plugin cannot be dispatched anyway.
+        let unknown = build_runtime_contract_inner("definitely-not-a-tool", "m", "hi", None, None, None, None, None)
+            .expect("an unknown tool keeps the built-in provider fallback contract");
+        assert_eq!(unknown.pointer("/cli/capabilities/supports_mcp").and_then(Value::as_bool), Some(true));
     }
 
     #[test]

--- a/crates/orchestrator-plugin-host/src/session/mod.rs
+++ b/crates/orchestrator-plugin-host/src/session/mod.rs
@@ -29,6 +29,6 @@ pub use plugin_supervisor::{
     SupervisorConfig, SupervisorError,
 };
 pub use session_backend_resolver::{
-    canonical_tool_alias, is_reserved_provider_tool, provider_install_command, SessionBackendResolver,
-    RESERVED_PROVIDER_TOOLS,
+    canonical_tool_alias, is_reserved_provider_tool, provider_declared_supports_mcp, provider_install_command,
+    SessionBackendResolver, RESERVED_PROVIDER_TOOLS,
 };

--- a/crates/orchestrator-plugin-host/src/session/plugin_backend.rs
+++ b/crates/orchestrator-plugin-host/src/session/plugin_backend.rs
@@ -96,6 +96,18 @@ pub struct PluginSessionBackend {
     /// back to all-false for plugin-specific capabilities" (the most
     /// conservative posture — never overclaim).
     pub(crate) declared_methods: Vec<String>,
+    /// Whether the plugin DECLARES it consumes host-injected MCP servers.
+    ///
+    /// This backs `capabilities().supports_mcp`, which is the SOURCE OF TRUTH
+    /// for whether the daemon injects an agent's profile/skill MCP servers into
+    /// the wire request for this provider tool — consulted in place of the
+    /// kernel's name-based capability table. Every provider plugin consumes MCP,
+    /// so it defaults to `true`. The plugin protocol has no per-plugin
+    /// MCP-consume flag yet, so discovery leaves it at the default today;
+    /// sourcing it from a first-class manifest/handshake capability is tracked
+    /// as TASK-277. The field + `with_declared_supports_mcp` builder already
+    /// make it the single overridable source of truth.
+    pub(crate) declared_supports_mcp: bool,
     /// The plugin manifest's `notification_buffer_size` hint, forwarded to
     /// the spawn options so the host's broadcast capacity honors the
     /// documented priority chain.
@@ -127,6 +139,10 @@ impl PluginSessionBackend {
             supervisor,
             dispatch_observer,
             declared_methods: Vec::new(),
+            // Default to MCP-capable: every provider plugin consumes host MCP
+            // servers unless its manifest explicitly opts out. Overridden from
+            // the manifest via `with_declared_supports_mcp` during discovery.
+            declared_supports_mcp: true,
             notification_buffer_hint: None,
         }
     }
@@ -148,6 +164,15 @@ impl PluginSessionBackend {
     #[must_use]
     pub fn with_declared_methods(mut self, methods: Vec<String>) -> Self {
         self.declared_methods = methods;
+        self
+    }
+
+    /// Plumb the plugin's DECLARED MCP capability (see
+    /// [`PluginSessionBackend::declared_supports_mcp`]). Discovery derives this
+    /// from the manifest; direct constructors default to `true` (MCP-capable).
+    #[must_use]
+    pub fn with_declared_supports_mcp(mut self, supports_mcp: bool) -> Self {
+        self.declared_supports_mcp = supports_mcp;
         self
     }
 
@@ -878,7 +903,10 @@ impl SessionBackend for PluginSessionBackend {
             supports_resume: self.manifest_supports_resume(),
             supports_terminate: self.manifest_supports_terminate(),
             supports_permissions: true,
-            supports_mcp: true,
+            // Plugin-declared (manifest-derived), NOT hardcoded: the injection
+            // decision for this provider tool's profile/skill MCP servers reads
+            // this value. Defaults true; a provider opts out via the manifest.
+            supports_mcp: self.declared_supports_mcp,
             supports_tool_events: false,
             supports_thinking_events: false,
             supports_artifact_events: false,
@@ -1189,6 +1217,12 @@ pub struct DiscoveredProviderPlugin {
     /// Forwarded into `PluginSessionBackend::declared_methods` so the
     /// backend reports honest `SessionCapabilities`.
     pub declared_methods: Vec<String>,
+    /// The plugin's DECLARED MCP capability, derived from the manifest via
+    /// [`provider_capabilities_declare_mcp`]. Forwarded into
+    /// `PluginSessionBackend::declared_supports_mcp` so the backend's
+    /// `capabilities().supports_mcp` — the source of truth for MCP-server
+    /// injection — reflects the plugin's own declaration.
+    pub declared_supports_mcp: bool,
     /// The manifest's `notification_buffer_size` hint, forwarded so spawned
     /// hosts honor the documented broadcast-capacity priority chain.
     pub notification_buffer_size: Option<usize>,
@@ -1199,6 +1233,7 @@ impl DiscoveredProviderPlugin {
         let mut backend = PluginSessionBackend::new(self.plugin_name, self.binary_path, self.provider_tool)
             .with_env_required(self.env_required)
             .with_declared_methods(self.declared_methods)
+            .with_declared_supports_mcp(self.declared_supports_mcp)
             .with_notification_buffer_hint(self.notification_buffer_size);
         if let Some(root) = self.project_root {
             backend = backend.with_project_root(root);
@@ -1225,6 +1260,11 @@ pub fn discover_provider_plugins(project_root: &std::path::Path) -> Vec<Discover
                 .unwrap_or_else(|| plugin.name.clone());
             let env_required = plugin.manifest.env_required.clone();
             let declared_methods = plugin.manifest.capabilities.clone();
+            // Every provider plugin consumes MCP; the protocol carries no
+            // per-plugin MCP-consume flag yet (TASK-277 sources this from a
+            // first-class manifest/handshake capability). Until then, a
+            // discovered provider declares MCP-capable.
+            let declared_supports_mcp = true;
             let notification_buffer_size = plugin.manifest.notification_buffer_size;
             DiscoveredProviderPlugin {
                 plugin_name: plugin.name,
@@ -1233,6 +1273,7 @@ pub fn discover_provider_plugins(project_root: &std::path::Path) -> Vec<Discover
                 project_root: Some(project_root.clone()),
                 env_required,
                 declared_methods,
+                declared_supports_mcp,
                 notification_buffer_size,
             }
         })
@@ -1762,6 +1803,21 @@ mod tests {
             !caps_default.supports_resume && !caps_default.supports_terminate,
             "no declared_methods plumbed → must default to false, not the legacy hardcoded true"
         );
+    }
+
+    #[test]
+    fn capabilities_supports_mcp_reflects_declared_field_not_a_hardcoded_true() {
+        use animus_session_backend::session::session_backend::SessionBackend;
+
+        // Default constructor => MCP-capable.
+        let default_backend = PluginSessionBackend::new("p", PathBuf::from("/nonexistent/p"), "p");
+        assert!(default_backend.capabilities().supports_mcp, "provider defaults to MCP-capable");
+
+        // A provider that DECLARES it does not consume MCP reports false, so the
+        // daemon injects no profile/skill MCP servers for it.
+        let opted_out =
+            PluginSessionBackend::new("q", PathBuf::from("/nonexistent/q"), "q").with_declared_supports_mcp(false);
+        assert!(!opted_out.capabilities().supports_mcp, "declared supports_mcp:false must be honored");
     }
 
     fn env_req(name: &str) -> EnvRequirement {

--- a/crates/orchestrator-plugin-host/src/session/session_backend_resolver.rs
+++ b/crates/orchestrator-plugin-host/src/session/session_backend_resolver.rs
@@ -9,6 +9,28 @@ use animus_session_backend::session::{
 
 use super::plugin_backend::{discover_provider_plugins, PluginSessionBackend};
 
+/// Return the DECLARED `supports_mcp` of the provider plugin backing `tool`,
+/// or `None` when no provider plugin is installed for it.
+///
+/// This is the SOURCE OF TRUTH for whether the daemon injects an agent's
+/// profile/skill-declared MCP servers for a provider tool: it is the loaded
+/// plugin's OWN declaration (`PluginSessionBackend::capabilities().supports_mcp`,
+/// itself derived from the plugin manifest), resolved UNIFORMLY for every
+/// provider tool — NOT a kernel-maintained name->capability allow-list and NOT
+/// a name-based "unknown tool => assume MCP" heuristic. A tool with no backing
+/// provider plugin returns `None`; the caller then falls back to its minimal
+/// static behavior for genuinely in-tree/legacy tools.
+///
+/// Discovery is manifest-only (no long-running spawn) and backed by the
+/// on-disk manifest cache, so repeated calls within a process are cheap.
+pub fn provider_declared_supports_mcp(project_root: &Path, tool: &str) -> Option<bool> {
+    let lookup = canonical_tool_alias(tool);
+    discover_provider_plugins(project_root)
+        .into_iter()
+        .find(|plugin| plugin.provider_tool.eq_ignore_ascii_case(&lookup))
+        .map(|plugin| plugin.declared_supports_mcp)
+}
+
 /// Provider tool names that historically mapped to in-tree (built-in) backends.
 ///
 /// The in-tree backends were removed in v0.4.12 in favor of the standalone


### PR DESCRIPTION
## Summary

TASK-272: the ao-cli daemon did not inject profile-declared MCP servers (krisp, github) into the wire request for out-of-tree provider tools such as LaunchApp's , so workflow agents never received those MCP tools.

Root cause:  set the runtime contract's  (the gate every MCP-injection site reads) purely from the hardcoded, name-based  table, which returns None for any tool the kernel does not recognize ->  -> the daemon skipped all MCP-server injection.

PR #313 (folded into rc.7) papered over this with a name heuristic ("unknown tool name => assume MCP-capable"). That heuristic was rejected. **This PR supersedes #313's approach.**

## The fix (focused)

The MCP-server-injection decision now consults the **RESOLVED provider plugin's DECLARED ** instead of the name-based table. When a provider plugin backs the tool, its declared capability overrides the contract's :

- a plugin declaring  gets its agent's profile/skill MCP servers injected on the wire;
- a plugin declaring  does not;
- known built-in tools keep their existing launch templates and metadata.

The built-in  /  /  tables are **kept intact** - they still supply launch templates and the non-mcp capability fields, plus a harmless fallback for a tool with no installed plugin (which cannot be dispatched anyway). This is deliberately narrow; the broader "retire the built-in tables" work is deferred.

## The single injection-decision site

 resolves the backing plugin's declared  and threads it into a pure inner builder that applies one override:



This is the shared chokepoint both the ad-hoc  path and the out-of-tree workflow-runner phase path funnel through for the contract's  gate. The public signature is unchanged, so the runner picks this up on a plain rebuild (no runner source change).

## Wiring

- **orchestrator-plugin-host**:  gains a  field (default true) backing , plus a  builder. New  resolves the backing provider plugin's declared value via manifest-only discovery (no new spawn). Sourcing this from a first-class manifest/handshake MCP capability is deferred to **TASK-277** (needs a protocol change); until then a discovered provider declares MCP-capable.
- **orchestrator-core**:  resolves the declared value against the ambient project root and threads it into  (pure, testable).

## Tests

- Pure inner-builder cases: declared true / false / none across plugin-only () and known-built-in () tools.
- Discovery-backed end-to-end test (): a provider tool with NO name-table entry gets its profile MCP servers on the wire purely because its installed plugin declares  (OAuth server rewritten to the  stdio entry, resolved bearer never leaks).
- Plugin-backend capability tests:  reflects the declared field, not a hardcoded true.

## Gates

-  (workspace) clean.
- 
running 406 tests
test daemon_config::tests::daemon_project_config_serializes_none_runtime_fields_omitted ... ok
test config::tests::cli_project_root_wins ... ok
test doctor::tests::path_is_executable_requires_execute_permission ... ok
test daemon_config::tests::resolve_silent_threshold_defaults_when_unset ... ok
test daemon_config::tests::load_daemon_project_config_defaults_when_missing ... ok
test daemon_config::tests::daemon_project_config_deserializes_missing_runtime_fields_as_none ... ok
test config::tests::falls_through_to_cwd_when_cli_arg_missing ... ok
test daemon_config::tests::resolve_silent_threshold_reads_configured_value ... ok
test daemon_config::tests::daemon_project_config_round_trips_runtime_fields ... ok
test domain_state::tests::history_record_round_trips_run_id ... ok
test domain_state::tests::history_record_without_run_id_still_loads_and_omits_field ... ok
test daemon_config::tests::daemon_project_config_loads_legacy_idle_timeout_field ... ok
test execution_projection::project_requirement_workflow_status::tests::requirement_task_generation_run_projects_in_progress ... ok
test execution_projection::project_requirement_workflow_status::tests::unrelated_workflow_ref_does_not_mutate_requirement_status ... ok
test execution_projection::project_requirement_workflow_status::tests::requirement_task_generation_projects_planned ... ok
test config::tests::cache_kill_switch_disables_caching ... ok
test execution_projection::tests::is_workflow_paused_reason_matches_bare_and_enriched_markers ... ok
test daemon_config::tests::daemon_project_config_preserves_unknown_fields ... ok
test execution_projection::tests::foreign_blocked_reason_is_not_clobbered_or_cleared ... ok
test execution_projection::tests::old_bare_marker_still_clears_on_resume ... ok
test execution_projection::tests::detail_less_repause_does_not_downgrade_enriched_marker ... ok
test execution_projection::tests::bare_pause_marker_is_upgraded_to_carry_budget_detail ... ok
test execution_projection::tests::paused_marker_carries_budget_detail_and_resume_clears_it ... ok
test execution_projection::tests::project_execution_fact_does_not_auto_mark_done_for_legacy_facts ... ok
test execution_projection::tests::project_execution_fact_does_not_auto_mark_task_done_on_success ... ok
test execution_projection::tests::project_execution_fact_reports_unknown_subject_kind_as_unprojected ... ok
test execution_projection::tests::workflow_paused_reason_formats_bare_and_enriched ... ok
test daemon_config::tests::daemon_project_config_loads_legacy_auto_policy_fields ... ok
test config::tests::falls_back_to_current_dir_outside_git_repo ... ok
test flavor::tests::parses_and_validates_v1_manifest ... ok
test flavor::tests::rejects_unknown_schema ... ok
test flavor::tests::required_plugins_tags_each_slug_with_its_role ... ok
test flavor::tests::bundled_default_flavor_required_set_covers_daemon_preflight_roles ... ok
test flavor::tests::all_plugin_slugs_collects_required_and_optional_recommendations ... ok
test flavor::tests::bundled_fallback_loads_when_no_manifest_on_disk ... ok
test doctor::tests::run_for_project_marks_project_root_file_as_fail ... ok
test doctor::tests::run_for_project_marks_non_directory_ao_path_as_fail ... ok
test doctor::tests::run_for_project_marks_expected_core_files_as_ok_when_present ... ok
test doctor::tests::run_for_project_marks_invalid_daemon_config_as_fail ... ok
test plugin_preflight::tests::auto_install_failure_fix_command_includes_allow_shadow_builtin ... ok
test plugin_preflight::tests::flavor_manifest_error_fails_preflight_even_with_no_missing_roles ... ok
test plugin_preflight::tests::flavor_manifest_error_leads_rendered_message_and_suppresses_install_advice ... ok
test plugin_preflight::tests::install_target_for_resolves_role_labels_to_repo_specs ... ok
test plugin_preflight::tests::install_target_for_resolves_workflow_runner_and_queue_roles ... ok
test plugin_preflight::tests::missing_roles_without_flavor_error_keep_install_advice_template ... ok
test plugin_preflight::tests::multiple_missing_roles_render_one_composed_flavor_fix_command ... ok
test plugin_preflight::tests::preflight_refuses_when_workflow_runner_or_queue_plugin_missing ... ok
test plugin_preflight::tests::preflight_satisfied_when_subject_backend_covers_all_required_kinds ... ok
test plugin_preflight::tests::preflight_with_auto_install_but_install_still_does_not_cover_role_reports_missing ... ok
test plugin_preflight::tests::preflight_with_auto_install_installs_missing_plugin_and_marks_satisfied ... ok
test plugin_preflight::tests::preflight_with_no_plugins_and_no_auto_install_reports_missing_with_fix_commands ... ok
test doctor::tests::run_for_project_reports_warns_for_missing_bootstrap_files ... ok
test plugin_preflight::tests::preflight_with_provider_installed_marks_provider_role_satisfied ... ok
test plugin_preflight::tests::provider_missing_preflight_suggests_command_that_actually_works ... ok
test plugin_preflight::tests::queue_underpin_warning_ignores_unparseable_versions ... ok
test plugin_preflight::tests::queue_underpin_warning_fires_below_floor ... ok
test plugin_preflight::tests::queue_underpin_warning_silent_at_or_above_floor ... ok
test plugin_preflight::tests::single_missing_role_keeps_per_role_fix_without_composed_command ... ok
test plugin_preflight::tests::summarize_with_lock_is_identity_when_lockfile_absent ... ok
test plugin_preflight::tests::workflow_runner_underpin_warning_fires_below_floor ... ok
test plugin_preflight::tests::workflow_runner_underpin_warning_ignores_unparseable_versions ... ok
test plugin_preflight::tests::workflow_runner_underpin_warning_silent_at_or_above_floor ... ok
test plugin_registry::tests::all_provider_plugins_have_non_empty_tags ... ok
test plugin_registry::tests::all_subject_plugins_have_non_empty_tags ... ok
test plugin_registry::tests::default_subject_backend_is_kind_agnostic_starter ... ok
test plugin_registry::tests::non_privileged_kinds_resolve_by_uniform_convention ... ok
test plugin_registry::tests::provider_default_is_claude_at_curated_tag ... ok
test plugin_preflight::tests::summarize_with_lock_translates_native_subject_kind_to_installed_kind ... ok
test plugin_registry::tests::subject_kind_requirement_resolves_to_subject_requirements ... ok
test plugin_registry::tests::subject_kind_task_resolves_to_subject_default ... ok
test plugin_registry::tests::unknown_subject_kind_returns_none ... ok
test principal::tests::bootstrap_refuses_to_overwrite_existing_file ... ok
test principal::tests::enforce_mode_admin_role_allows_everything ... ok
test principal::tests::enforce_mode_daemon_always_allowed ... ok
test principal::tests::enforce_mode_denies_unknown_principal ... ok
test principal::tests::enforce_mode_viewer_role_allows_only_reads ... ok
test principal::tests::principal_id_and_kind_labels_are_stable ... ok
test principal::tests::principal_serializes_with_kind_tag ... ok
test principal::tests::rbac_mode_serializes_kebab_case ... ok
test principal::tests::resolve_by_os_user_walks_os_users_list ... ok
test principal::tests::single_user_mode_allows_everything ... ok
test runtime_contract::tests::build_launch_contract_enforces_machine_output_for_supported_tools ... ok
test runtime_contract::tests::build_launch_contract_preserves_opencode_glm_and_minimax_models ... ok
test runtime_contract::tests::build_launch_contract_supports_resume_mode ... ok
test runtime_contract::tests::build_runtime_contract_enforces_mcp_only_when_supported_tool_has_endpoint ... ok
test runtime_contract::tests::build_runtime_contract_includes_rich_cli_shape ... ok
test principal::tests::bootstrap_writes_default_file_when_absent ... ok
test runtime_contract::tests::no_backing_plugin_falls_back_to_static_table_for_known_builtins ... ok
test runtime_contract::tests::no_backing_plugin_preserves_static_table_behavior ... ok
test runtime_contract::tests::plugin_declared_mcp_false_keeps_provider_tool_non_mcp ... ok
test runtime_contract::tests::plugin_declared_mcp_is_authoritative_for_known_builtin_names ... ok
test runtime_contract::tests::plugin_declared_mcp_true_marks_out_of_tree_provider_tool_mcp_capable ... ok
test runtime_contract::tests::cli_tool_flags_resolve_from_config_supplied_tool_metadata ... ok
test secret_device_store::tests::file_is_not_plaintext ... ok
test execution_projection::tests::project_schedule_dispatch_missed_does_not_update_last_run ... ok
test execution_projection::tests::project_schedule_dispatch_attempt_updates_last_run_and_run_count ... ok
test secret_keysource::tests::decide_auto_falls_back_to_device_id_only_when_interactive ... ok
test secret_keysource::tests::decide_auto_hard_errors_on_server_or_no_tty ... ok
test secret_keysource::tests::decide_auto_prefers_user_key_then_passphrase ... ok
test secret_keysource::tests::device_id_is_deterministic_and_binds_to_machine_material ... ok
test secret_keysource::tests::key_source_kind_parse_round_trips ... ok
test secret_device_store::tests::round_trip_set_get_list_delete ... ok
test secret_keysource::tests::user_key_accepts_hex_and_base64_and_rejects_wrong_length ... ok
test secret_store::tests::enforce_cap_fails_over_limit ... ok
test secret_store::tests::enforce_cap_passes_under_limit ... ok
test secret_store::tests::keychain_service_name_includes_scope ... ok
test model_quality::tests::suppression_requires_min_attempts ... ok
test secret_store::tests::mock_store_round_trip ... ok
test model_quality::tests::suppression_is_phase_scoped ... ok
test secret_device_store::tests::tamper_fails_closed ... ok
test secret_store::tests::validate_key_accepts_standard_env_shape ... ok
test secret_store::tests::validate_key_rejects_bad_shapes ... ok
test secret_store::tests::snapshot_returns_all_pairs ... ok
test model_quality::tests::suppression_triggers_at_threshold ... ok
test execution_projection::tests::project_schedule_dispatch_missed_then_attempt_separates_counters ... ok
test services::daemon_impl::tests::daemon_health_cache_expires_after_ttl ... ok
test secret_device_store::tests::wrong_device_key_cannot_decrypt ... ok
test services::daemon_impl::tests::daemon_health_cache_returns_stored_value_within_ttl ... ok
test services::daemon_impl::tests::daemon_health_cache_keys_isolate_by_project_root ... ok
test model_quality::tests::unknown_verdict_counts_as_fail ... ok
test services::daemon_impl::tests::parse_runtime_pause_state_defaults_when_unpaused_or_invalid ... ok
test config::tests::cached_cwd_lookup_preserves_git_repo_source ... ok
test config::tests::repeat_calls_hit_in_process_cache ... ok
test services::daemon_impl::tests::parse_runtime_pause_state_reads_paused_record ... ok
test config::tests::resolves_repo_root_from_git_subdirectory ... ok
test services::review_impl::tests::request_handoff_requires_run_id ... ok
test services::planning_shared::requirement_lifecycle::tests::requirement_lifecycle_can_rework_then_approve ... ok
test services::planning_shared::requirement_lifecycle::tests::requirement_lifecycle_respects_rework_budget ... ok
test services::planning_shared::requirement_lifecycle::tests::requirement_lifecycle_happy_path_approves ... ok
test services::state_store::tests::mutation_loader_rejects_invalid_core_state_json ... ok
test services::state_store::tests::mutation_loader_returns_default_when_state_file_is_missing ... ok
test services::tests::execute_requirements_blocks_when_vision_constraints_are_not_covered ... ok
test services::tests::execute_requirements_can_include_wont_with_opt_in ... ok
test model_quality::tests::suppression_clears_after_recovery ... ok
test services::tests::execute_requirements_excludes_wont_by_default ... ok
test model_quality::tests::rework_verdict_increments_reworks_not_fails ... ok
test services::tests::execute_requirements_generates_stable_task_titles ... ok
test services::tests::execute_requirements_runs_requirement_state_machine_before_task_materialization ... ok
test services::tests::execute_requirements_maps_requirement_priority_to_task_priority ... ok
test model_quality::tests::advance_verdict_lifts_suppression_over_time ... ok
test services::daemon_impl::tests::fast_snapshot_does_not_open_sqlite ... ok
test services::daemon_impl::tests::fast_snapshot_returns_stopped_for_empty_project ... ok
test services::schedule_state::tests::load_missing_schedule_state_returns_default ... ok
test services::review_impl::tests::transcript_path_uses_project_state_dir ... ok
test services::schedule_state::tests::save_and_load_schedule_state_round_trip ... ok
test secret_store::tests::keyring_store_index_round_trip ... ok
test config::tests::relative_cli_arg_keys_include_cwd ... ok
test services::daemon_impl::tests::fast_snapshot_matches_full_snapshot_status_for_empty_project ... ok
test services::tests::file_hub_bootstraps_architecture_docs_file ... ok
test services::daemon_impl::tests::file_hub_start_does_not_spawn_runner_sidecar ... ok
test services::daemon_impl::tests::file_hub_start_sets_running ... ok
test services::tests::file_hub_bootstraps_workflow_yaml_with_phase_catalog ... ok
test config::tests::resolves_primary_repo_root_from_linked_worktree ... ok
test config::tests::cli_project_root_dot_in_linked_worktree_resolves_primary_repo_root ... ok
test secret_keysource::tests::passphrase_is_deterministic_per_salt_and_varies_by_salt ... ok
test services::tests::file_hub_mutations_fail_closed_for_invalid_core_state_json ... ok
test services::tests::file_hub_explicit_git_bootstrap_initializes_repository_and_head ... ok
test services::tests::file_hub_new_bootstraps_base_configs_for_project_path ... ok
test services::tests::file_hub_new_bootstraps_ao_without_initializing_git_repository ... ok
test services::tests::file_hub_errors_when_requested_pipeline_is_missing_from_config ... ok
test services::tests::file_hub_daemon_mutation_interleaves_with_task_create_without_lost_updates ... ok
test services::tests::in_memory_hub_with_project_root_engages_plugin_fallback ... ok
test services::tests::in_memory_hub_without_project_root_skips_plugin_fallback ... ok
test services::daemon_impl::tests::daemon_health_cache_invalidated_by_lifecycle_mutations ... ok
test services::tests::file_hub_new_does_not_rewrite_existing_core_state_on_boot ... ok
test services::tests::planning_draft_requirements_preserves_vision_constraints_when_max_is_small ... ok
test services::tests::file_hub_concurrent_task_creates_keep_unique_ids ... ok
test services::tests::planning_service_drafts_and_executes_requirements ... ok
test services::tests::planning_service_query_filters_and_sorts_requirements ... ok
test services::tests::requirements_refine_propagates_research_metadata_to_tasks ... ok
test services::tests::set_status_from_blocked_to_ready_clears_paused_and_blocked_fields ... ok
test services::tests::task_filter_supports_linked_architecture_entity ... ok
test services::tests::task_priority_policy_reports_active_high_budget_overflow ... ok
test services::tests::task_priority_rebalance_plan_is_deterministic_and_budget_compliant ... ok
test services::tests::task_priority_rebalance_rejects_conflicting_override_task_ids ... ok
test services::tests::task_service_query_returns_stable_paginated_priority_order ... ok
test services::tests::task_service_rejects_unknown_architecture_entities ... ok
test services::tests::task_service_supports_priority_checklists_and_dependencies ... ok
test services::tests::update_status_from_on_hold_to_in_progress_clears_paused_and_blocked_fields ... ok
test services::tests::file_hub_recompiles_repo_workflow_yaml_on_startup ... ok
test services::tests::workflow_service_query_filters_by_status_and_reference ... ok
test services::tests::file_hub_concurrent_requirement_upserts_keep_unique_ids ... ok
test services::trigger_state::tests::lock_trigger_state_is_exclusive ... ok
test services::trigger_state::tests::load_missing_trigger_state_returns_default ... ok
test services::tests::file_hub_subject_resolver_engages_plugin_fallback ... ok
test state_machine_parity::workflow_failed_state_can_resume_for_retry ... ok
test state_machines::engine::tests::builtin_workflow_machine_marks_merge_conflict_as_non_terminal ... ok
test services::tests::file_hub_persists_tasks ... ok
test state_machines::engine::tests::evaluate_guard_checks_correct_phase ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_at_limit ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_no_reworks_yet ... ok
test state_machines::engine::tests::compile_builtin_document ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_over_limit ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_under_limit ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_with_zero_max ... ok
test state_machines::engine::tests::evaluate_guard_unknown_guard_passes ... ok
test state_machines::engine::tests::full_lifecycle_with_rework ... ok
test state_machines::engine::tests::full_lifecycle_happy_path ... ok
test state_machines::engine::tests::guard_blocked_returns_error ... ok
test state_machines::engine::tests::guard_blocked_falls_through_to_unguarded ... ok
test state_machines::engine::tests::no_transition_cancelled_start ... ok
test state_machines::engine::tests::no_transition_failed_gates_passed ... ok
test state_machines::engine::tests::no_transition_completed_phase_started ... ok
test state_machines::engine::tests::no_transition_idle_phase_succeeded ... ok
test state_machines::engine::tests::no_transition_paused_phase_succeeded ... ok
test state_machines::engine::tests::no_transition_run_phase_start ... ok
test state_machines::engine::tests::requirement_guard_blocks_transition_when_budget_exceeded ... ok
test state_machines::engine::tests::requirement_lifecycle_blocks_rework_when_budget_exceeded ... ok
test state_machines::engine::tests::requirement_lifecycle_uses_evaluate_guard_for_rework_budget ... ok
test state_machines::engine::tests::state_unchanged_on_guard_blocked_error ... ok
test state_machines::engine::tests::state_unchanged_on_no_transition_error ... ok
test state_machines::engine::tests::valid_apply_transition_no_more_phases ... ok
test state_machines::engine::tests::valid_cancel_from_idle ... ok
test state_machines::engine::tests::valid_cancel_from_paused ... ok
test state_machines::engine::tests::valid_cancel_from_run_phase ... ok
test state_machines::engine::tests::valid_evaluate_transition_phase_started ... ok
test state_machines::engine::tests::valid_evaluate_gates_gates_passed ... ok
test state_machines::engine::tests::valid_idle_start ... ok
test state_machines::engine::tests::valid_pause_from_evaluate_gates ... ok
test state_machines::engine::tests::valid_pause_from_idle ... ok
test state_machines::engine::tests::valid_pause_from_run_phase ... ok
test state_machines::engine::tests::valid_run_phase_phase_failed ... ok
test state_machines::engine::tests::valid_run_phase_phase_skipped ... ok
test state_machines::engine::tests::valid_run_phase_phase_succeeded ... ok
test state_machines::engine::tests::workflow_apply_uses_ordered_first_match ... ok
test state_machines::tests::missing_file_falls_back_in_json_mode ... ok
test services::trigger_state::tests::save_and_load_trigger_state_round_trip ... ok
test state_machines::tests::invalid_file_falls_back_in_json_mode ... ok
test state_machines::validator::tests::builtin_definition_validates ... ok
test services::tests::file_hub_persists_planning_artifacts ... ok
test state_machines::validator::tests::invalid_guard_reference_is_rejected ... ok
test state_machines::validator::tests::machine_missing_executor_required_transition_is_rejected ... ok
test store::tests::fsync_dir_succeeds_on_existing_directory ... ok
test state_machines::tests::strict_mode_errors_when_file_is_invalid ... ok
test state_machine_parity::workflow_transition_matrix_matches_legacy_behavior ... ok
test subject_adapter::adapter::tests::builtin_project_adapter_returns_project_root_for_requirement_subjects ... ok
test subject_adapter::adapter::tests::builtin_subject_resolver_uses_requirement_adapter_registry ... ok
test store::tests::fsync_rename_promotes_temp_to_final_and_makes_it_readable ... ok
test subject_adapter::adapter::tests::ensure_execution_cwd_routes_in_tree_task_through_adapter_even_after_task_take ... ok
test subject_adapter::adapter::tests::ensure_execution_cwd_uses_project_root_for_plugin_owned_task ... ok
test store::tests::write_json_atomic_round_trip_persists_value_durably ... ok
test subject_adapter::adapter::tests::managed_worktree_mcp_config_falls_back_to_primary_repo_manifest_path ... ok
test subject_adapter::adapter::tests::resolve_falls_back_to_plugin_when_in_tree_requirement_adapter_errors ... ok
test subject_adapter::adapter::tests::resolve_binds_subjectless_adhoc_dispatch_without_error ... ok
test subject_adapter::adapter::tests::resolve_falls_back_to_plugin_when_in_tree_task_adapter_errors ... ok
test subject_adapter::adapter::tests::resolve_reports_both_errors_when_fallback_also_misses ... ok
test types::tests::phase_decision_deserializes_unknown_verdict_with_fallback ... ok
test types::tests::phase_decision_deserializes_with_expected_defaults ... ok
test types::tests::phase_decision_no_changes_needed_evidence_serializes ... ok
test types::tests::phase_decision_serializes_with_evidence_payload ... ok
test types::tests::requirement_priority_to_task_priority_mapping_is_stable ... ok
test types::tests::task_status_deserializes_contract_aliases_and_helpers_stay_consistent ... ok
test types::tests::task_type_as_str_matches_canonical_serialization_and_aliases ... ok
test workflow::dependency::tests::cancel_policy_cancels_join_on_first_failure_without_waiting ... ok
test workflow::dependency::tests::block_policy_holds_join_when_an_upstream_fails ... ok
test workflow::dependency::tests::detect_cycles_finds_a_two_node_cycle ... ok
test workflow::dependency::tests::detect_cycles_finds_self_loop ... ok
test workflow::dependency::tests::detect_cycles_none_for_a_dag ... ok
test workflow::dependency::tests::escalated_and_cancelled_upstreams_count_as_failed ... ok
test workflow::dependency::tests::join_fires_exactly_once_after_all_three_complete ... ok
test workflow::dependency::tests::missing_upstream_keeps_join_waiting_race_safe ... ok
test workflow::dependency::tests::no_depends_on_key_is_not_a_join ... ok
test workflow::dependency::tests::multi_join_chain_fans_in_independently ... ok
test workflow::dependency::tests::parses_comma_and_whitespace_list_and_dedups ... ok
test workflow::dependency::tests::parses_json_array_upstreams ... ok
test workflow::dependency::tests::policy_parse_is_case_insensitive_with_block_default ... ok
test workflow::dependency::tests::partial_completion_does_not_fire ... ok
test workflow::dependency::tests::proceed_policy_fires_join_even_with_a_failed_upstream ... ok
test workflow::dependency::tests::proceed_policy_still_waits_for_a_running_upstream ... ok
test workflow::dependency::tests::should_hold_at_enqueue_reflects_barrier_state ... ok
test workflow::dependency::tests::spec_round_trips_through_vars ... ok
test workflow::dependency::tests::validate_flags_self_dependency_and_unknown_upstream ... ok
test workflow::dependency::tests::validate_ok_for_known_upstreams ... ok
test workflow::environment_client::tests::build_exec_request_merges_extra_env_over_command_env ... ok
test workflow::environment_client::tests::exec_rpc_timeout_adds_headroom_over_command_limit ... ok
test state_machines::tests::write_state_machines_document_is_atomic_and_readable ... ok
test workflow::environment_client::tests::ping_detects_a_dead_host ... ok
test workflow::environment_client::tests::ping_treats_method_not_supported_as_alive ... ok
test workflow::environment_client::tests::exec_stream_ignores_other_handles ... ok
test workflow::environment_client::tests::select_errors_when_ambiguous_and_no_match ... ok
test workflow::environment_client::tests::select_falls_back_to_sole_environment_plugin ... ok
test workflow::environment_client::tests::select_prefers_exact_name_match ... ok
test workflow::environment_client::tests::exec_stream_forwards_output_and_returns_response ... ok
test workflow::journal_client::tests::actor_blob_key_is_stripped_before_deserialization ... ok
test workflow::journal_client::tests::durable_journal_inactive_without_plugin ... ok
test services::tests::file_hub_persists_workflows_with_machine_state ... ok
Initialized empty Git repository in /private/var/folders/_t/qq6w856d3p5_tnsm80nw5k240000gn/T/ao-subject-adapter-task-1783627474411008000/.git/
test services::tests::file_hub_uses_custom_pipeline_from_workflow_config_v2 ... ok
test services::tests::file_hub_complete_phase_with_decision_honors_rework_routing ... ok
test workflow::journal_client::tests::import_is_a_noop_for_sqlite_backend ... ok
test workflow::journal_client::tests::journal_run_round_trips_through_blob ... ok
test workflow::journal_client::tests::kill_switch_forces_sqlite ... ok
test workflow::journal_client::tests::no_plugin_installed_resolves_to_sqlite ... ok
test workflow::journal_client::tests::phase_failed_wire_event_carries_failed_status_and_detail ... ok
test workflow::journal_client::tests::import_empty_sqlite_writes_marker_and_imports_nothing ... ok
test workflow::journal_client::tests::subject_id_blob_key_is_stripped_before_deserialization ... ok
test workflow::journal_client::tests::to_journal_run_records_subject_id_for_task_kind ... ok
test workflow::journal_client::tests::to_journal_run_records_subject_id_for_generic_baas_kind ... ok
test workflow::journal_client::tests::wire_kind_phase_failed_maps_to_completed_with_failed_status ... ok
test workflow::phase_plan::tests::phase_plan_fallback_normalizes_legacy_refs ... ok
test services::tests::file_hub_delete_requirement_removes_sqlite_row_and_does_not_resurrect ... ok
test services::tests::file_hub_yaml_only_repo_executes_workflow_without_json_config ... ok
[main (root-commit) a014100] init
 1 file changed, 1 insertion(+)
 create mode 100644 README.md
test services::tests::persist_dirty_to_sqlite_rolls_back_all_entities_on_partial_failure ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_legacy_workflow_config_exists_without_v2 ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_pipeline_is_missing_from_config ... ok
test services::tests::execute_requirements_skips_tasks_with_active_workflow_on_file_hub ... ok
test workflow::journal_client::tests::import_skips_when_marker_present ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_workflow_config_is_invalid ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_workflow_config_is_missing ... ok
test workflow::journal_client::tests::import_copies_runs_and_checkpoints_and_writes_marker ... ok
test workflow::tests::advance_can_follow_agent_selected_target_when_yaml_allows_it ... ok
test workflow::tests::advance_ignores_agent_target_phase_and_uses_default_order ... ok
test workflow::tests::backoff_calculation ... ok
test workflow::tests::bootstrap_derives_status_from_machine_state ... ok
test services::tests::file_hub_run_persists_actor_for_lifecycle_continuation ... ok
test workflow::tests::cancel_keeps_status_synced_with_machine_state ... ok
test workflow::tests::custom_verdict_key_routes_backward_to_prior_phase ... ok
test workflow::tests::custom_verdict_key_backward_jump_respects_rework_budget ... ok
test workflow::tests::custom_verdict_key_routes_forward_to_mapped_target ... ok
test workflow::tests::custom_verdict_key_without_mapping_fails ... ok
test workflow::tests::default_max_attempts_is_3_when_no_config ... ok
test workflow::tests::executor_backoff_delay_for_phase_returns_correct_values ... ok
test workflow::tests::lifecycle_does_not_pause_completed_workflow ... ok
test workflow::tests::failed_phase_keeps_status_synced_with_machine_state ... ok
test workflow::tests::lifecycle_double_pause_is_noop ... ok
test workflow::tests::lifecycle_marks_completed_workflow_as_merge_conflict ... ok
test workflow::tests::lifecycle_resolves_merge_conflict_and_clears_failure_reason ... ok
test workflow::tests::lifecycle_resume_on_running_is_noop ... ok
test workflow::tests::lifecycle_skip_duplicate_cancels_workflow_early ... ok
test workflow::tests::lifecycle_skip_already_done_completes_workflow_early ... ok
test services::tests::workflow_service_exposes_decisions_and_checkpoints ... ok
test workflow::tests::machine_state_to_workflow_status_mapping ... ok
test workflow::tests::merge_conflict_blocks_phase_failure_with_actionable_error ... ok
test workflow::tests::merge_conflict_blocks_phase_success_with_actionable_error ... ok
test workflow::tests::no_on_verdict_uses_default_advance_behavior ... ok
test workflow::phase_plan::tests::resolve_phase_plan_prefers_explicit_config_pipeline_before_alias_normalization ... ok
test workflow::tests::on_verdict_advance_skips_to_configured_phase ... ok
test workflow::tests::on_verdict_rework_routes_to_configured_phase ... ok
test workflow::tests::phase_failure_while_paused_records_failure_and_resume_restarts ... ok
test workflow::tests::phase_with_max_attempts_1_escalates_immediately_on_rework ... ok
test workflow::tests::phase_with_max_attempts_5_allows_more_retries ... ok
test workflow::tests::release_held_run_ignores_a_run_that_already_started ... ok
test workflow::tests::release_held_run_starts_the_run_exactly_once ... ok
test workflow::tests::resume_clears_failure_and_can_complete_after_retry ... ok
test workflow::phase_plan::tests::resolve_phase_plan_requires_pack_install_for_canonical_requirement_workflow_refs ... ok
test services::tests::file_hub_completion_remains_successful_when_auto_prune_errors ... ok
test services::tests::file_hub_auto_prunes_checkpoints_on_completion_when_enabled ... ok
test workflow::tests::rework_routes_to_prior_phase_by_id ... ok
test workflow::tests::rework_with_nonexistent_target_falls_back_to_current_phase ... ok
test workflow::tests::rework_without_target_reruns_current_phase ... ok
test workflow::tests::rework_restart_refreshes_phase_started_at ... ok
test workflow::tests::select_workflow_prune_candidates_applies_status_keep_last_and_age ... ok
test workflow::tests::select_workflow_prune_candidates_saturates_oversized_age ... ok
test workflow::tests::select_workflow_prune_candidates_skips_non_terminal_runs ... ok
test workflow::tests::skip_guard_evaluator_supports_not_equals ... ok
test workflow::tests::skip_guarded_phase_any_matching_guard_causes_skip ... ok
test workflow::tests::skip_guarded_phase_does_not_skip_when_guard_does_not_match ... ok
test workflow::tests::skip_guarded_phase_skips_first_phase_on_bootstrap ... ok
test workflow::tests::skip_guarded_phase_skips_when_task_type_matches ... ok
test workflow::tests::skip_guarded_phase_with_empty_skip_if_runs_normally ... ok
test workflow::tests::skip_guarded_phases_skips_consecutive_phases ... ok
test workflow::tests::state_machine_allows_resume_from_failed ... ok
test workflow::tests::state_machine_enters_merge_conflict_from_completed ... ok
test workflow::tests::state_machine_resolves_merge_conflict_to_completed ... ok
test workflow::tests::state_machine_transitions ... ok
test services::tests::planning_execute_starts_workflows_with_config_phase_plan ... ok
test workflow::tests::load_stale_task_summaries_matches_in_progress_status ... ok
test workflow::tests::load_workflow_ref_index_decodes_compressed_workflow_blobs ... ok
test workflow::phase_plan::tests::resolve_phase_plan_requires_pack_install_for_optional_pack_workflows ... ok
test workflow::tests::resume_manager_detects_resumable_running_workflow ... ok
test subject_adapter::adapter::tests::builtin_project_adapter_provisions_task_worktree_via_task_adapter ... ok
test workflow::tests::resume_manager_detects_interrupted_failed_and_escalated_workflows ... ok
test workflow::tests::state_manager_prune_runs_rejects_non_terminal_status_filter ... ok
test workflow::phase_plan::tests::resolve_phase_plan_resolves_actor_private_workflow_only_for_that_actor ... ok
Initialized empty Git repository in /private/var/folders/_t/qq6w856d3p5_tnsm80nw5k240000gn/T/ao-subject-adapter-delegate-1783627474598727000/.git/
test workflow::tests::save_checkpoint_skips_numbers_of_orphan_checkpoint_rows ... ok
test workflow::phase_plan::tests::resolve_phase_plan_uses_config_default_pipeline_when_none_is_requested ... ok
test workflow::tests::state_manager_delete_run_rejects_active_workflow ... ok
test workflow::tests::status_stays_in_sync_through_lifecycle_transitions ... ok
test workflow::tests::sync_status_derives_from_machine_state ... ok
test workflow_events::tests::cancel_leaves_done_task_untouched ... ok
test workflow::tests::save_checkpoint_rolls_back_checkpoint_row_when_workflow_save_fails ... ok
test workflow_events::tests::cancel_of_completed_workflow_leaves_task_untouched ... ok
test workflow_events::tests::cancel_projects_task_to_cancelled ... ok
test workflow_events::tests::pause_annotates_task_with_pause_marker_without_flipping_status ... ok
test workflow_events::tests::pause_marker_prefix_is_stable ... ok
test workflow_events::tests::pause_does_not_overwrite_existing_blocked_reason ... ok
test workflow_events::tests::ready_reset_clears_pause_marker_after_workflow_pause ... ok
test workflow_events::tests::pause_of_completed_workflow_does_not_annotate_task ... ok
test workflow_events::tests::resume_clears_pause_marker ... ok
test workflow_runner_registry::tests::reused_pid_after_restart_is_never_live ... ok
test workflow_events::tests::resume_preserves_foreign_blocked_reason ... ok
test workflow::tests::state_manager_cleanup_deletes_terminal_workflows_with_null_timestamps ... ok
test workflow::phase_plan::tests::resolve_phase_plan_uses_config_phases_for_standard_pipeline ... ok
test workflow::tests::state_manager_prune_runs_dry_run_previews_without_deleting ... ok
test workflow::tests::state_manager_cleanup_deletes_old_terminal_workflows ... ok
test workflow::tests::state_manager_delete_run_removes_row_and_storage ... ok
[main (root-commit) a014100] init
 1 file changed, 1 insertion(+)
 create mode 100644 README.md
test workflow::tests::state_manager_prune_dry_run_keeps_checkpoint_files_and_metadata ... ok
test workflow::tests::state_manager_saves_checkpoints ... ok
test workflow::phase_plan::tests::resolve_phase_plan_uses_machine_installed_pack_workflows ... ok
test services::tests::manual_phase_approval_resume_clears_task_pause_marker ... FAILED
test workflow::tests::state_manager_prune_runs_deletes_terminal_runs_and_storage ... ok
test workflow::tests::state_manager_prunes_checkpoints_older_than_age ... ok
test workflow::tests::state_manager_prunes_to_keep_last_per_phase ... ok
test workflow::tests::state_manager_prunes_legacy_checkpoints_by_inferred_phase ... ok
HEAD is now at a014100 init
test subject_adapter::adapter::tests::ensure_execution_cwd_delegates_to_environment_plugin_when_gated_on ... ok
test workflow::environment_client::tests::prepare_exec_teardown_round_trip ... ok
test workflow::environment_client::tests::two_clients_share_one_host_process ... ok

failures:

---- services::tests::manual_phase_approval_resume_clears_task_pause_marker stdout ----

thread 'services::tests::manual_phase_approval_resume_clears_task_pause_marker' (4098838) panicked at crates/orchestrator-core/src/services/tests.rs:2789:6:
approve manual phase: workflow 'review-pack' references unknown phase 'requirements'; add it to phase_catalog or define it under phases; workflow 'review-pack' references unknown phase 'testing'; add it to phase_catalog or define it under phases
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    services::tests::manual_phase_approval_resume_clears_task_pause_marker

test result: FAILED. 405 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.09s (406) and  (207) and  (1319): all pass.
-  clean;  clean.
- Pre-existing failures unrelated to this change and identical on the clean base: the  testkit e2e (external fixture binary not built here) and 24 daemon-runtime trigger/discovery tests.
- Codex self-vet: no P1; one P2 (test-only process cwd mutation) fixed inline by removing it.

Do not merge/deploy/tag: the main session cuts rc.8 from this PR, rebuilds the runner, repins the portal, deploys, and verifies krisp.