### PR TITLE
Remove task/requirement-specific CLI + MCP surface; use --subject-id (TASK-278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **BREAKING — removed the deprecated `--task-id` / `--requirement-id` flags.**
+  `task` and `requirement` are ordinary subject kinds now, so there is no
+  task/requirement-specific CLI or MCP surface. Use `--subject-id` for every
+  kind on `queue enqueue`, `workflow run`, `workflow prompt render`, and the
+  `workflow list` filter (accepts a qualified `task:TASK-001` /
+  `requirement:REQ-042` / `blog:BLOG-001` or a bare `TASK-001`); the
+  `agent approve-hook` escalation context moves from `--task-id` to
+  `--subject-id`. The matching `animus mcp serve` tool inputs
+  (`animus.queue.enqueue`, `animus.workflow.run`, `.execute`, `.run-multiple`,
+  `.list`) drop `task_id` / `requirement_id` for `subject_id`. `--title` and
+  `--adhoc` are unchanged. The flags were already deprecated in v0.7 (TASK-247);
+  callers that shell the CLI or MCP should pass `--subject-id` / `subject_id`.
+  Note: because requirement runs no longer have a privileged kind-specific
+  default, a requirement dispatched via `--subject-id requirement:REQ-001`
+  without an explicit workflow ref uses the project default workflow (the old
+  `--requirement-id` flag defaulted to `animus.requirement/plan`) — name the
+  workflow explicitly, e.g. `animus workflow run animus.requirement/plan
+  --subject-id requirement:REQ-001`.
+
 ## [0.7.0-rc.1] - 2026-07-03
 
 **v0.7.0-rc.1 — Composable, multi-tenant platform (release candidate).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,7 @@ v0.4.4 — `animus task` and `animus requirements` are gone):
 ```bash
 animus subject next --kind task
 animus subject status --kind task --id task:TASK-XXX --status in-progress
-animus workflow run --task-id TASK-XXX
+animus workflow run --subject-id task:TASK-XXX
 animus queue list
 animus daemon health
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ animus daemon preflight                          # verify all required plugins a
 
 # Option 1: run a workflow on demand
 animus subject create --kind task --title "Add rate limiting" --priority p1
-animus workflow run --task-id TASK-001
+animus workflow run --subject-id TASK-001
 
 # Option 2: go fully autonomous
 animus daemon start                              # daemon executes ready subjects continuously

--- a/crates/orchestrator-cli/src/cli_types/agent_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/agent_types.rs
@@ -81,8 +81,12 @@ pub(crate) struct AgentApproveHookArgs {
     pub(crate) format: ApproveHookFormat,
     #[arg(long, value_name = "WORKFLOW_ID", help = "Optional workflow id context recorded on any escalation.")]
     pub(crate) workflow_id: Option<String>,
-    #[arg(long, value_name = "TASK_ID", help = "Optional task id context recorded on any escalation.")]
-    pub(crate) task_id: Option<String>,
+    #[arg(
+        long = "subject-id",
+        value_name = "SUBJECT_ID",
+        help = "Optional subject id context recorded on any escalation."
+    )]
+    pub(crate) subject_id: Option<String>,
     #[arg(
         long,
         value_name = "SECONDS",

--- a/crates/orchestrator-cli/src/cli_types/mod.rs
+++ b/crates/orchestrator-cli/src/cli_types/mod.rs
@@ -251,27 +251,25 @@ mod tests {
         match cli.command {
             Command::Queue { command: QueueCommand::Enqueue(args) } => {
                 assert_eq!(args.subject_id.as_deref(), Some("blog:BLOG-001"));
-                assert!(args.task_id.is_none());
+                assert!(args.title.is_none());
             }
             other => panic!("expected queue enqueue, got {other:?}"),
         }
     }
 
     #[test]
-    fn queue_enqueue_subject_id_conflicts_with_kind_flags() {
-        for other in [["--task-id", "TASK-1"], ["--requirement-id", "REQ-1"], ["--title", "x"]] {
-            let error = Cli::try_parse_from([
-                "animus",
-                "queue",
-                "enqueue",
-                "--subject-id",
-                "blog:BLOG-001",
-                other[0],
-                other[1],
-            ])
-            .expect_err("--subject-id must be mutually exclusive with the kind flags");
-            assert_eq!(error.kind(), ErrorKind::ArgumentConflict, "flag {}: {error}", other[0]);
-        }
+    fn queue_enqueue_subject_id_conflicts_with_title() {
+        let error =
+            Cli::try_parse_from(["animus", "queue", "enqueue", "--subject-id", "blog:BLOG-001", "--title", "x"])
+                .expect_err("--subject-id must be mutually exclusive with --title");
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict, "{error}");
+    }
+
+    #[test]
+    fn queue_enqueue_rejects_removed_task_id_flag() {
+        let error = Cli::try_parse_from(["animus", "queue", "enqueue", "--task-id", "TASK-1"])
+            .expect_err("--task-id was removed");
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument, "{error}");
     }
 
     #[test]
@@ -281,20 +279,24 @@ mod tests {
         match cli.command {
             Command::Workflow { command: WorkflowCommand::Run(args) } => {
                 assert_eq!(args.subject_id.as_deref(), Some("blog:BLOG-001"));
-                assert!(args.task_id.is_none());
+                assert!(args.title.is_none());
             }
             other => panic!("expected workflow run, got {other:?}"),
         }
     }
 
     #[test]
-    fn workflow_run_subject_id_conflicts_with_kind_flags() {
-        for other in [["--task-id", "TASK-1"], ["--requirement-id", "REQ-1"], ["--title", "x"]] {
-            let error =
-                Cli::try_parse_from(["animus", "workflow", "run", "--subject-id", "blog:BLOG-001", other[0], other[1]])
-                    .expect_err("--subject-id must be mutually exclusive with the kind flags");
-            assert_eq!(error.kind(), ErrorKind::ArgumentConflict, "flag {}: {error}", other[0]);
-        }
+    fn workflow_run_subject_id_conflicts_with_title() {
+        let error = Cli::try_parse_from(["animus", "workflow", "run", "--subject-id", "blog:BLOG-001", "--title", "x"])
+            .expect_err("--subject-id must be mutually exclusive with --title");
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict, "{error}");
+    }
+
+    #[test]
+    fn workflow_run_rejects_removed_task_id_flag() {
+        let error = Cli::try_parse_from(["animus", "workflow", "run", "--task-id", "TASK-1"])
+            .expect_err("--task-id was removed");
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument, "{error}");
     }
 
     #[test]
@@ -711,12 +713,13 @@ mod tests {
 
     #[test]
     fn parses_queue_enqueue_command() {
-        let cli = Cli::try_parse_from(["animus", "queue", "enqueue", "--task-id", "TASK-123", "--workflow-ref", "ops"])
-            .expect("queue enqueue command should parse");
+        let cli =
+            Cli::try_parse_from(["animus", "queue", "enqueue", "--subject-id", "TASK-123", "--workflow-ref", "ops"])
+                .expect("queue enqueue command should parse");
 
         match cli.command {
             Command::Queue { command: QueueCommand::Enqueue(args) } => {
-                assert_eq!(args.task_id.as_deref(), Some("TASK-123"));
+                assert_eq!(args.subject_id.as_deref(), Some("TASK-123"));
                 assert_eq!(args.workflow_ref.as_deref(), Some("ops"));
             }
             _ => panic!("expected queue enqueue command"),
@@ -786,13 +789,14 @@ mod tests {
 
     #[test]
     fn parses_workflow_run_with_positional_pipeline() {
-        let cli = Cli::try_parse_from(["animus", "workflow", "run", "animus.task/standard", "--task-id", "TASK-123"])
-            .expect("workflow run should parse");
+        let cli =
+            Cli::try_parse_from(["animus", "workflow", "run", "animus.task/standard", "--subject-id", "task:TASK-123"])
+                .expect("workflow run should parse");
 
         match cli.command {
             Command::Workflow { command: WorkflowCommand::Run(args) } => {
                 assert_eq!(args.pipeline.as_deref(), Some("animus.task/standard"));
-                assert_eq!(args.task_id.as_deref(), Some("TASK-123"));
+                assert_eq!(args.subject_id.as_deref(), Some("task:TASK-123"));
             }
             _ => panic!("expected workflow run command"),
         }
@@ -962,8 +966,16 @@ mod tests {
     #[test]
     fn workflow_run_parses_actor_json_for_transport_scoping() {
         let actor_json = r#"{"user_id":"alice","claims":["admin"],"tenant_id":"acme"}"#;
-        let cli = Cli::try_parse_from(["animus", "workflow", "run", "--task-id", "TASK-1", "--actor-json", actor_json])
-            .expect("workflow run --actor-json should parse");
+        let cli = Cli::try_parse_from([
+            "animus",
+            "workflow",
+            "run",
+            "--subject-id",
+            "task:TASK-1",
+            "--actor-json",
+            actor_json,
+        ])
+        .expect("workflow run --actor-json should parse");
         match cli.command {
             Command::Workflow { command: WorkflowCommand::Run(args) } => {
                 assert_eq!(args.actor_json.as_deref(), Some(actor_json));
@@ -971,7 +983,7 @@ mod tests {
             other => panic!("expected workflow run, got {other:?}"),
         }
         // No flag => None => global scope.
-        let cli = Cli::try_parse_from(["animus", "workflow", "run", "--task-id", "TASK-1"])
+        let cli = Cli::try_parse_from(["animus", "workflow", "run", "--subject-id", "task:TASK-1"])
             .expect("bare workflow run should parse");
         match cli.command {
             Command::Workflow { command: WorkflowCommand::Run(args) } => assert_eq!(args.actor_json, None),

--- a/crates/orchestrator-cli/src/cli_types/queue_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/queue_types.rs
@@ -8,11 +8,11 @@ pub(crate) enum QueueCommand {
     List,
     /// Show queue statistics.
     Stats,
-    /// Enqueue a subject dispatch for a task, requirement, or custom title.
+    /// Enqueue a subject dispatch for any subject kind or a custom title.
     ///
     /// Examples:
-    ///   animus queue enqueue --task-id TASK-001
-    ///   animus queue enqueue --requirement-id REQ-042 --workflow-ref ops
+    ///   animus queue enqueue --subject-id TASK-001
+    ///   animus queue enqueue --subject-id requirement:REQ-042 --workflow-ref ops
     ///   animus queue enqueue --title "Investigate flaky test" --description "Suite fails intermittently on CI"
     Enqueue(QueueEnqueueArgs),
     /// Hold one or more queued subjects.
@@ -29,36 +29,22 @@ pub(crate) enum QueueCommand {
 pub(crate) struct QueueEnqueueArgs {
     #[arg(
         long,
-        value_name = "TASK_ID",
-        group = "subject",
-        help = "Task subject to enqueue (e.g. TASK-001). Mutually exclusive with --requirement-id / --title."
-    )]
-    pub(crate) task_id: Option<String>,
-    #[arg(
-        long,
-        value_name = "REQ_ID",
-        group = "subject",
-        help = "Requirement subject to enqueue (e.g. REQ-042). Mutually exclusive with --task-id / --title."
-    )]
-    pub(crate) requirement_id: Option<String>,
-    #[arg(
-        long,
         value_name = "TITLE",
         group = "subject",
-        help = "Custom subject title for ad-hoc dispatches. Mutually exclusive with --task-id / --requirement-id."
+        help = "Custom subject title for ad-hoc dispatches. Mutually exclusive with --subject-id / --adhoc."
     )]
     pub(crate) title: Option<String>,
     #[arg(
         long = "subject-id",
         value_name = "SUBJECT_ID",
         group = "subject",
-        help = "Generic subject to enqueue for any kind (BaaS dynamic kinds like blog/post). Accepts a qualified id (blog:BLOG-001 — kind trusted; the recommended form) or a bare id (BLOG-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form). Mutually exclusive with --task-id / --requirement-id / --title."
+        help = "Subject to enqueue for any kind. Accepts a qualified id (task:TASK-001 / requirement:REQ-042 / blog:BLOG-001 — kind trusted; the recommended form) or a bare id (TASK-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form). Mutually exclusive with --title / --adhoc."
     )]
     pub(crate) subject_id: Option<String>,
     #[arg(
         long,
         group = "subject",
-        help = "Dispatch a subjectless (ad-hoc) run with NO bound subject. The workflow runs without subject-bound template vars — use for subject-less-by-design workflows (e.g. relate) fired without a target. Requires --workflow-ref. Mutually exclusive with --task-id / --requirement-id / --title / --subject-id. NOTE: not yet supported through the installed queue plugin (its RPC protocol still requires a subject); dispatch such runs directly for now."
+        help = "Dispatch a subjectless (ad-hoc) run with NO bound subject. The workflow runs without subject-bound template vars — use for subject-less-by-design workflows (e.g. relate) fired without a target. Requires --workflow-ref. Mutually exclusive with --subject-id / --title. NOTE: not yet supported through the installed queue plugin (its RPC protocol still requires a subject); dispatch such runs directly for now."
     )]
     pub(crate) adhoc: bool,
     #[arg(long, value_name = "TEXT", help = "Custom subject description (used with --title).")]

--- a/crates/orchestrator-cli/src/cli_types/shared_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/shared_types.rs
@@ -72,12 +72,6 @@ pub(crate) struct IdArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct TaskIdArgs {
-    #[arg(short, long, value_name = "TASK_ID", help = "Task identifier.")]
-    pub(crate) task_id: String,
-}
-
-#[derive(Debug, Args)]
 pub(crate) struct LogArgs {
     #[arg(
         long,

--- a/crates/orchestrator-cli/src/cli_types/workflow_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/workflow_types.rs
@@ -83,14 +83,18 @@ pub(crate) struct WorkflowListArgs {
     pub(crate) status: Option<String>,
     #[arg(long, value_name = "WORKFLOW_REF", help = "Filter workflows by workflow definition/reference id.")]
     pub(crate) workflow_ref: Option<String>,
-    #[arg(long, value_name = "TASK_ID", help = "Filter workflows linked to a task id.")]
-    pub(crate) task_id: Option<String>,
+    #[arg(
+        long = "subject-id",
+        value_name = "SUBJECT_ID",
+        help = "Filter workflows linked to a subject id. Matched exactly against the id the workflow stored — built-in kinds (task/requirement) store the qualified form, so filter with `task:TASK-001`."
+    )]
+    pub(crate) subject_id: Option<String>,
     #[arg(long, value_name = "PHASE_ID", help = "Filter workflows containing a phase id.")]
     pub(crate) phase_id: Option<String>,
     #[arg(
         long,
         value_name = "TEXT",
-        help = "Case-insensitive text search over workflow id, task id, ref, and phases."
+        help = "Case-insensitive text search over workflow id, subject id, ref, and phases."
     )]
     pub(crate) search: Option<String>,
     #[arg(long, value_name = "SORT", help = WORKFLOW_SORT_HELP)]
@@ -276,22 +280,13 @@ pub(crate) struct WorkflowRunArgs {
         help = "Workflow definition name from project YAML or an installed pack (e.g. standard-workflow, hotfix-workflow, vendor.pack/review)."
     )]
     pub(crate) pipeline: Option<String>,
-    #[arg(
-        long,
-        value_name = "TASK_ID",
-        group = "subject",
-        help = "Task to run the workflow for. Accepts a bare id (TASK-001) or the qualified form (task:TASK-001)."
-    )]
-    pub(crate) task_id: Option<String>,
-    #[arg(long, value_name = "REQ_ID", group = "subject", help = "Requirement id to run the workflow for.")]
-    pub(crate) requirement_id: Option<String>,
     #[arg(long, value_name = "TITLE", group = "subject", help = "Custom workflow title for freeform execution.")]
     pub(crate) title: Option<String>,
     #[arg(
         long = "subject-id",
         value_name = "SUBJECT_ID",
         group = "subject",
-        help = "Generic subject to run the workflow for, any kind (BaaS dynamic kinds like blog/post). Accepts a qualified id (blog:BLOG-001 — kind trusted; the recommended form) or a bare id (BLOG-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form). Mutually exclusive with --task-id / --requirement-id / --title."
+        help = "Subject to run the workflow for, any kind. Accepts a qualified id (task:TASK-001 / requirement:REQ-042 / blog:BLOG-001 — kind trusted; the recommended form) or a bare id (TASK-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form). Mutually exclusive with --title."
     )]
     pub(crate) subject_id: Option<String>,
     #[arg(long, value_name = "TEXT", help = "Custom workflow description (used with --title).")]
@@ -337,15 +332,13 @@ pub(crate) struct WorkflowPromptRenderArgs {
         help = "Existing workflow id to render from persisted workflow state."
     )]
     pub(crate) workflow_id: Option<String>,
-    #[arg(long, value_name = "TASK_ID", group = "subject", help = "Task id for ad-hoc prompt rendering.")]
-    pub(crate) task_id: Option<String>,
     #[arg(
-        long,
-        value_name = "REQ_ID",
+        long = "subject-id",
+        value_name = "SUBJECT_ID",
         group = "subject",
-        help = "Requirement id for ad-hoc prompt rendering (alternative to --task-id)."
+        help = "Subject to render an ad-hoc prompt for, any kind. Accepts a qualified id (task:TASK-001 / requirement:REQ-042 / blog:BLOG-001 — kind trusted; the recommended form) or a bare id (TASK-001 — kind probed across backends that declare concrete kinds; pure catch-all dynamic backends require the qualified form)."
     )]
-    pub(crate) requirement_id: Option<String>,
+    pub(crate) subject_id: Option<String>,
     #[arg(long, value_name = "TITLE", group = "subject", help = "Custom workflow title for ad-hoc prompt rendering.")]
     pub(crate) title: Option<String>,
     #[arg(long, value_name = "TEXT", help = "Custom workflow description (used with --title).")]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_command_args.rs
@@ -2,8 +2,6 @@ use super::{push_opt, QueueEnqueueInput, QueueReorderInput, QueueSubjectInput};
 
 pub(super) fn build_queue_enqueue_args(input: &QueueEnqueueInput) -> Vec<String> {
     let mut args = vec!["queue".to_string(), "enqueue".to_string()];
-    push_opt(&mut args, "--task-id", input.task_id.clone());
-    push_opt(&mut args, "--requirement-id", input.requirement_id.clone());
     push_opt(&mut args, "--title", input.title.clone());
     push_opt(&mut args, "--subject-id", input.subject_id.clone());
     push_opt(&mut args, "--description", input.description.clone());

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
@@ -3,16 +3,11 @@ use super::*;
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct QueueEnqueueInput {
     #[serde(default)]
-    pub(super) task_id: Option<String>,
-    #[serde(default)]
-    pub(super) requirement_id: Option<String>,
-    #[serde(default)]
     pub(super) title: Option<String>,
-    /// For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like
-    /// blog/post/etc.), pass `subject_id` (the kernel resolves the kind)
-    /// instead of `task_id`. Accepts a qualified id (`blog:BLOG-001` — kind
-    /// trusted) or a bare id (`BLOG-001` — kind resolved via the subject
-    /// router). Mutually exclusive with `task_id` / `requirement_id` / `title`.
+    /// Subject to enqueue for any kind (task, requirement, or dynamic kinds like
+    /// blog/post). Accepts a qualified id (`task:TASK-001` / `blog:BLOG-001` —
+    /// kind trusted) or a bare id (`TASK-001` — kind resolved via the subject
+    /// router). Mutually exclusive with `title`.
     #[serde(default)]
     pub(super) subject_id: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
@@ -22,7 +22,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.queue.enqueue",
-        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using a task, requirement, custom, or arbitrary-kind subject plus optional workflow/input override. Prerequisites: Subjects must exist; custom subjects require a title. For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post/etc.), pass subject_id (the kernel resolves the kind) instead of task_id. Example: {\"task_id\": \"TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
+        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using any subject kind or a custom title plus optional workflow/input override. Prerequisites: Subjects must exist; custom subjects require a title. Pass subject_id for any subject kind (task, requirement, or dynamic kinds like blog/post) — a qualified id (task:TASK-001, blog:BLOG-001) is trusted, a bare id (TASK-001) is resolved via the subject router. Example: {\"subject_id\": \"TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
         input_schema = ao_schema_for_type::<QueueEnqueueInput>()
     )]
     async fn ao_queue_enqueue(&self, params: Parameters<QueueEnqueueInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -173,15 +173,18 @@ fn build_cli_error_payload_falls_back_to_stdout_envelope_when_stderr_json_missin
 
 #[test]
 fn build_bulk_workflow_run_item_args_basic() {
-    let item = BulkWorkflowRunItem { task_id: "TASK-4".to_string(), workflow_ref: None, input_json: None };
+    let item = BulkWorkflowRunItem { subject_id: "TASK-4".to_string(), workflow_ref: None, input_json: None };
     let args = build_bulk_workflow_run_item_args(&item);
-    assert_eq!(args, vec!["workflow".to_string(), "run".to_string(), "--task-id".to_string(), "TASK-4".to_string(),]);
+    assert_eq!(
+        args,
+        vec!["workflow".to_string(), "run".to_string(), "--subject-id".to_string(), "TASK-4".to_string(),]
+    );
 }
 
 #[test]
 fn build_bulk_workflow_run_item_args_with_workflow_ref_and_input() {
     let item = BulkWorkflowRunItem {
-        task_id: "TASK-5".to_string(),
+        subject_id: "TASK-5".to_string(),
         workflow_ref: Some("my-pipeline".to_string()),
         input_json: Some(r#"{"key":"val"}"#.to_string()),
     };
@@ -192,7 +195,7 @@ fn build_bulk_workflow_run_item_args_with_workflow_ref_and_input() {
             "workflow".to_string(),
             "run".to_string(),
             "my-pipeline".to_string(),
-            "--task-id".to_string(),
+            "--subject-id".to_string(),
             "TASK-5".to_string(),
             "--input-json".to_string(),
             r#"{"key":"val"}"#.to_string(),
@@ -207,17 +210,21 @@ fn validate_workflow_run_multiple_rejects_empty() {
 }
 
 #[test]
-fn validate_workflow_run_multiple_rejects_empty_task_id() {
-    let runs = vec![BulkWorkflowRunItem { task_id: "".to_string(), workflow_ref: None, input_json: None }];
+fn validate_workflow_run_multiple_rejects_empty_subject_id() {
+    let runs = vec![BulkWorkflowRunItem { subject_id: "".to_string(), workflow_ref: None, input_json: None }];
     let err = validate_workflow_run_multiple_input("animus.workflow.run-multiple", &runs).unwrap_err();
-    assert!(err.contains("task_id must not be empty"), "expected empty-task-id error, got: {err}");
+    assert!(err.contains("subject_id must not be empty"), "expected empty-subject-id error, got: {err}");
 }
 
 #[test]
 fn validate_workflow_run_multiple_accepts_valid_runs() {
     let runs = vec![
-        BulkWorkflowRunItem { task_id: "TASK-1".to_string(), workflow_ref: None, input_json: None },
-        BulkWorkflowRunItem { task_id: "TASK-2".to_string(), workflow_ref: Some("p1".to_string()), input_json: None },
+        BulkWorkflowRunItem { subject_id: "TASK-1".to_string(), workflow_ref: None, input_json: None },
+        BulkWorkflowRunItem {
+            subject_id: "TASK-2".to_string(),
+            workflow_ref: Some("p1".to_string()),
+            input_json: None,
+        },
     ];
     assert!(validate_workflow_run_multiple_input("animus.workflow.run-multiple", &runs).is_ok());
 }
@@ -237,7 +244,7 @@ fn on_error_continue_as_str() {
 #[test]
 fn validate_workflow_run_multiple_rejects_over_max() {
     let runs: Vec<BulkWorkflowRunItem> = (0..=MAX_BATCH_SIZE)
-        .map(|i| BulkWorkflowRunItem { task_id: format!("TASK-{i}"), workflow_ref: None, input_json: None })
+        .map(|i| BulkWorkflowRunItem { subject_id: format!("TASK-{i}"), workflow_ref: None, input_json: None })
         .collect();
     let err = validate_workflow_run_multiple_input("animus.workflow.run-multiple", &runs).unwrap_err();
     assert!(err.contains("exceeds maximum"), "expected max-size error, got: {err}");
@@ -737,7 +744,7 @@ fn build_workflow_list_args_includes_filters_and_sort() {
     let args = build_workflow_list_args(&WorkflowListInput {
         status: Some("running".to_string()),
         workflow_ref: Some("default".to_string()),
-        task_id: Some("TASK-123".to_string()),
+        subject_id: Some("TASK-123".to_string()),
         phase_id: Some("implementation".to_string()),
         search: Some("retry".to_string()),
         sort: Some("started_at".to_string()),
@@ -755,7 +762,7 @@ fn build_workflow_list_args_includes_filters_and_sort() {
             "running".to_string(),
             "--workflow-ref".to_string(),
             "default".to_string(),
-            "--task-id".to_string(),
+            "--subject-id".to_string(),
             "TASK-123".to_string(),
             "--phase-id".to_string(),
             "implementation".to_string(),
@@ -862,10 +869,8 @@ fn build_daemon_config_set_args_wires_all_runtime_settings() {
 #[test]
 fn build_queue_enqueue_args_includes_optional_fields() {
     let input = QueueEnqueueInput {
-        task_id: Some("TASK-123".to_string()),
-        requirement_id: None,
         title: None,
-        subject_id: None,
+        subject_id: Some("TASK-123".to_string()),
         description: None,
         workflow_ref: Some("ops".to_string()),
         input_json: Some("{\"mode\":\"fast\"}".to_string()),
@@ -879,7 +884,7 @@ fn build_queue_enqueue_args_includes_optional_fields() {
         vec![
             "queue".to_string(),
             "enqueue".to_string(),
-            "--task-id".to_string(),
+            "--subject-id".to_string(),
             "TASK-123".to_string(),
             "--workflow-ref".to_string(),
             "ops".to_string(),
@@ -1543,7 +1548,7 @@ fn mcp_workflow_list_routes_via_control_when_socket_present() {
     let input = WorkflowListInput {
         status: Some("running".to_string()),
         workflow_ref: None,
-        task_id: Some("TASK-1".to_string()),
+        subject_id: Some("TASK-1".to_string()),
         phase_id: None,
         search: None,
         sort: None,
@@ -1557,7 +1562,7 @@ fn mcp_workflow_list_routes_via_control_when_socket_present() {
     assert_eq!(args[1], "list");
     assert!(args.contains(&"--status".to_string()));
     assert!(args.contains(&"running".to_string()));
-    assert!(args.contains(&"--task-id".to_string()));
+    assert!(args.contains(&"--subject-id".to_string()));
     assert!(args.contains(&"TASK-1".to_string()));
 }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_command_args.rs
@@ -4,7 +4,7 @@ pub(super) fn build_workflow_list_args(input: &super::WorkflowListInput) -> Vec<
     let mut args = vec!["workflow".to_string(), "list".to_string()];
     push_opt(&mut args, "--status", input.status.clone());
     push_opt(&mut args, "--workflow-ref", input.workflow_ref.clone());
-    push_opt(&mut args, "--task-id", input.task_id.clone());
+    push_opt(&mut args, "--subject-id", input.subject_id.clone());
     push_opt(&mut args, "--phase-id", input.phase_id.clone());
     push_opt(&mut args, "--search", input.search.clone());
     push_opt(&mut args, "--sort", input.sort.clone());
@@ -16,8 +16,8 @@ pub(super) fn build_bulk_workflow_run_item_args(item: &BulkWorkflowRunItem) -> V
     if let Some(workflow_ref) = item.workflow_ref.clone() {
         args.push(workflow_ref);
     }
-    args.push("--task-id".to_string());
-    args.push(item.task_id.clone());
+    args.push("--subject-id".to_string());
+    args.push(item.subject_id.clone());
     push_opt(&mut args, "--input-json", item.input_json.clone());
     args
 }
@@ -33,8 +33,8 @@ pub(super) fn validate_workflow_run_multiple_input(
         return Err(format!("{tool_name}: runs count {} exceeds maximum {MAX_BATCH_SIZE}", runs.len()));
     }
     for (i, item) in runs.iter().enumerate() {
-        if item.task_id.trim().is_empty() {
-            return Err(format!("{tool_name}: item[{i}].task_id must not be empty"));
+        if item.subject_id.trim().is_empty() {
+            return Err(format!("{tool_name}: item[{i}].subject_id must not be empty"));
         }
     }
     Ok(())

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
@@ -8,8 +8,11 @@ pub(super) struct WorkflowListInput {
     pub(super) status: Option<String>,
     #[serde(default)]
     pub(super) workflow_ref: Option<String>,
+    /// Filter workflows linked to a subject id. Matched exactly against the id
+    /// the workflow stored — built-in kinds (task/requirement) store the
+    /// qualified form, so filter with `task:TASK-001`.
     #[serde(default)]
-    pub(super) task_id: Option<String>,
+    pub(super) subject_id: Option<String>,
     #[serde(default)]
     pub(super) phase_id: Option<String>,
     #[serde(default)]
@@ -27,16 +30,11 @@ pub(super) struct WorkflowListInput {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct WorkflowRunInput {
     #[serde(default)]
-    pub(super) task_id: Option<String>,
-    #[serde(default)]
-    pub(super) requirement_id: Option<String>,
-    #[serde(default)]
     pub(super) title: Option<String>,
-    /// For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like
-    /// blog/post/etc.), pass `subject_id` (the kernel resolves the kind)
-    /// instead of `task_id`. Accepts a qualified id (`blog:BLOG-001` — kind
-    /// trusted) or a bare id (`BLOG-001` — kind resolved via the subject
-    /// router). Mutually exclusive with `task_id` / `requirement_id` / `title`.
+    /// Subject to run the workflow for, any kind (task, requirement, or dynamic
+    /// kinds like blog/post). Accepts a qualified id (`task:TASK-001` /
+    /// `blog:BLOG-001` — kind trusted) or a bare id (`TASK-001` — kind resolved
+    /// via the subject router). Mutually exclusive with `title`.
     #[serde(default)]
     pub(super) subject_id: Option<String>,
     #[serde(default)]
@@ -51,7 +49,9 @@ pub(super) struct WorkflowRunInput {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct BulkWorkflowRunItem {
-    pub(super) task_id: String,
+    /// Subject to run the workflow for. Accepts a qualified id (`task:TASK-001`)
+    /// or a bare id (`TASK-001`, kind resolved via the subject router).
+    pub(super) subject_id: String,
     #[serde(default)]
     pub(super) workflow_ref: Option<String>,
     #[serde(default)]
@@ -118,7 +118,10 @@ pub(super) struct WorkflowConfigEntityRemoveInput {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct WorkflowExecuteInput {
-    pub(super) task_id: String,
+    /// Subject to execute the workflow for. Accepts a qualified id
+    /// (`task:TASK-001`) or a bare id (`TASK-001`, kind resolved via the subject
+    /// router).
+    pub(super) subject_id: String,
     #[serde(default)]
     pub(super) workflow_ref: Option<String>,
     #[serde(default)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
@@ -4,7 +4,7 @@ use super::*;
 impl AoMcpServer {
     #[tool(
         name = "animus.workflow.list",
-        description = "List workflows with optional filters (status, workflow_ref, task_id, phase_id, search), plus sort and pagination hints. Purpose: View workflow executions and their current state. Prerequisites: None. Example: {\"status\": \"running\"} or {\"task_id\": \"TASK-001\", \"sort\": \"started_at\"}. Sequencing: Use animus.workflow.get for specific workflow details, or animus.workflow.run to start a new workflow.",
+        description = "List workflows with optional filters (status, workflow_ref, subject_id, phase_id, search), plus sort and pagination hints. Purpose: View workflow executions and their current state. Prerequisites: None. Example: {\"status\": \"running\"} or {\"subject_id\": \"TASK-001\", \"sort\": \"started_at\"}. Sequencing: Use animus.workflow.get for specific workflow details, or animus.workflow.run to start a new workflow.",
         input_schema = ao_schema_for_type::<WorkflowListInput>()
     )]
     async fn ao_workflow_list(&self, params: Parameters<WorkflowListInput>) -> Result<CallToolResult, McpError> {
@@ -20,15 +20,13 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.workflow.run",
-        description = "Run a workflow for a subject. Purpose: Execute a workflow to complete subject phases automatically. Prerequisites: Subject should exist. For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post/etc.), pass subject_id (the kernel resolves the kind) instead of task_id. Example: {\"task_id\": \"TASK-001\"} or {\"subject_id\": \"blog:BLOG-001\"} or {\"subject_id\": \"blog:BLOG-001\", \"workflow_ref\": \"draft-post\"}. Sequencing: Use animus.subject.status to track progress, animus.workflow.get to monitor, and animus.workflow.pause/resume/cancel for control.",
+        description = "Run a workflow for a subject. Purpose: Execute a workflow to complete subject phases automatically. Prerequisites: Subject should exist. Pass subject_id for any subject kind (task, requirement, or dynamic kinds like blog/post) — a qualified id (task:TASK-001, blog:BLOG-001) is trusted, a bare id (TASK-001) is resolved via the subject router. Example: {\"subject_id\": \"TASK-001\"} or {\"subject_id\": \"blog:BLOG-001\", \"workflow_ref\": \"draft-post\"}. Sequencing: Use animus.subject.status to track progress, animus.workflow.get to monitor, and animus.workflow.pause/resume/cancel for control.",
         input_schema = ao_schema_for_type::<WorkflowRunInput>()
     )]
     async fn ao_workflow_run(&self, params: Parameters<WorkflowRunInput>) -> Result<CallToolResult, McpError> {
         let input = params.0;
         let mut args = vec!["workflow".to_string(), "run".to_string()];
         push_workflow_run_pipeline_arg(&mut args, input.workflow_ref);
-        push_opt(&mut args, "--task-id", input.task_id);
-        push_opt(&mut args, "--requirement-id", input.requirement_id);
         push_opt(&mut args, "--title", input.title);
         push_opt(&mut args, "--subject-id", input.subject_id);
         push_opt(&mut args, "--description", input.description);
@@ -151,7 +149,7 @@ impl AoMcpServer {
             .map(|item| {
                 let args = build_bulk_workflow_run_item_args(&item);
                 let command = args.join(" ");
-                BatchItemExec { target_id: item.task_id, command, args }
+                BatchItemExec { target_id: item.subject_id, command, args }
             })
             .collect();
         self.run_batch_tool("animus.workflow.run-multiple", items, &input.on_error, input.project_root).await
@@ -159,7 +157,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.workflow.execute",
-        description = "Execute a workflow synchronously. Purpose: Run a workflow without the daemon, blocking until completion. Prerequisites: Task must exist (use animus.subject.get with {\"kind\":\"task\"} to verify). Example: {\"task_id\": \"TASK-001\"} or {\"task_id\": \"TASK-001\", \"phase\": \"implementation\"}. Sequencing: Use animus.subject.get to verify the task first, or animus.workflow.config.get to review workflow config.",
+        description = "Execute a workflow synchronously. Purpose: Run a workflow without the daemon, blocking until completion. Prerequisites: Subject must exist (use animus.subject.get to verify). Pass subject_id for any kind — a qualified id (task:TASK-001) is trusted, a bare id (TASK-001) is resolved via the subject router. Example: {\"subject_id\": \"TASK-001\"} or {\"subject_id\": \"TASK-001\", \"phase\": \"implementation\"}. Sequencing: Use animus.subject.get to verify the subject first, or animus.workflow.config.get to review workflow config.",
         input_schema = ao_schema_for_type::<WorkflowExecuteInput>()
     )]
     async fn ao_workflow_execute(&self, params: Parameters<WorkflowExecuteInput>) -> Result<CallToolResult, McpError> {
@@ -167,8 +165,8 @@ impl AoMcpServer {
         let mut args = vec!["workflow".to_string(), "run".to_string()];
         push_workflow_run_pipeline_arg(&mut args, input.workflow_ref);
         args.push("--sync".to_string());
-        args.push("--task-id".to_string());
-        args.push(input.task_id);
+        args.push("--subject-id".to_string());
+        args.push(input.subject_id);
         push_opt(&mut args, "--phase", input.phase);
         push_opt(&mut args, "--model", input.model);
         push_opt(&mut args, "--tool", input.tool);

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -8,8 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use orchestrator_core::{load_workflow_config_or_default, services::ServiceHub};
 use protocol::{SubjectDispatch, SubjectDispatchExt};
 
-use super::ops_workflow::resolve_requirement_workflow_ref;
-use super::subject_id_dispatch::{resolve_subject_id_ref, subject_ref_for_kind, RouterSubjectProbe, SubjectKindProbe};
+use super::subject_id_dispatch::{resolve_subject_id_ref, RouterSubjectProbe};
 use crate::{invalid_input_error, print_ok, print_value, CliError, CliErrorKind, QueueCommand, QueueSubjectArgs};
 
 /// Build a genuinely subjectless (ad-hoc) dispatch with NO bound subject.
@@ -28,11 +27,8 @@ fn subjectless_dispatch(workflow_ref: String, input: Option<serde_json::Value>) 
     SubjectDispatch::subjectless(workflow_ref, "manual-queue-enqueue", chrono::Utc::now()).with_input(input)
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn resolve_enqueue_dispatch(
     project_root: &str,
-    task_id: Option<String>,
-    requirement_id: Option<String>,
     title: Option<String>,
     description: Option<String>,
     workflow_ref: Option<String>,
@@ -47,30 +43,8 @@ async fn resolve_enqueue_dispatch(
         })?;
         return Ok(subjectless_dispatch(workflow_ref, input));
     }
-    match (task_id, requirement_id, title) {
-        (Some(task_id), None, None) => {
-            // Resolve the task's existence through the installed subject_backend
-            // plugin(s) — the SAME store `subject get/list/status` read — instead
-            // of the in-tree file-backed task store. On a deployment whose
-            // subjects live in a plugin backend (e.g. animus-postgres) the
-            // in-tree store is empty, so the legacy `hub.tasks().get()` path
-            // returned not_found for subjects that demonstrably exist. This keeps
-            // enqueue-by-id consistent with the generic `--subject-id` path.
-            let workflow_ref = workflow_ref.unwrap_or_else(|| {
-                load_workflow_config_or_default(std::path::Path::new(project_root)).config.default_workflow_ref
-            });
-            let probe = RouterSubjectProbe::discover(std::path::Path::new(project_root)).await?;
-            resolve_builtin_kind_dispatch("task", &task_id, workflow_ref, input, &probe).await
-        }
-        (None, Some(requirement_id), None) => {
-            let workflow_ref = match workflow_ref {
-                Some(workflow_ref) => workflow_ref,
-                None => resolve_requirement_workflow_ref(project_root)?,
-            };
-            let probe = RouterSubjectProbe::discover(std::path::Path::new(project_root)).await?;
-            resolve_builtin_kind_dispatch("requirement", &requirement_id, workflow_ref, input, &probe).await
-        }
-        (None, None, Some(title)) => Ok(SubjectDispatch::for_custom(
+    match title {
+        Some(title) => Ok(SubjectDispatch::for_custom(
             title,
             description.unwrap_or_default(),
             workflow_ref.unwrap_or_else(|| {
@@ -79,43 +53,10 @@ async fn resolve_enqueue_dispatch(
             input,
             "manual-queue-enqueue",
         )),
-        (None, None, None) => Err(anyhow!(
-            "no subject specified. Use --task-id TASK_ID for existing tasks, --requirement-id REQ_ID for requirements, --title \"name\" for custom dispatches, or --adhoc --workflow-ref REF for a subjectless run."
-        )),
-        _ => Err(anyhow!(
-            "--task-id, --requirement-id, and --title are mutually exclusive - provide only one subject selector."
+        None => Err(anyhow!(
+            "no subject specified. Use --subject-id SUBJECT_ID for existing subjects (any kind; qualified task:TASK-001 or bare TASK-001), --title \"name\" for custom dispatches, or --adhoc --workflow-ref REF for a subjectless run."
         )),
     }
-}
-
-/// Resolve a built-in `--task-id` / `--requirement-id` enqueue by confirming the
-/// subject's existence through the subject router (the installed
-/// `subject_backend` plugin), then building a kind-correct dispatch carrying the
-/// backend-qualified id.
-///
-/// The existence probe routes `<kind>/get` to the same plugin store that
-/// `subject get/list/status` and the generic `--subject-id` enqueue path use,
-/// so a subject created through a plugin backend resolves here too. A missing
-/// subject surfaces a clean `not_found` (exit class 3); a genuinely unhealthy
-/// backend propagates as an error rather than masquerading as not-found.
-async fn resolve_builtin_kind_dispatch(
-    kind: &str,
-    native_id: &str,
-    workflow_ref: String,
-    input: Option<serde_json::Value>,
-    probe: &dyn SubjectKindProbe,
-) -> Result<SubjectDispatch> {
-    let qualified_id = crate::qualify_subject_id(native_id, kind);
-    if !probe.subject_exists(kind, &qualified_id).await? {
-        return Err(crate::not_found_error(format!("{kind} not found: {native_id}")));
-    }
-    Ok(SubjectDispatch::for_subject_with_metadata(
-        subject_ref_for_kind(kind, qualified_id),
-        workflow_ref,
-        "manual-queue-enqueue",
-        chrono::Utc::now(),
-    )
-    .with_input(input))
 }
 
 /// Resolve a generic `--subject-id` enqueue into a kind-correct
@@ -232,8 +173,6 @@ pub(crate) async fn handle_queue(
             } else {
                 resolve_enqueue_dispatch(
                     project_root,
-                    args.task_id.clone(),
-                    args.requirement_id.clone(),
                     args.title.clone(),
                     args.description.clone(),
                     args.workflow_ref.clone(),
@@ -780,56 +719,9 @@ async fn lookup_plugin_entries_by_subject_set(
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
     use orchestrator_core::{builtin_workflow_config, write_agent_runtime_config, write_workflow_config};
 
     use super::*;
-
-    /// Stub subject probe: reports whether a given `(kind, qualified_id)` exists,
-    /// so the built-in `--task-id` / `--requirement-id` resolution can be tested
-    /// without spawning a real subject_backend plugin.
-    struct StubProbe {
-        exists: bool,
-    }
-
-    #[async_trait]
-    impl SubjectKindProbe for StubProbe {
-        fn candidate_kinds(&self) -> Vec<String> {
-            vec!["task".to_string(), "requirement".to_string()]
-        }
-
-        async fn subject_exists(&self, _kind: &str, _qualified_id: &str) -> Result<bool> {
-            Ok(self.exists)
-        }
-    }
-
-    #[tokio::test]
-    async fn resolve_builtin_kind_dispatch_resolves_existing_task_via_router() {
-        // The router (subject_backend plugin) owns the id — enqueue must resolve
-        // it and build a kind=task dispatch carrying the backend-qualified id.
-        let probe = StubProbe { exists: true };
-        let dispatch = resolve_builtin_kind_dispatch("task", "TASK-216", "standard-workflow".to_string(), None, &probe)
-            .await
-            .expect("existing task resolves");
-        // `task` canonicalizes to the namespaced built-in kind, and the id is
-        // carried in the backend-qualified `task:<native>` form the subject
-        // backend resolves (matching the generic `--subject-id` path).
-        assert_eq!(dispatch.subject_kind(), Some("animus.task"));
-        assert_eq!(dispatch.subject_id(), Some("task:TASK-216"));
-        assert_eq!(dispatch.workflow_ref, "standard-workflow");
-    }
-
-    #[tokio::test]
-    async fn resolve_builtin_kind_dispatch_missing_subject_is_not_found() {
-        // The router does not own the id — enqueue must surface a clean not_found
-        // (exit class 3) rather than a generic internal error.
-        let probe = StubProbe { exists: false };
-        let err = resolve_builtin_kind_dispatch("task", "TASK-999", "standard-workflow".to_string(), None, &probe)
-            .await
-            .expect_err("missing subject should fail");
-        assert!(err.to_string().contains("task not found: TASK-999"), "got: {err}");
-        assert_eq!(crate::classify_cli_error_kind(&err), CliErrorKind::NotFound);
-    }
 
     #[test]
     fn queue_plugin_required_keeps_message_and_kind_but_adds_structured_remediation() {
@@ -854,14 +746,12 @@ mod tests {
         write_agent_runtime_config(temp.path(), &crate::shared::seeded_agent_runtime_config())
             .expect("write runtime config");
 
-        let err =
-            resolve_enqueue_dispatch(temp.path().to_string_lossy().as_ref(), None, None, None, None, None, None, false)
-                .await
-                .expect_err("missing subject should fail");
+        let err = resolve_enqueue_dispatch(temp.path().to_string_lossy().as_ref(), None, None, None, None, false)
+            .await
+            .expect_err("missing subject should fail");
 
         let msg = err.to_string();
-        assert!(msg.contains("--task-id"), "error should mention --task-id");
-        assert!(msg.contains("--requirement-id"), "error should mention --requirement-id");
+        assert!(msg.contains("--subject-id"), "error should mention --subject-id");
         assert!(msg.contains("--title"), "error should mention --title");
         assert!(msg.contains("custom dispatches"), "error should suggest custom dispatches");
         assert!(msg.contains("--adhoc"), "error should mention the subjectless --adhoc path");
@@ -874,8 +764,6 @@ mod tests {
         // an explicit workflow ref. It must build a valid dispatch (not error).
         let dispatch = resolve_enqueue_dispatch(
             temp.path().to_string_lossy().as_ref(),
-            None,
-            None,
             None,
             None,
             Some("relate".to_string()),
@@ -895,10 +783,9 @@ mod tests {
     #[tokio::test]
     async fn resolve_enqueue_dispatch_adhoc_requires_workflow_ref() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let err =
-            resolve_enqueue_dispatch(temp.path().to_string_lossy().as_ref(), None, None, None, None, None, None, true)
-                .await
-                .expect_err("adhoc without workflow ref should fail");
+        let err = resolve_enqueue_dispatch(temp.path().to_string_lossy().as_ref(), None, None, None, None, true)
+            .await
+            .expect_err("adhoc without workflow ref should fail");
         assert!(err.to_string().contains("--workflow-ref"), "error names the missing workflow ref: {err}");
     }
 
@@ -913,31 +800,6 @@ mod tests {
         assert_eq!(b.subject_key(), None);
         assert!(a.subject().is_none());
         assert!(b.subject().is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_enqueue_dispatch_multiple_subjects_shows_mutual_exclusivity_error() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let workflow_config = builtin_workflow_config();
-        write_workflow_config(temp.path(), &workflow_config).expect("write config");
-        write_agent_runtime_config(temp.path(), &crate::shared::seeded_agent_runtime_config())
-            .expect("write runtime config");
-
-        let err = resolve_enqueue_dispatch(
-            temp.path().to_string_lossy().as_ref(),
-            Some("TASK-1".to_string()),
-            Some("REQ-1".to_string()),
-            None,
-            None,
-            None,
-            None,
-            false,
-        )
-        .await
-        .expect_err("multiple subjects should fail");
-
-        let msg = err.to_string();
-        assert!(msg.contains("mutually exclusive"), "error should mention mutual exclusivity");
     }
 
     #[tokio::test]

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
@@ -12,8 +12,6 @@ use animus_workflow_runner_protocol as workflow_proto;
 #[derive(Debug)]
 pub(crate) struct WorkflowExecuteArgs {
     pub(crate) workflow_id: Option<String>,
-    pub(crate) task_id: Option<String>,
-    pub(crate) requirement_id: Option<String>,
     pub(crate) title: Option<String>,
     /// Generic, kind-correct subject dispatch for the BaaS `--subject-id` path.
     /// When set (and not re-attaching to an existing workflow), it is relayed
@@ -42,14 +40,11 @@ pub(crate) struct WorkflowExecuteArgs {
 }
 
 pub(crate) async fn handle_workflow_execute(
-    mut args: WorkflowExecuteArgs,
+    args: WorkflowExecuteArgs,
     hub: Arc<dyn ServiceHub>,
     project_root: &str,
     json: bool,
 ) -> Result<()> {
-    if args.requirement_id.is_some() && args.workflow_ref.is_none() {
-        args.workflow_ref = Some(super::resolve_requirement_workflow_ref(project_root)?);
-    }
     if args.workflow_id.is_some() && !args.vars.is_empty() {
         anyhow::bail!(
             "--var cannot be used with --workflow-id; persisted workflow vars are authoritative for existing workflows"
@@ -66,10 +61,7 @@ pub(crate) async fn handle_workflow_execute(
         hub.daemon().start(Default::default()).await?;
     }
 
-    let task_id_for_sync = args.task_id.clone();
     let phase_filter = args.phase.clone();
-    let task_id_for_output = args.task_id.clone();
-    let requirement_id_for_output = args.requirement_id.clone();
 
     // Re-attaching to an existing workflow record: the persisted record is
     // authoritative for subject, input, and vars. Register this process in
@@ -124,8 +116,11 @@ pub(crate) async fn handle_workflow_execute(
             workflow_id: None,
             subject_dispatch: args.subject_dispatch.clone(),
             subject_ref: None,
-            task_id: args.task_id.clone(),
-            requirement_id: args.requirement_id.clone(),
+            // task/requirement are ordinary subjects now: a concrete-kind subject
+            // arrives as `subject_dispatch` (from `--subject-id`); only a freeform
+            // `--title` custom run travels via `title`.
+            task_id: None,
+            requirement_id: None,
             title: args.title.clone(),
             description: args.description.clone(),
             workflow_ref: args.workflow_ref.clone(),
@@ -162,23 +157,12 @@ pub(crate) async fn handle_workflow_execute(
         | workflow_proto::workflow_status::Parsed::Unknown(_) => None,
     };
     if phase_filter.is_none() {
-        if let (Some(task_id), Some(status)) = (task_id_for_sync.as_deref(), parsed_status) {
-            project_terminal_workflow_result(
-                hub.clone(),
-                project_root,
-                plugin_result.subject_id.as_str(),
-                Some(task_id),
-                Some(plugin_result.workflow_ref.as_str()),
-                Some(plugin_result.workflow_id.as_str()),
-                status,
-                None,
-            )
-            .await;
-        } else if let (true, Some(status)) = (existing_workflow.is_some(), parsed_status) {
+        if let (true, Some(status)) = (existing_workflow.is_some(), parsed_status) {
             // workflow-id-only invocations (detached async-run children,
-            // manual `--sync --workflow-id` resumes) carry no --task-id;
-            // derive the subject from the persisted record so the task
-            // status projection still lands.
+            // manual `--sync --workflow-id` resumes) carry no bound subject on
+            // the args; derive the subject from the persisted record so the
+            // subject status projection still lands. Fresh `--subject-id` runs
+            // are projected by the workflow_runner plugin that owns the run.
             if let Ok(reloaded) = hub.workflows().get(plugin_result.workflow_id.as_str()).await {
                 project_terminal_workflow_result(
                     hub.clone(),
@@ -201,8 +185,6 @@ pub(crate) async fn handle_workflow_execute(
                 "workflow_ref": plugin_result.workflow_ref,
                 "workflow_status": plugin_result.workflow_status,
                 "subject_id": plugin_result.subject_id,
-                "task_id": task_id_for_output,
-                "requirement_id": requirement_id_for_output,
                 "execution_cwd": plugin_result.execution_cwd,
                 "phases_requested": plugin_result.phases_requested,
                 "total_duration_secs": plugin_result.total_duration_secs,

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -34,7 +34,7 @@ use crate::{
 /// empty-state hint when there are no runs yet.
 fn print_workflow_list_table(items: &[protocol::orchestrator::OrchestratorWorkflow]) {
     if items.is_empty() {
-        println!("No workflow runs yet. Start one with: animus workflow run <pipeline> --task-id <id>");
+        println!("No workflow runs yet. Start one with: animus workflow run <pipeline> --subject-id <id>");
         return;
     }
     let rows: Vec<Vec<String>> = items
@@ -65,72 +65,18 @@ async fn resolve_subject_id_ref_via_router(
     resolve_subject_id_ref(subject_id, &probe).await
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn resolve_workflow_run_dispatch(
-    hub: Arc<dyn ServiceHub>,
+/// Build a freeform `--title` custom dispatch. Subjects of any concrete kind
+/// (task/requirement/blog/…) travel the generic `--subject-id` path instead;
+/// this only handles the titled, subjectless-by-title custom run.
+fn resolve_workflow_run_dispatch(
     project_root: &str,
-    task_id: Option<String>,
-    requirement_id: Option<String>,
     title: Option<String>,
     description: Option<String>,
     workflow_ref: Option<String>,
     vars: std::collections::HashMap<String, String>,
 ) -> Result<protocol::SubjectDispatch> {
-    match (task_id, requirement_id, title) {
-        (Some(tid), None, None) => {
-            // v0.4.12+: task data may live in an installed `subject_backend` plugin
-            // rather than the in-tree task store. Try the in-tree store first (so
-            // legacy projects keep working); if that misses, route through the
-            // subject_resolver so the plugin fallback path engages. Either way we
-            // need the resolved task id (and `is_frontend_related()` if available)
-            // to pick a workflow ref.
-            let (resolved_id, default_ref) = match hub.tasks().get(&tid).await {
-                Ok(task) => (task.id.clone(), default_workflow_ref_for_task(&task, project_root)),
-                Err(in_tree_err) => {
-                    let subject = protocol::orchestrator::SubjectRef::task(tid.clone());
-                    match hub.subject_resolver().resolve_subject_context(&subject, None, None).await {
-                        Ok(ctx) => (ctx.subject_id, default_project_workflow_ref(project_root)),
-                        Err(plugin_err) => {
-                            return Err(anyhow!(
-                                "task '{tid}' not found (in-tree: {in_tree_err}; plugin: {plugin_err})"
-                            ));
-                        }
-                    }
-                }
-            };
-            Ok(protocol::SubjectDispatch::for_task_with_metadata(
-                resolved_id,
-                workflow_ref.unwrap_or(default_ref),
-                "manual-cli-run",
-                Utc::now(),
-            ))
-            .map(|dispatch| dispatch.with_vars(vars))
-        }
-        (None, Some(rid), None) => {
-            // Mirror the task path: try in-tree, fall back to plugin-backed
-            // subject resolver so requirement-kind plugins (e.g. linear) work.
-            let resolved_id = match hub.planning().get_requirement(&rid).await {
-                Ok(_) => rid,
-                Err(in_tree_err) => {
-                    let subject = protocol::orchestrator::SubjectRef::requirement(rid.clone());
-                    match hub.subject_resolver().resolve_subject_context(&subject, None, None).await {
-                        Ok(ctx) => ctx.subject_id,
-                        Err(plugin_err) => {
-                            return Err(anyhow!(
-                                "requirement '{rid}' not found (in-tree: {in_tree_err}; plugin: {plugin_err})"
-                            ));
-                        }
-                    }
-                }
-            };
-            Ok(protocol::SubjectDispatch::for_requirement(
-                resolved_id,
-                workflow_ref.unwrap_or(resolve_requirement_workflow_ref(project_root)?),
-                "manual-cli-run",
-            ))
-            .map(|dispatch| dispatch.with_vars(vars))
-        }
-        (None, None, Some(t)) => Ok(protocol::SubjectDispatch::for_custom(
+    match title {
+        Some(t) => Ok(protocol::SubjectDispatch::for_custom(
             t,
             description.unwrap_or_default(),
             workflow_ref.unwrap_or_else(|| default_project_workflow_ref(project_root)),
@@ -138,8 +84,7 @@ async fn resolve_workflow_run_dispatch(
             "manual-cli-run",
         )
         .with_vars(vars)),
-        (None, None, None) => Err(anyhow!("one of --task-id, --requirement-id, or --title must be provided")),
-        _ => Err(anyhow!("--task-id, --requirement-id, and --title are mutually exclusive")),
+        None => Err(anyhow!("one of --subject-id or --title must be provided")),
     }
 }
 
@@ -404,7 +349,11 @@ fn build_workflow_query(args: crate::WorkflowListArgs) -> Result<WorkflowQuery> 
         filter: WorkflowFilter {
             status: parse_workflow_status_opt(args.status.as_deref())?,
             workflow_ref: args.workflow_ref,
-            task_id: args.task_id,
+            // The workflow record's subject-linkage column stores the id in the
+            // exact form the dispatch carried (built-in kinds keep the qualified
+            // `task:TASK-001`; the filter is an exact match), so pass the
+            // `--subject-id` value through verbatim rather than normalizing it.
+            task_id: args.subject_id,
             phase_id: args.phase_id,
             search_text: args.search,
         },
@@ -463,12 +412,7 @@ pub(crate) async fn handle_workflow(
                 print_value(pruned, json)
             }
         },
-        WorkflowCommand::Run(mut args) => {
-            // Accept either a bare task id (`TASK-001`) or the `task:`-qualified
-            // form (`task:TASK-001`); the task store keys on the bare native id,
-            // so normalize at the CLI boundary. Only the `task:` qualifier is
-            // stripped so a foreign-kind qualifier is not silently rewritten.
-            args.task_id = args.task_id.map(|id| crate::bare_task_id(&id));
+        WorkflowCommand::Run(args) => {
             let workflow_ref = args.pipeline.clone();
             // Generic BaaS subject path: resolve the subject's real kind once
             // (qualified prefix or router probe) and build a kind-correct
@@ -509,8 +453,6 @@ pub(crate) async fn handle_workflow(
             if args.sync {
                 let execute_args = WorkflowExecuteArgs {
                     workflow_id: args.workflow_id,
-                    task_id: args.task_id,
-                    requirement_id: args.requirement_id,
                     title: args.title,
                     subject_dispatch: subject_id_dispatch.clone(),
                     description: args.description,
@@ -535,20 +477,13 @@ pub(crate) async fn handle_workflow(
                 execute::handle_workflow_execute(execute_args, hub, project_root, json).await?;
                 Ok(())
             } else {
-                // C6.5: when JSON mode + task id + daemon is running,
-                // route the start through the control wire so the
-                // daemon's WorkflowService owns the run lifecycle. The
-                // wire response is a WorkflowRunStart (id + status +
-                // started_at) which is a strict subset of the local
-                // OrchestratorWorkflow shape; that's the intentional
-                // trade for the cross-transport story. Requirement /
-                // title / freeform paths and any --input-json path stay
-                // local — the wire surface only covers `workflow/run`
-                // for task subjects today.
-                // Parse --var KEY=VALUE pairs up front so both the
-                // control-wire path and the local path receive the same
-                // validated map. Otherwise the wire path would silently
-                // drop user-supplied vars when the daemon is running.
+                // C6.5: the daemon's WorkflowService owns the run lifecycle when
+                // the subject travels the control wire. Since a subject now always
+                // arrives as a kind-correct `--subject-id` dispatch (or a `--title`
+                // freeform / `--input-json` payload), those non-subject_id paths
+                // stay local.
+                // Parse --var KEY=VALUE pairs up front so the local path receives
+                // the validated map (matching the sync path).
                 let parsed_vars = if args.input_json.is_none() {
                     parse_workflow_vars(&args.vars)?
                 } else {
@@ -564,21 +499,6 @@ pub(crate) async fn handle_workflow(
                     // inbound control request supplies its own actor instead.
                     actor: asserted_actor.clone(),
                 };
-                if json && args.input_json.is_none() && args.requirement_id.is_none() && args.title.is_none() {
-                    if let Some(task_id) = args.task_id.as_ref() {
-                        if let Some(start) = try_workflow_run_via_control(
-                            project_root,
-                            task_id,
-                            workflow_ref.clone(),
-                            &parsed_vars,
-                            &runner_overrides,
-                        )
-                        .await?
-                        {
-                            return print_value(start, true);
-                        }
-                    }
-                }
                 let dispatch = if let Some(subject_dispatch) = subject_id_dispatch {
                     // Generic subject: the kind-correct dispatch was built up
                     // front; the detached runner resolves it via `<kind>/get`.
@@ -588,19 +508,13 @@ pub(crate) async fn handle_workflow(
                         Some(raw) => {
                             resolve_workflow_run_dispatch_from_raw_input(hub.clone(), project_root, &raw).await?
                         }
-                        None => {
-                            resolve_workflow_run_dispatch(
-                                hub.clone(),
-                                project_root,
-                                args.task_id,
-                                args.requirement_id,
-                                args.title,
-                                args.description,
-                                workflow_ref,
-                                parsed_vars,
-                            )
-                            .await?
-                        }
+                        None => resolve_workflow_run_dispatch(
+                            project_root,
+                            args.title,
+                            args.description,
+                            workflow_ref,
+                            parsed_vars,
+                        )?,
                     }
                 };
                 // Post-v0.5 there is no in-process executor: a bare
@@ -879,7 +793,7 @@ pub(crate) async fn handle_workflow(
 /// wire: the wire request only carries status/cursor/limit, has no
 /// sort parameter, and collapses `escalated` into `Failed`.
 fn workflow_list_expressible_on_wire(args: &crate::WorkflowListArgs) -> bool {
-    if args.workflow_ref.is_some() || args.task_id.is_some() || args.phase_id.is_some() || args.search.is_some() {
+    if args.workflow_ref.is_some() || args.subject_id.is_some() || args.phase_id.is_some() || args.search.is_some() {
         return false;
     }
     match parse_workflow_query_sort_opt(args.sort.as_deref()) {
@@ -936,63 +850,6 @@ async fn try_workflow_get_via_control(
         Ok(response) => Ok(Some(response)),
         Err(err) if is_method_unavailable(&err) => {
             tracing::debug!(error = %err, "workflow/get wire returned unavailable; falling back to local");
-            Ok(None)
-        }
-        Err(err) => Err(err),
-    }
-}
-
-async fn try_workflow_run_via_control(
-    project_root: &str,
-    task_id: &str,
-    definition: Option<String>,
-    vars: &std::collections::HashMap<String, String>,
-    overrides: &phases::DetachedRunnerOverrides,
-) -> Result<Option<animus_control_protocol::types::WorkflowRunStart>> {
-    use animus_control_protocol::types::WorkflowRunRequest as WireRequest;
-    use orchestrator_daemon_runtime::control::{is_method_unavailable, ControlClient};
-
-    let project_root_path = Path::new(project_root);
-    let Some(client) = ControlClient::try_connect(project_root_path).await? else {
-        return Ok(None);
-    };
-    // Plumb --var KEY=VALUE pairs through the control wire via the
-    // `params` map under the well-known `vars` key so they reach
-    // `WorkflowRunInput::with_vars` on the daemon side. See the
-    // matching extraction in `ops_workflow::control_routing::workflow_run`.
-    let mut params: std::collections::BTreeMap<String, serde_json::Value> = std::collections::BTreeMap::new();
-    if !vars.is_empty() {
-        let vars_obj: serde_json::Map<String, serde_json::Value> =
-            vars.iter().map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone()))).collect();
-        params.insert("vars".to_string(), serde_json::Value::Object(vars_obj));
-    }
-    // Same trick for --model / --tool / --phase-timeout-secs under the
-    // well-known `overrides` key so the daemon-spawned runner honors the
-    // same execution overrides as the local async path. Older daemons
-    // ignore the extra key.
-    if overrides.model.is_some() || overrides.tool.is_some() || overrides.phase_timeout_secs.is_some() {
-        let mut overrides_obj = serde_json::Map::new();
-        if let Some(model) = overrides.model.as_deref() {
-            overrides_obj.insert("model".to_string(), serde_json::Value::String(model.to_string()));
-        }
-        if let Some(tool) = overrides.tool.as_deref() {
-            overrides_obj.insert("tool".to_string(), serde_json::Value::String(tool.to_string()));
-        }
-        if let Some(timeout) = overrides.phase_timeout_secs {
-            overrides_obj.insert("phase_timeout_secs".to_string(), serde_json::Value::from(timeout));
-        }
-        params.insert("overrides".to_string(), serde_json::Value::Object(overrides_obj));
-    }
-    // Relay the transport-asserted actor (from an explicit `--actor-json`) over
-    // the control wire so the daemon scopes the run to that user. With no flag
-    // `overrides.actor` is `None` and the run is global — the CLI client never
-    // synthesizes an actor from local context; authenticated actors are
-    // asserted only by the caller (the flag) or the transport plugins.
-    let request = WireRequest { task_id: task_id.to_string(), definition, params, actor: overrides.actor.clone() };
-    match client.workflow_run(request).await {
-        Ok(response) => Ok(Some(response)),
-        Err(err) if is_method_unavailable(&err) => {
-            tracing::debug!(error = %err, "workflow/run wire returned unavailable; falling back to local");
             Ok(None)
         }
         Err(err) => Err(err),
@@ -1089,7 +946,7 @@ mod tests {
         crate::WorkflowListArgs {
             status: None,
             workflow_ref: None,
-            task_id: None,
+            subject_id: None,
             phase_id: None,
             search: None,
             sort: None,
@@ -1120,7 +977,7 @@ mod tests {
         assert!(!workflow_list_expressible_on_wire(&args));
 
         let mut args = list_args();
-        args.task_id = Some("TASK-1".to_string());
+        args.subject_id = Some("TASK-1".to_string());
         assert!(!workflow_list_expressible_on_wire(&args));
 
         let mut args = list_args();
@@ -1160,40 +1017,26 @@ mod tests {
         assert!(message.contains("workflow agent-runtime set --help"));
     }
 
-    #[tokio::test]
-    async fn resolve_workflow_run_dispatch_builds_task_dispatch_with_concrete_workflow_ref() {
-        let hub = Arc::new(InMemoryServiceHub::new());
-        let task = hub
-            .tasks()
-            .create(TaskCreateInput {
-                title: "dispatch me".to_string(),
-                description: "task dispatch builder test".to_string(),
-                task_type: Some(TaskType::Feature),
-                priority: Some(Priority::Medium),
-                created_by: Some("test".to_string()),
-                tags: Vec::new(),
-                linked_requirements: Vec::new(),
-                linked_architecture_entities: Vec::new(),
-            })
-            .await
-            .expect("task should be created");
-
+    #[test]
+    fn resolve_workflow_run_dispatch_builds_custom_title_dispatch() {
         let dispatch = resolve_workflow_run_dispatch(
-            hub,
             "/tmp/unused",
-            Some(task.id.clone()),
-            None,
-            None,
-            None,
-            None,
+            Some("Investigate flaky test".to_string()),
+            Some("Suite fails intermittently".to_string()),
+            Some("standard-workflow".to_string()),
             std::collections::HashMap::new(),
         )
-        .await
-        .expect("dispatch should resolve");
+        .expect("custom dispatch should resolve");
 
-        assert_eq!(dispatch.subject_id(), Some(task.id.as_str()));
-        assert_eq!(dispatch.workflow_ref, orchestrator_core::workflow_ref_for_task(&task));
+        assert_eq!(dispatch.workflow_ref, "standard-workflow");
         assert_eq!(dispatch.trigger_source, "manual-cli-run");
+    }
+
+    #[test]
+    fn resolve_workflow_run_dispatch_requires_title_or_subject() {
+        let err = resolve_workflow_run_dispatch("/tmp/unused", None, None, None, std::collections::HashMap::new())
+            .expect_err("no title should error");
+        assert!(err.to_string().contains("--subject-id"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/prompt.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/prompt.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use orchestrator_core::{
     ensure_workflow_config_compiled, load_workflow_config, load_workflow_config_or_default,
-    resolve_phase_plan_for_workflow_ref, services::ServiceHub, workflow_ref_for_task, OrchestratorWorkflow, SubjectRef,
+    resolve_phase_plan_for_workflow_ref, services::ServiceHub, OrchestratorWorkflow, SubjectRef,
     WorkflowDecisionAction,
 };
 use serde::Serialize;
@@ -256,37 +256,32 @@ async fn resolve_ad_hoc_context(
     hub: Arc<dyn ServiceHub>,
     project_root: &str,
 ) -> Result<ResolvedPromptContext> {
-    let (subject, workflow_ref, fallback_title, fallback_description) =
-        match (&args.task_id, &args.requirement_id, &args.title) {
-            (Some(task_id), None, None) => {
-                let task = hub.tasks().get(task_id).await?;
-                let workflow_ref = args.workflow_ref.clone().unwrap_or_else(|| workflow_ref_for_task(&task));
-                (SubjectRef::task(task.id.clone()), workflow_ref, Some(task.title), Some(task.description))
-            }
-            (None, Some(requirement_id), None) => {
-                hub.planning().get_requirement(requirement_id).await?;
-                (
-                    SubjectRef::requirement(requirement_id.clone()),
-                    args.workflow_ref.clone().unwrap_or(super::resolve_requirement_workflow_ref(project_root)?),
-                    None,
-                    None,
-                )
-            }
-            (None, None, Some(title)) => (
-                SubjectRef::custom(title.clone(), args.description.clone().unwrap_or_default()),
-                args.workflow_ref.clone().unwrap_or_else(|| {
-                    load_workflow_config_or_default(Path::new(project_root)).config.default_workflow_ref
-                }),
-                Some(title.clone()),
-                Some(args.description.clone().unwrap_or_default()),
-            ),
-            (None, None, None) => {
-                return Err(anyhow!("one of --workflow-id, --task-id, --requirement-id, or --title must be provided"));
-            }
-            _ => {
-                return Err(anyhow!("--task-id, --requirement-id, and --title are mutually exclusive"));
-            }
-        };
+    let (subject, workflow_ref, fallback_title, fallback_description) = match (&args.subject_id, &args.title) {
+        (Some(subject_id), None) => {
+            // Generic subject resolution (qualified `kind:id` or bare-id probe),
+            // the same path as `workflow run --subject-id`. task/requirement are
+            // ordinary subject kinds here — no privileged branch.
+            let subject = super::resolve_subject_id_ref_via_router(project_root, subject_id).await?;
+            let workflow_ref = args.workflow_ref.clone().unwrap_or_else(|| {
+                load_workflow_config_or_default(Path::new(project_root)).config.default_workflow_ref
+            });
+            (subject, workflow_ref, None, None)
+        }
+        (None, Some(title)) => (
+            SubjectRef::custom(title.clone(), args.description.clone().unwrap_or_default()),
+            args.workflow_ref.clone().unwrap_or_else(|| {
+                load_workflow_config_or_default(Path::new(project_root)).config.default_workflow_ref
+            }),
+            Some(title.clone()),
+            Some(args.description.clone().unwrap_or_default()),
+        ),
+        (None, None) => {
+            return Err(anyhow!("one of --workflow-id, --subject-id, or --title must be provided"));
+        }
+        (Some(_), Some(_)) => {
+            return Err(anyhow!("--subject-id and --title are mutually exclusive"));
+        }
+    };
 
     let resolved = hub
         .subject_resolver()
@@ -457,8 +452,7 @@ mod tests {
     fn base_args() -> WorkflowPromptRenderArgs {
         WorkflowPromptRenderArgs {
             workflow_id: None,
-            task_id: None,
-            requirement_id: None,
+            subject_id: None,
             title: None,
             description: None,
             workflow_ref: None,

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/interactions.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/interactions.rs
@@ -724,7 +724,7 @@ async fn resolve_hook_decision(
         None,
         timeout_secs,
         args.workflow_id.as_deref(),
-        args.task_id.as_deref(),
+        args.subject_id.as_deref(),
     )
     .await;
     let decision = approval_decision_from_outcome(outcome, timeout_secs);
@@ -969,7 +969,7 @@ phases:
                     agent_id: "swe".to_string(),
                     format: crate::ApproveHookFormat::Generic,
                     workflow_id: None,
-                    task_id: None,
+                    subject_id: None,
                     timeout_secs: Some(1),
                 };
 

--- a/crates/orchestrator-cli/tests/cli_smoke.rs
+++ b/crates/orchestrator-cli/tests/cli_smoke.rs
@@ -161,8 +161,8 @@ fn help_uses_explicit_value_names_and_repeatable_flag_guidance() -> Result<(), B
         "workflow run help should expose the pipeline positional argument"
     );
     assert!(
-        workflow_run_stdout.contains("--task-id <TASK_ID>"),
-        "workflow run help should expose the explicit TASK_ID value name"
+        workflow_run_stdout.contains("--subject-id <SUBJECT_ID>"),
+        "workflow run help should expose the explicit SUBJECT_ID value name"
     );
     assert!(
         workflow_run_stdout.contains("When provided, values in this payload override individual CLI flags."),

--- a/docs/architecture/workflow-first-cli.md
+++ b/docs/architecture/workflow-first-cli.md
@@ -43,8 +43,8 @@ This keeps the runtime aligned with the plugin-pack kernel design:
 | Command | Canonical Ref |
 |---|---|
 | `animus workflow run animus.requirement/draft --title "..." --sync` | `animus.requirement/draft` |
-| `animus workflow run animus.requirement/execute --requirement-id REQ-001` | `animus.requirement/execute` |
-| `animus workflow run animus.task/standard --task-id TASK-001` | `animus.task/standard` |
+| `animus workflow run animus.requirement/execute --subject-id requirement:REQ-001` | `animus.requirement/execute` |
+| `animus workflow run animus.task/standard --subject-id TASK-001` | `animus.task/standard` |
 
 ## Related Docs
 

--- a/docs/concepts/how-ao-works.md
+++ b/docs/concepts/how-ao-works.md
@@ -96,8 +96,8 @@ encode domain behavior.
 Examples:
 
 - `animus subject next --kind task`
-- `animus workflow run animus.task/standard --task-id TASK-001`
-- `animus workflow run animus.requirement/execute --requirement-id REQ-001`
+- `animus workflow run animus.task/standard --subject-id TASK-001`
+- `animus workflow run animus.requirement/execute --subject-id requirement:REQ-001`
 - `animus mcp serve`
 - ready-queue and schedule dispatches
 

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -40,8 +40,8 @@ dispatch them through the workflow engine:
 
 | Operator Entry Point | Canonical Ref | Notes |
 |---|---|---|
-| `animus workflow run animus.task/standard --task-id TASK-001` | `animus.task/standard` | Explicit workflow ref execution through the CLI |
-| `animus workflow run animus.requirement/execute --requirement-id REQ-001` | `animus.requirement/execute` | Requirement execution resolves to the canonical pack ref |
+| `animus workflow run animus.task/standard --subject-id TASK-001` | `animus.task/standard` | Explicit workflow ref execution through the CLI |
+| `animus workflow run animus.requirement/execute --subject-id requirement:REQ-001` | `animus.requirement/execute` | Requirement execution resolves to the canonical pack ref |
 | `animus workflow run standard-workflow` | `animus.task/standard` | Repository-specific workflows can wrap canonical pack refs |
 
 The first-party pack boundary is currently most visible in task, requirement,

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -13,7 +13,7 @@ flowchart TD
     --> START["4b. animus daemon start (preflight)"]
     --> INSPECT["5. animus status / workflow list"]
 
-    START -. "optional dry run" .-> SYNC["animus workflow run --task-id ... --sync"]
+    START -. "optional dry run" .-> SYNC["animus workflow run --subject-id ... --sync"]
 ```
 
 ## 0. Five-Minute Walkthrough
