### PR TITLE
fix(plugin-host): source declared_supports_mcp from the plugin manifest (REQUIREMENT-039)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "animus-actor"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "schemars",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "animus-config-protocol"
 version = "0.1.1"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "animus-actor",
  "anyhow",
@@ -94,11 +94,11 @@ dependencies = [
 [[package]]
 name = "animus-control-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "animus-actor",
  "animus-log-storage-protocol",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "animus-subject-protocol 0.1.16",
  "animus-trigger-protocol",
  "anyhow",
@@ -114,9 +114,9 @@ dependencies = [
 [[package]]
 name = "animus-environment-protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "schemars",
  "serde",
  "serde_json",
@@ -125,9 +125,9 @@ dependencies = [
 [[package]]
 name = "animus-journal-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",
  "chrono",
@@ -140,9 +140,9 @@ dependencies = [
 [[package]]
 name = "animus-log-storage-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",
  "chrono",
@@ -191,8 +191,8 @@ dependencies = [
 
 [[package]]
 name = "animus-plugin-protocol"
-version = "0.1.17"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+version = "0.1.18"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "schemars",
  "serde",
@@ -203,7 +203,7 @@ dependencies = [
 name = "animus-plugin-runtime"
 version = "0.1.0"
 dependencies = [
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "animus-session-backend",
  "anyhow",
  "async-trait",
@@ -230,7 +230,7 @@ name = "animus-runtime-shared"
 version = "0.1.0"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",
  "chrono",
@@ -257,10 +257,10 @@ dependencies = [
 [[package]]
 name = "animus-session-backend"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",
  "serde",
@@ -290,10 +290,10 @@ dependencies = [
 [[package]]
 name = "animus-subject-protocol"
 version = "0.1.16"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",
  "chrono",
@@ -307,9 +307,9 @@ dependencies = [
 [[package]]
 name = "animus-trigger-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",
  "chrono",
@@ -323,10 +323,10 @@ dependencies = [
 [[package]]
 name = "animus-workflow-runner-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "animus-subject-protocol 0.1.16",
  "schemars",
  "serde",
@@ -2787,7 +2787,7 @@ dependencies = [
  "animus-environment-protocol",
  "animus-log-storage-protocol",
  "animus-mcp-oauth",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "animus-queue-protocol",
  "animus-runtime-shared",
  "animus-session-backend",
@@ -2859,7 +2859,7 @@ dependencies = [
  "animus-actor",
  "animus-environment-protocol",
  "animus-journal-protocol",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "anyhow",
  "argon2",
  "async-trait",
@@ -2897,7 +2897,7 @@ dependencies = [
  "animus-actor",
  "animus-control-protocol",
  "animus-log-storage-protocol",
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "animus-runtime-shared",
  "animus-subject-protocol 0.1.16",
  "anyhow",
@@ -2945,7 +2945,7 @@ dependencies = [
 name = "orchestrator-plugin-host"
 version = "0.1.0"
 dependencies = [
- "animus-plugin-protocol 0.1.17",
+ "animus-plugin-protocol 0.1.18",
  "animus-session-backend",
  "anyhow",
  "async-trait",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.5#7a5ef899c0292d25f2075e50545908127b3b7499"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
 dependencies = [
  "animus-subject-protocol 0.1.16",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "animus-actor"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "schemars",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "animus-config-protocol"
 version = "0.1.1"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-actor",
  "anyhow",
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "animus-control-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-actor",
  "animus-log-storage-protocol",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "animus-environment-protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-plugin-protocol 0.1.18",
  "schemars",
@@ -125,7 +125,7 @@ dependencies = [
 [[package]]
 name = "animus-journal-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-plugin-protocol 0.1.18",
  "anyhow",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "animus-log-storage-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-plugin-protocol 0.1.18",
  "anyhow",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "animus-plugin-protocol"
 version = "0.1.18"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "schemars",
  "serde",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "animus-session-backend"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-actor",
  "animus-plugin-protocol 0.1.18",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "animus-subject-protocol"
 version = "0.1.16"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-actor",
  "animus-plugin-protocol 0.1.18",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "animus-trigger-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-plugin-protocol 0.1.18",
  "anyhow",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "animus-workflow-runner-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-actor",
  "animus-plugin-protocol 0.1.18",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=agent%2Fv0.7.0%2Fdeclared-supports-mcp#67807d6d2fc5b8f73ae52d6902f59f0430b023b6"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.6#0d6bb3be203bf9e38a79ab347b28d2bef5c0498b"
 dependencies = [
  "animus-subject-protocol 0.1.16",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ categories = ["command-line-utilities", "development-tools"]
 # animus-subject-protocol resolves to one source (no duplicate-crate type
 # mismatches). animus-plugin-protocol/runtime remain in-tree pending a
 # follow-up move.
-animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
+animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
 # v0.7: environment plugin kind — EnvironmentSpec/HarnessCommand/ExecRequest wire
 # types + prepare/exec/exec_stream/teardown methods. Consumed by the routing
 # resolver + the follow-on runtime EnvironmentClient (not yet built).
-animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5", package = "protocol" }
+animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp", package = "protocol" }
 orchestrator-daemon-runtime = { path = "crates/orchestrator-daemon-runtime" }
 orchestrator-logging = { path = "crates/orchestrator-logging" }
 orchestrator-plugin-host = { path = "crates/orchestrator-plugin-host" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ categories = ["command-line-utilities", "development-tools"]
 # animus-subject-protocol resolves to one source (no duplicate-crate type
 # mismatches). animus-plugin-protocol/runtime remain in-tree pending a
 # follow-up move.
-animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-subject-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
 # v0.7: environment plugin kind — EnvironmentSpec/HarnessCommand/ExecRequest wire
 # types + prepare/exec/exec_stream/teardown methods. Consumed by the routing
 # resolver + the follow-on runtime EnvironmentClient (not yet built).
-animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp", package = "protocol" }
+animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6", package = "protocol" }
 orchestrator-daemon-runtime = { path = "crates/orchestrator-daemon-runtime" }
 orchestrator-logging = { path = "crates/orchestrator-logging" }
 orchestrator-plugin-host = { path = "crates/orchestrator-plugin-host" }

--- a/crates/animus-plugin-runtime/src/lib.rs
+++ b/crates/animus-plugin-runtime/src/lib.rs
@@ -66,6 +66,12 @@ impl ProviderInfo {
             ],
             env_required: Vec::new(),
             notification_buffer_size: None,
+            // TODO(codex-p2): plumb an opt-out through `ProviderInfo` so a
+            // runtime-built provider can declare `supports_mcp: false`. For now
+            // it stays undeclared (None) => the kernel's historical MCP-capable
+            // default, matching the protocol repo's `provider_main` deferral
+            // (REQUIREMENT-039).
+            supports_mcp: None,
         }
     }
 

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -39,9 +39,9 @@ animus-environment-protocol = { workspace = true }
 # embed subject-protocol types, so `animus-subject-protocol-wire` MUST match
 # control's rev. v0.1.26 additively adds `actor: Option<Actor>` to the control +
 # workflow-runner request types relayed by the control surface / plugin_clients.
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
 animus-actor = { workspace = true }
 # Plugin protocol crates used by the plugin-host wrappers in
 # `services::plugin_clients` to dispatch `workflow/*` and `queue/*` RPCs through
@@ -51,7 +51,7 @@ animus-actor = { workspace = true }
 # NOT share `animus-subject-protocol-wire`'s rev (cargo forbids two names for one
 # package instance), so they stay a distinct rev.
 animus-queue-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.5.10" }
-animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
+animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
 animus-subject-protocol-v05 = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.5.10" }
 protocol = { workspace = true }
 animus-session-backend = { workspace = true }

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -39,9 +39,9 @@ animus-environment-protocol = { workspace = true }
 # embed subject-protocol types, so `animus-subject-protocol-wire` MUST match
 # control's rev. v0.1.26 additively adds `actor: Option<Actor>` to the control +
 # workflow-runner request types relayed by the control surface / plugin_clients.
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
 animus-actor = { workspace = true }
 # Plugin protocol crates used by the plugin-host wrappers in
 # `services::plugin_clients` to dispatch `workflow/*` and `queue/*` RPCs through
@@ -51,7 +51,7 @@ animus-actor = { workspace = true }
 # NOT share `animus-subject-protocol-wire`'s rev (cargo forbids two names for one
 # package instance), so they stay a distinct rev.
 animus-queue-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.5.10" }
-animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
 animus-subject-protocol-v05 = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.5.10" }
 protocol = { workspace = true }
 animus-session-backend = { workspace = true }

--- a/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
@@ -8164,6 +8164,7 @@ name = "same"
             capabilities: vec!["agent/run".to_string()],
             env_required: Vec::new(),
             notification_buffer_size: None,
+            supports_mcp: None,
         }
     }
 
@@ -9987,6 +9988,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["subject_kind:task".into(), "subject_kind:incident".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         assert_eq!(rename_eligible_native_kind(&manifest).as_deref(), Some("task"));
     }
@@ -10003,6 +10005,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["provider_tool:claude".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         // v0.5.7 only renames subject_backend kinds; provider dispatch
         // does not consult plugins.lock yet, so providers must skip the
@@ -10026,6 +10029,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["subject_kind:task.*".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         assert_eq!(rename_eligible_native_kind(&manifest), None);
     }
@@ -10042,6 +10046,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["subject_kind:task.*".into(), "subject_kind:incident".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         assert_eq!(rename_eligible_native_kind(&manifest).as_deref(), Some("incident"));
     }
@@ -10058,6 +10063,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["http_routes:foo".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         assert_eq!(rename_eligible_native_kind(&manifest), None);
     }
@@ -10192,6 +10198,7 @@ required = ["launchapp-dev/animus-queue-default"]
             ],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         let kinds = all_rename_eligible_native_kinds(&manifest);
         assert_eq!(kinds, vec!["task".to_string(), "requirement".to_string(), "incident".to_string()]);
@@ -10214,6 +10221,7 @@ required = ["launchapp-dev/animus-queue-default"]
             ],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         let kinds = all_rename_eligible_native_kinds(&manifest);
         assert_eq!(kinds, vec!["task".to_string(), "requirement".to_string()]);
@@ -10251,6 +10259,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["subject_kind:task".into(), "subject_kind:requirement".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         let err = compute_kind_assignment(Some(&manifest), &lock, &[], "subject-multi", None)
             .expect_err("secondary kind collision must refuse the install");
@@ -10332,6 +10341,7 @@ required = ["launchapp-dev/animus-queue-default"]
             capabilities: vec!["subject_kind:task".into(), "subject_kind:incident".into()],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         };
         let (assigned, native) = compute_kind_assignment(Some(&manifest), &lock, &[], "subject-multi", None)
             .expect("primary auto-increment with free secondary must succeed");

--- a/crates/orchestrator-cli/src/services/operations/ops_web.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_web.rs
@@ -678,6 +678,7 @@ mod tests {
                 capabilities: capabilities.iter().map(|s| s.to_string()).collect(),
                 env_required: Vec::new(),
                 notification_buffer_size: None,
+                supports_mcp: None,
             },
             source: DiscoverySource::ExplicitConfig,
         }

--- a/crates/orchestrator-core/src/plugin_preflight/tests.rs
+++ b/crates/orchestrator-core/src/plugin_preflight/tests.rs
@@ -304,6 +304,7 @@ fn discovered_subject_plugin(name: &str, native_kind: &str) -> DiscoveredPlugin 
             capabilities: vec![format!("subject_kind:{native_kind}")],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         },
         source: DiscoverySource::PluginPath,
     }

--- a/crates/orchestrator-core/src/workflow/environment_client.rs
+++ b/crates/orchestrator-core/src/workflow/environment_client.rs
@@ -1102,6 +1102,7 @@ mod tests {
                 capabilities: Vec::new(),
                 env_required: Vec::new(),
                 notification_buffer_size: None,
+                supports_mcp: None,
             },
             source: orchestrator_plugin_host::DiscoverySource::PluginPath,
         }

--- a/crates/orchestrator-daemon-runtime/Cargo.toml
+++ b/crates/orchestrator-daemon-runtime/Cargo.toml
@@ -27,12 +27,12 @@ animus-plugin-protocol = { workspace = true }
 # All animus-protocol git deps pin the SAME tag (v0.1.26) so the transitively
 # pulled `animus-subject-protocol` resolves to ONE source rev. v0.1.26 additively
 # adds `actor: Option<Actor>` to the control request types relayed by the daemon.
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
 animus-actor = { workspace = true }
 # Subject / SubjectChangedEvent share the same v0.1.26 surface as the
 # control-protocol (one source rev so the protocol versions stay in lockstep).
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
 protocol = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -51,14 +51,14 @@ interprocess = "2.4"
 protocol = { workspace = true, features = ["test-utils"] }
 tempfile = "3"
 tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "signal", "test-util", "time"] }
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp", features = ["client"] }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6", features = ["client"] }
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures-core = "0.3"
 futures-util = "0.3"
 serde_json = "1.0"
 uuid = { version = "1", features = ["v4"] }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.6" }
 animus-runtime-shared = { workspace = true }
 
 [lints]

--- a/crates/orchestrator-daemon-runtime/Cargo.toml
+++ b/crates/orchestrator-daemon-runtime/Cargo.toml
@@ -27,12 +27,12 @@ animus-plugin-protocol = { workspace = true }
 # All animus-protocol git deps pin the SAME tag (v0.1.26) so the transitively
 # pulled `animus-subject-protocol` resolves to ONE source rev. v0.1.26 additively
 # adds `actor: Option<Actor>` to the control request types relayed by the daemon.
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
 animus-actor = { workspace = true }
 # Subject / SubjectChangedEvent share the same v0.1.26 surface as the
 # control-protocol (one source rev so the protocol versions stay in lockstep).
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
 protocol = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -51,14 +51,14 @@ interprocess = "2.4"
 protocol = { workspace = true, features = ["test-utils"] }
 tempfile = "3"
 tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "signal", "test-util", "time"] }
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5", features = ["client"] }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp", features = ["client"] }
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures-core = "0.3"
 futures-util = "0.3"
 serde_json = "1.0"
 uuid = { version = "1", features = ["v4"] }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.5" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", branch = "agent/v0.7.0/declared-supports-mcp" }
 animus-runtime-shared = { workspace = true }
 
 [lints]

--- a/crates/orchestrator-daemon-runtime/src/control/dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/control/dispatch.rs
@@ -1563,6 +1563,7 @@ mod health_probe_env_tests {
             capabilities: Vec::new(),
             env_required: required,
             notification_buffer_size: None,
+            supports_mcp: None,
         }
     }
 

--- a/crates/orchestrator-daemon-runtime/src/log_storage.rs
+++ b/crates/orchestrator-daemon-runtime/src/log_storage.rs
@@ -626,6 +626,7 @@ mod tests {
                 capabilities: vec![],
                 env_required: vec![],
                 notification_buffer_size: None,
+                supports_mcp: None,
             },
             source: DiscoverySource::ProjectLocal,
         }

--- a/crates/orchestrator-daemon-runtime/src/schedule/trigger_supervisor.rs
+++ b/crates/orchestrator-daemon-runtime/src/schedule/trigger_supervisor.rs
@@ -1128,6 +1128,7 @@ mod tests {
                 capabilities: Vec::new(),
                 env_required: Vec::new(),
                 notification_buffer_size: None,
+                supports_mcp: None,
             },
             source: orchestrator_plugin_host::DiscoverySource::ExplicitConfig,
         }

--- a/crates/orchestrator-daemon-runtime/src/subject_dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/subject_dispatch.rs
@@ -677,6 +677,7 @@ mod tests {
                 capabilities: vec![],
                 env_required: vec![],
                 notification_buffer_size: None,
+                supports_mcp: None,
             },
             source: DiscoverySource::ProjectLocal,
         }