@@ -103,7 +103,7 @@ animus status
 ## Test a Workflow Before Running the Daemon
 
 ```bash
-animus workflow run --task-id TASK-001 --sync
+animus workflow run --subject-id TASK-001 --sync
 ```
 
 ## Requirement-First Flow

--- a/docs/getting-started/typical-day.md
+++ b/docs/getting-started/typical-day.md
@@ -75,7 +75,7 @@ animus logs tail
 ## Testing a Workflow Before Enabling the Daemon
 
 ```bash
-animus workflow run --task-id TASK-001 --sync
+animus workflow run --subject-id TASK-001 --sync
 ```
 
 Use synchronous runs to debug a workflow definition, prompt, or plugin setup in

--- a/docs/guides/requirements-workflow.md
+++ b/docs/guides/requirements-workflow.md
@@ -23,13 +23,16 @@ animus subject status --kind requirement --id requirement:REQ-001 --status ready
 
 ## Execute a Workflow for a Requirement
 
-Use the workflow surface when the requirement itself should drive execution:
+Use the workflow surface when the requirement itself should drive execution.
+A requirement is an ordinary subject kind, so name the workflow explicitly
+(there is no requirement-specific default workflow — without a workflow ref the
+run uses the project default):
 
 ```bash
-animus workflow run --requirement-id REQ-001
+animus workflow run animus.requirement/plan --subject-id requirement:REQ-001
 ```
 
-`animus workflow run --requirement-id ...` uses the same fallback pattern as
+`animus workflow run --subject-id ...` uses the same fallback pattern as
 task execution: Animus checks the in-tree requirement store first, then retries
 through the active `subject_backend` resolver when the requirement is owned by
 a plugin.

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -25,7 +25,7 @@ animus status
 
 ```bash
 animus subject status --kind task --id task:TASK-001 --status in_progress
-animus workflow run --task-id TASK-001 --sync
+animus workflow run --subject-id TASK-001 --sync
 animus subject status --kind task --id task:TASK-001 --status done
 ```
 

--- a/docs/guides/task-management.md
+++ b/docs/guides/task-management.md
@@ -25,7 +25,7 @@ animus subject get --kind task --id task:TASK-001
 Subject ids accept either the bare native id (`TASK-001`) or the
 kind-qualified form (`task:TASK-001`) wherever an `--id` or subject-id argument
 is taken — `subject get/update/status`, `queue hold/release/drop`, and
-`workflow run --task-id`. The bare form is normalized to the qualified form at
+`workflow run --subject-id`. The bare form is normalized to the qualified form at
 the CLI boundary, so both resolve the same subject. The human-readable
 `animus subject list` table prints the canonical qualified ids.
 
@@ -46,17 +46,17 @@ animus subject update --kind task --id task:TASK-001 --priority p0 --labels urge
 ## Run a Workflow for a Task
 
 ```bash
-animus workflow run --task-id TASK-001
+animus workflow run --subject-id TASK-001
 ```
 