--- a/crates/orchestrator-plugin-host/src/manifest_cache.rs
+++ b/crates/orchestrator-plugin-host/src/manifest_cache.rs
@@ -274,6 +274,7 @@ mod tests {
             capabilities: vec![],
             env_required: vec![],
             notification_buffer_size: None,
+            supports_mcp: None,
         }
     }
 

--- a/crates/orchestrator-plugin-host/src/session/plugin_backend.rs
+++ b/crates/orchestrator-plugin-host/src/session/plugin_backend.rs
@@ -1242,6 +1242,18 @@ impl DiscoveredProviderPlugin {
     }
 }
 
+/// Resolve a provider's MCP-consume decision from its DECLARED manifest
+/// capability (TASK-277 / REQUIREMENT-039), rather than a hardcoded per-tool
+/// default.
+///
+/// Back-compat: an undeclared field (`None` — older plugins built before
+/// protocol 1.2.0, which omit the field entirely) means the provider keeps the
+/// historical default of MCP-capable. Only an explicit `Some(false)` opts a
+/// provider out of host MCP-server injection.
+fn declared_supports_mcp_from_manifest(manifest: &animus_plugin_protocol::PluginManifest) -> bool {
+    manifest.supports_mcp.unwrap_or(true)
+}
+
 /// Inspect manifests of every discovered plugin under `project_root` and return only
 /// the provider-kind plugins. Provider tool name defaults to the plugin name minus the
 /// `animus-provider-` prefix.