-`animus workflow run --task-id ...` first checks the in-tree task store and
+`animus workflow run --subject-id ...` first checks the in-tree task store and
 then falls back to the active `subject_backend` resolution path. That means the
 same command works for built-in tasks and plugin-owned tasks.
 
 For terminal debugging, use synchronous execution:
 
 ```bash
-animus workflow run --task-id TASK-001 --sync
+animus workflow run --subject-id TASK-001 --sync
 ```
 
 Built-in tasks usually execute in a managed worktree. Plugin-owned task

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -68,10 +68,10 @@ The command surface converges on a small set of conventions:
   existing install, remove a dirty worktree, bypass a reference guard), not
   for skipping confirmation. `workflow pause/cancel --confirm <id>` is a
   deliberate repeat-the-id safety pattern for remote mutation and stays as-is.
-- **IDs**: domain-prefixed id flags (`--task-id`, `--run-id`,
-  `--workflow-id`) are accepted wherever the domain is unambiguous; workflow
-  commands take `--workflow-id` as an alias of `--id`. `subject --id` stays
-  kind-generic by design.
+- **IDs**: id flags (`--subject-id`, `--run-id`, `--workflow-id`) are accepted
+  wherever the domain is unambiguous; workflow commands take `--workflow-id` as
+  an alias of `--id`. `subject --id` and `--subject-id` stay kind-generic by
+  design — pass a bare id or a `kind:id`-qualified id.
 - **Durations**: age/window flags accept unit suffixes `s`/`m`/`h`/`d`
   (`--since 2h`, `workflow prune --older-than 12h`). Bare numbers keep their
   historical default unit (`--older-than 30` still means 30 days).
@@ -859,12 +859,17 @@ other subject kind. By default the entry is dispatched as soon as the daemon
 has capacity.
 
 ```bash
-animus queue enqueue --task-id TASK-001
-animus queue enqueue --requirement-id REQ-042 --workflow-ref ops
+animus queue enqueue --subject-id TASK-001
+animus queue enqueue --subject-id requirement:REQ-042 --workflow-ref ops
 animus queue enqueue --title "Investigate flaky test" --description "Fails on CI"
-animus queue enqueue --subject-id blog:BLOG-001                      # BaaS dynamic kind
+animus queue enqueue --subject-id blog:BLOG-001                      # dynamic kind
 animus queue enqueue --adhoc --workflow-ref relate                   # subjectless (ad-hoc) run
 ```
+
+> **Removed in v0.7 (breaking).** The deprecated `--task-id` / `--requirement-id`
+> flags were removed. `task` and `requirement` are ordinary subject kinds now —
+> use `--subject-id` (qualified `task:TASK-001` / `requirement:REQ-042`, or a
+> bare `TASK-001`) for every kind.
 
 **Subjectless (ad-hoc) runs (`--adhoc`).** A workflow that finds its own
 target (or needs none) can be dispatched with NO bound subject via `--adhoc`
@@ -872,20 +877,18 @@ plus a required `--workflow-ref`. The run has no subject-bound template vars,
 so a subjectless-by-design workflow (e.g. `relate`) is a first-class mode, not
 an error. Each ad-hoc dispatch carries a unique id so a burst of subjectless
 runs is never deduped into one queue entry. `--adhoc` is mutually exclusive