@@ -1260,11 +1272,7 @@ pub fn discover_provider_plugins(project_root: &std::path::Path) -> Vec<Discover
                 .unwrap_or_else(|| plugin.name.clone());
             let env_required = plugin.manifest.env_required.clone();
             let declared_methods = plugin.manifest.capabilities.clone();
-            // Every provider plugin consumes MCP; the protocol carries no
-            // per-plugin MCP-consume flag yet (TASK-277 sources this from a
-            // first-class manifest/handshake capability). Until then, a
-            // discovered provider declares MCP-capable.
-            let declared_supports_mcp = true;
+            let declared_supports_mcp = declared_supports_mcp_from_manifest(&plugin.manifest);
             let notification_buffer_size = plugin.manifest.notification_buffer_size;
             DiscoveredProviderPlugin {
                 plugin_name: plugin.name,
@@ -1818,6 +1826,41 @@ mod tests {
         let opted_out =
             PluginSessionBackend::new("q", PathBuf::from("/nonexistent/q"), "q").with_declared_supports_mcp(false);
         assert!(!opted_out.capabilities().supports_mcp, "declared supports_mcp:false must be honored");
+    }
+
+    #[test]
+    fn declared_supports_mcp_from_manifest_sources_the_declared_field() {
+        fn manifest(supports_mcp: Option<bool>) -> animus_plugin_protocol::PluginManifest {
+            animus_plugin_protocol::PluginManifest {
+                name: "animus-provider-portal".to_string(),
+                version: "0.1.0".to_string(),
+                plugin_kind: animus_plugin_protocol::PLUGIN_KIND_PROVIDER.to_string(),
+                plugin_kinds: Vec::new(),
+                description: "out-of-tree provider".to_string(),
+                protocol_version: "1.2.0".to_string(),
+                capabilities: vec!["agent/run".to_string()],
+                env_required: Vec::new(),
+                notification_buffer_size: None,
+                supports_mcp,
+            }
+        }
+
+        // Back-compat: an older plugin that omits the field (None) keeps the
+        // historical MCP-capable default.
+        assert!(
+            declared_supports_mcp_from_manifest(&manifest(None)),
+            "undeclared supports_mcp must default to MCP-capable (back-compat)"
+        );
+        // An explicit opt-out is honored.
+        assert!(
+            !declared_supports_mcp_from_manifest(&manifest(Some(false))),
+            "declared supports_mcp:false must be sourced from the manifest"
+        );
+        // An explicit opt-in is honored.
+        assert!(
+            declared_supports_mcp_from_manifest(&manifest(Some(true))),
+            "declared supports_mcp:true must be sourced from the manifest"
+        );
     }
 
     fn env_req(name: &str) -> EnvRequirement {


### PR DESCRIPTION
## What

The provider plugin host now sources declared_supports_mcp from the plugin's DECLARED manifest field (PluginManifest.supports_mcp) instead of a hardcoded true. First slice of TASK-277 / REQUIREMENT-039.

The #314 (rc.8) plumbing already threads declared_supports_mcp all the way into capabilities().supports_mcp and the MCP-injection decision. This PR only changes its SOURCE from a constant to the manifest.

## Changes

- New helper declared_supports_mcp_from_manifest in plugin_backend.rs reads manifest.supports_mcp with a back-compat default of true. discover_provider_plugins calls it instead of the old let declared_supports_mcp = true. Unit test covers None (undeclared -> true), Some(false), Some(true).
- All in-tree PluginManifest struct literals gain supports_mcp: None. This is mechanical fallout of the new protocol field (Rust struct literals must set every field); most sites are test helpers.
- The in-tree animus-plugin-runtime provider manifest emits supports_mcp: None with a TODO(codex-p2) to plumb an explicit opt-out through ProviderInfo. Deferred because it mirrors the same deferral in the protocol repo provider_main, and ProviderInfo has no opt-out field yet.

## Back-compat

An undeclared field (older plugins built before protocol 1.2.0, which omit it) resolves to true via unwrap_or(true) — identical to today behavior. Only an explicit false opts a provider out of host MCP-server injection.

## Coordination for main session — REQUIRED before merge

- This depends on the animus-protocol change (PR to release/0.7) that adds PluginManifest.supports_mcp. To build now, the animus-protocol git deps in Cargo.toml, crates/orchestrator-cli/Cargo.toml, and crates/orchestrator-daemon-runtime/Cargo.toml are TEMPORARILY repinned from tag v0.7.0-rc.5 to branch agent/v0.7.0/declared-supports-mcp (plus the resulting Cargo.lock update).
- Main session must repin the fleet to the CUT protocol tag (e.g. v0.7.0-rc.9) and cargo update before merge. Draft until then.

## Gates

- cargo check --workspace --all-targets: clean.
- cargo animus-fmt: clean. cargo animus-lint (clippy): clean. cargo animus-bin-check: clean.
- Targeted tests: orchestrator-plugin-host supports_mcp tests pass (new + existing); animus-plugin-runtime + orchestrator-core suites pass. One unrelated test (manual_phase_approval_resume_clears_task_pause_marker) fails only under full-suite parallelism and passes in isolation — a pre-existing test-isolation flake, not caused by this change.
- codex review --uncommitted (high effort): no P1. Two P2 findings, both deferred: (1) runtime providers cannot yet declare supports_mcp:false via ProviderInfo — TODO added; (2) a theoretical stale manifest-cache omission — mitigated by the cache mtime-invalidation (a provider emitting the new field is a rebuilt, newer-mtime binary that busts the cache).

Part of TASK-277 / REQUIREMENT-039.