-with `--task-id` / `--requirement-id` / `--title` / `--subject-id`.
+with `--subject-id` / `--title`.
 
-**Generic subjects (`--subject-id`).** For a subject that is **not**
-`kind=task`/`requirement` (a BaaS dynamic kind such as `blog`, `post`, etc.),
-use `--subject-id` instead of `--task-id`. It accepts either a **qualified**
-id (`blog:BLOG-001` — the kind before the `:` is trusted; the recommended
-form) or a **bare** id (`BLOG-001` — the kind is resolved by probing the
-installed subject backends that declare concrete kinds). A backend that
-declares only the `subject_kind:*` catch-all (a pure dynamic-kind backend)
-cannot enumerate a bare id's kind, so it requires the qualified form.
-The resolved kind is preserved in the dispatch, so the queue lease and runner
-resolve the subject via `<kind>/get` rather than coercing it to a task.
-`--subject-id` is mutually exclusive with `--task-id` / `--requirement-id` /
-`--title`.
+**Subjects (`--subject-id`).** `--subject-id` enqueues a subject of **any**
+kind — `task`, `requirement`, or a dynamic kind such as `blog`/`post`. It
+accepts either a **qualified** id (`task:TASK-001` / `blog:BLOG-001` — the kind
+before the `:` is trusted; the recommended form) or a **bare** id (`TASK-001` —
+the kind is resolved by probing the installed subject backends that declare
+concrete kinds). A backend that declares only the `subject_kind:*` catch-all
+(a pure dynamic-kind backend) cannot enumerate a bare id's kind, so it requires
+the qualified form. The resolved kind is preserved in the dispatch, so the
+queue lease and runner resolve the subject via `<kind>/get`. `--subject-id` is
+mutually exclusive with `--title` / `--adhoc`.
 
 **Deferred dispatch.** `--at` schedules the entry for a future time; it stays
 queued (counted under `pending`, and broken out as `deferred` in
@@ -893,9 +896,9 @@ queued (counted under `pending`, and broken out as `deferred` in
 the next daemon pickup.
 
 ```bash
-animus queue enqueue --task-id TASK-001 --at 2026-06-13T15:00:00Z   # absolute (RFC 3339)
-animus queue enqueue --task-id TASK-001 --at 2h                     # relative: 90s / 30m / 2h / 3d
-animus queue enqueue --task-id TASK-001 --at 2h --expire-after 10m  # drop if not dispatched within grace
+animus queue enqueue --subject-id TASK-001 --at 2026-06-13T15:00:00Z   # absolute (RFC 3339)
+animus queue enqueue --subject-id TASK-001 --at 2h                     # relative: 90s / 30m / 2h / 3d
+animus queue enqueue --subject-id TASK-001 --at 2h --expire-after 10m  # drop if not dispatched within grace
 ```
 
 | Flag | Description |
@@ -1172,7 +1175,7 @@ Recommended pack installs are per-pack and never abort init: each pack reports
 `installed`, `already_installed`, or `failed` (with the manual
 `git clone ... && animus pack install --path ... --activate` recovery command).
 After a successful install, init prints the first runnable workflow command
-(`animus workflow run animus.task/standard --task-id ... --sync`). The
+(`animus workflow run animus.task/standard --subject-id ... --sync`). The
 `ANIMUS_INIT_PACK_SOURCE_DIR` env var overrides the GitHub clone with a local
 `<dir>/<pack-id>` source directory for offline installs and tests.
 
@@ -1820,7 +1823,7 @@ Priority is displayed in `p0`–`p3` bucket notation in all human-readable views
 ### ID normalization
 
 `subject get/update/status --id`, `queue hold/release/drop`, and
-`workflow run --task-id` all accept **either** the bare native id (e.g.
+`workflow run --subject-id` all accept **either** the bare native id (e.g.
 `TASK-001`) or the kind-qualified form (e.g. `task:TASK-001`). The bare form
 is normalized to the qualified form at the CLI boundary, so both resolve the
 same subject. You do not need to run any command in `--json` mode to discover
@@ -1835,15 +1838,14 @@ id never falls through to the `task`-favoring config default. This is what lets
 a workflow `mark-running` command (`animus subject status --id <kind>:<id>
 --status in-progress`) target the right backend without a `task` default.
 
-For subjects of an arbitrary kind (BaaS dynamic kinds like `blog`, `post`),
-`queue enqueue --subject-id` and `workflow run --subject-id` accept a
-qualified id (`blog:BLOG-001`, kind trusted — the recommended form) or a bare
-id (`BLOG-001`, kind resolved by probing installed backends that declare
-concrete kinds; a pure `subject_kind:*` catch-all backend requires the
-qualified form). The resolved kind is preserved on the dispatch so the subject
-is leased/run under its real kind (via `<kind>/get`) instead of being coerced
-to `task`. `--subject-id` is mutually exclusive with `--task-id` /
-`--requirement-id` / `--title`.
+For subjects of **any** kind — `task`, `requirement`, or a dynamic kind like
+`blog`/`post` — `queue enqueue --subject-id` and `workflow run --subject-id`
+accept a qualified id (`task:TASK-001` / `blog:BLOG-001`, kind trusted — the
+recommended form) or a bare id (`TASK-001`, kind resolved by probing installed
+backends that declare concrete kinds; a pure `subject_kind:*` catch-all backend
+requires the qualified form). The resolved kind is preserved on the dispatch so
+the subject is leased/run under its real kind (via `<kind>/get`). `--subject-id`
+is mutually exclusive with `--title` (and `--adhoc` for `queue enqueue`).
 
 ### `animus pack search` (positional query)
 
@@ -1874,7 +1876,7 @@ validate`, and `animus chat send` accept `--actor-json <JSON>` — a JSON-encode
 user, mirroring `animus mcp serve --actor-json`:
 
 ```bash
-animus workflow run --task-id TASK-1 --actor-json '{"user_id":"alice"}'
+animus workflow run --subject-id task:TASK-1 --actor-json '{"user_id":"alice"}'
 animus workflow config get  --actor-json '{"user_id":"alice"}'
 animus chat send "hi" --as-user alice --actor-json '{"user_id":"alice","claims":["admin"]}'
 ```

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -190,11 +190,11 @@ bounded fetch for recent entries, not a live stream.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `animus.workflow.run` | Start a workflow for a subject (async, via daemon). For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post), pass `subject_id` (the kernel resolves the kind) instead of `task_id` | `task_id`, `requirement_id`, `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `project_root` |
-| `animus.workflow.run-multiple` | Batch-run workflows for multiple tasks | `runs[]` (each: `task_id`, `workflow_ref`, `input_json`), `on_error`, `project_root` |
-| `animus.workflow.execute` | Execute a workflow synchronously (no daemon) | `task_id`, `workflow_ref`, `phase`, `model`, `tool`, `phase_timeout_secs`, `input_json`, `project_root` |
+| `animus.workflow.run` | Start a workflow for a subject (async, via daemon). Pass `subject_id` for any kind — qualified `task:TASK-001` / `blog:BLOG-001` (kind trusted) or bare `TASK-001` (kind resolved by the router) | `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `project_root` |
+| `animus.workflow.run-multiple` | Batch-run workflows for multiple subjects | `runs[]` (each: `subject_id`, `workflow_ref`, `input_json`), `on_error`, `project_root` |
+| `animus.workflow.execute` | Execute a workflow synchronously (no daemon) | `subject_id`, `workflow_ref`, `phase`, `model`, `tool`, `phase_timeout_secs`, `input_json`, `project_root` |
 | `animus.workflow.get` | Get full workflow state by ID | `id`, `project_root` |
-| `animus.workflow.list` | List workflow executions | `status`, `workflow_ref`, `task_id`, `phase_id`, `search`, `sort`, `limit`, `offset`, `max_tokens`, `project_root` |
+| `animus.workflow.list` | List workflow executions | `status`, `workflow_ref`, `subject_id`, `phase_id`, `search`, `sort`, `limit`, `offset`, `max_tokens`, `project_root` |
 | `animus.workflow.pause` | Pause a running workflow | `id`, `confirm`, `dry_run`, `project_root` |
 | `animus.workflow.cancel` | Cancel a running workflow permanently | `id`, `confirm`, `dry_run`, `project_root` |
 | `animus.workflow.resume` | Resume a paused workflow | `id`, `project_root` |
@@ -226,7 +226,7 @@ bounded fetch for recent entries, not a live stream.
 |---|---|---|
 | `animus.queue.list` | List queued subject dispatches | `project_root` |
 | `animus.queue.stats` | Get aggregate queue depth and status counts | `project_root` |
-| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). For subjects that are NOT kind=task/requirement (BaaS dynamic kinds like blog/post), pass `subject_id` (qualified `blog:BLOG-001` or bare `BLOG-001`; the kernel resolves the kind) instead of `task_id` | `task_id`, `requirement_id`, `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
+| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). Pass `subject_id` for any kind — qualified `task:TASK-001` / `blog:BLOG-001` (kind trusted) or bare `TASK-001` (kind resolved by the router) | `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
 | `animus.queue.reorder` | Set preferred dispatch order | `subject_ids[]`, `project_root` |
 | `animus.queue.hold` | Hold one or more pending subjects from dispatch | `subject_id`, `subject_ids[]`, `project_root` |
 | `animus.queue.release` | Release one or more held subjects for dispatch | `subject_id`, `subject_ids[]`, `project_root` |


### PR DESCRIPTION
## Summary

Implements board task TASK-278.  and  are ordinary subject kinds now, so the CLI/MCP exposes no task/requirement-specific entry points. Removes the deprecated (TASK-247)  /  flags; all interaction goes through the generic subject surface and  dispatch.

This is an intentionally BREAKING removal on the 0.7 line (the flags were already deprecated; the portal already shells ).

## CLI flags removed / renamed

- : dropped  /  (kept  /  / )
- : dropped  /  (kept  / )
- : dropped  / , added  (generic resolution)
- : renamed the  filter to 
- : renamed the  escalation context to 
- : deleted the now-unused  struct

## Handlers repointed

The internal  /  kind-qualification helpers stay as generic kind-qualification; only the privileged param plumbing is removed.

- :  drops the task/requirement branches and the  helper; enqueue routes via  (generic resolver) or 
- :  is title-only; dropped the task-id normalization, the task-id control-wire fast path, and the now-dead 
- :  drops /; the runner wire request sends  for those (a concrete-kind subject travels as , a freeform run via )
- :  resolves  generically
- : approve-hook reads 

## MCP tool schemas ()

, , , , and the  filter drop  /  for . Arg builders and tool descriptions updated. (Out of scope and intentionally retained:  and interaction-escalation  context, which are separate surfaces, not the removed dispatch flags.)

## Docs

CLI reference (), MCP tools reference (), , the in-repo , and the getting-started / guides / concepts examples now use .  notes the breaking removal, including that a requirement dispatched via  without an explicit workflow ref uses the project default workflow (name the workflow explicitly).

## Gates

 +  +  +  tests (1319 unit + 6 smoke) all green. Codex self-vet run (2 rounds); findings addressed/documented below.

## Notes for review (codex self-vet)

- Fixed inline: reverted an unrequested  normalization in the  filter to a verbatim pass-through, so the filter matches the exact stored id form.
- De-privileging (intended, documented in CHANGELOG): a requirement run/enqueue via  without  uses the project default workflow rather than the old requirement-specific default — restoring that would re-privilege .
-  for a task run via  is stored qualified () — this is the pre-existing  semantics (unchanged here) that the portal already relies on. The legacy in-tree  projection is best-effort and a no-op in plugin-backed deployments (the workflow_runner plugin owns subject-status projection); TASK-276 is removing that legacy path.

Do not merge/deploy/tag — the main session sequences this into the next rc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)