### PR TITLE
ao-cli: route task-status OUTPUT paths through the subject router (TASK-276)

### DIFF
--- a/crates/orchestrator-cli/src/services/cost/enforcement.rs
+++ b/crates/orchestrator-cli/src/services/cost/enforcement.rs
@@ -164,6 +164,10 @@ async fn enforce_on_exceed_action(
     record: &BudgetExceededRecord,
     warn: &mut dyn FnMut(String),
 ) -> std::result::Result<&'static str, ()> {
+    // Route task-status projections through the installed subject backend when
+    // one owns `task` (portal), else the in-tree store. Resolved once and
+    // shared by every projection in this action.
+    let store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
     if record.on_exceed == ON_EXCEED_FAIL {
         // `fail` is terminal by declaration. The daemon applies it directly
         // — the breaching phase's runner may already have exited, so there
@@ -197,6 +201,7 @@ async fn enforce_on_exceed_action(
         if current.status == WorkflowStatus::Paused {
             if let Err(error) = dispatch_workflow_event(
                 hub.clone(),
+                store.as_ref(),
                 project_root,
                 WorkflowEvent::Resume { workflow_id: record.workflow_id.clone(), feedback: None },
             )
@@ -215,7 +220,7 @@ async fn enforce_on_exceed_action(
                 // daemon's completion reconciliation does.
                 if let Some(task_id) = orchestrator_core::workflow_task_id(&workflow) {
                     orchestrator_core::project_task_terminal_workflow_status(
-                        hub,
+                        store.as_ref(),
                         &task_id,
                         WorkflowStatus::Failed,
                         Some(reason),
@@ -233,7 +238,7 @@ async fn enforce_on_exceed_action(
                     Ok(updated) if updated.status == WorkflowStatus::Failed => {
                         if let Some(task_id) = orchestrator_core::workflow_task_id(&updated) {
                             orchestrator_core::project_task_terminal_workflow_status(
-                                hub,
+                                store.as_ref(),
                                 &task_id,
                                 WorkflowStatus::Failed,
                                 Some(reason),
@@ -267,6 +272,7 @@ async fn enforce_on_exceed_action(
     }
     match dispatch_workflow_event(
         hub.clone(),
+        store.as_ref(),
         project_root,
         WorkflowEvent::Pause { workflow_id: record.workflow_id.clone(), reason_detail: Some(record.breach_summary()) },
     )

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/control_routing.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/control_routing.rs
@@ -269,9 +269,12 @@ impl WorkflowRouting for WorkflowRoutingImpl {
 
     async fn workflow_pause(&self, request: WirePauseRequest) -> Result<Unit, ControlError> {
         let hub = self.hub()?;
+        let root = self.project_root_str();
+        let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(&root, hub.clone()).await;
         let _ = dispatch_workflow_event(
             hub,
-            &self.project_root_str(),
+            task_store.as_ref(),
+            &root,
             WorkflowEvent::Pause { workflow_id: request.id, reason_detail: None },
         )
         .await
@@ -293,8 +296,10 @@ impl WorkflowRouting for WorkflowRoutingImpl {
 
     async fn workflow_cancel(&self, request: WireCancelRequest) -> Result<Unit, ControlError> {
         let hub = self.hub()?;
+        let root = self.project_root_str();
+        let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(&root, hub.clone()).await;
         let _ =
-            dispatch_workflow_event(hub, &self.project_root_str(), WorkflowEvent::Cancel { workflow_id: request.id })
+            dispatch_workflow_event(hub, task_store.as_ref(), &root, WorkflowEvent::Cancel { workflow_id: request.id })
                 .await
                 .map_err(internal)?;
         Ok(Unit::default())

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -694,8 +694,11 @@ pub(crate) async fn handle_workflow(
                     return print_value(workflow, json);
                 }
             }
+            let task_store =
+                orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
             let outcome = dispatch_workflow_event(
                 hub.clone(),
+                task_store.as_ref(),
                 project_root,
                 WorkflowEvent::Pause { workflow_id: args.id.clone(), reason_detail: None },
             )
@@ -728,8 +731,11 @@ pub(crate) async fn handle_workflow(
                     return print_value(workflow, json);
                 }
             }
+            let task_store =
+                orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
             let outcome = dispatch_workflow_event(
                 hub.clone(),
+                task_store.as_ref(),
                 project_root,
                 WorkflowEvent::Cancel { workflow_id: args.id.clone() },
             )

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/phases.rs
@@ -281,6 +281,11 @@ pub(crate) async fn start_workflow_with_runner(
     // workflow resolves at run-time, not only from the global view. The same
     // actor is relayed to the detached runner child via WORKFLOW_ACTOR_ENV.
     let workflow = hub.workflows().run(input, overrides.actor.as_ref()).await?;
+    // Route the Ready->InProgress transition through the installed subject
+    // backend when one owns `task` (portal); the in-tree store is empty there,
+    // so the transition would silently no-op and the daemon would re-dispatch
+    // the task after its workflow finished.
+    let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
     // Mirror the daemon's ready-dispatch contract: a dispatched task moves
     // to InProgress. Terminal projection never auto-completes tasks, so a
     // task left Ready here would be re-dispatched by the daemon after its
@@ -288,11 +293,10 @@ pub(crate) async fn start_workflow_with_runner(
     // runner's terminal projection cannot be overwritten afterwards.
     let mut task_status_before_dispatch = None;
     if !workflow.task_id.is_empty() {
-        if let Ok(task) = hub.tasks().get(&workflow.task_id).await {
-            if matches!(task.status, orchestrator_core::TaskStatus::Ready | orchestrator_core::TaskStatus::Backlog) {
-                let _ =
-                    hub.tasks().set_status(&workflow.task_id, orchestrator_core::TaskStatus::InProgress, false).await;
-                task_status_before_dispatch = Some(task.status);
+        if let Ok(view) = task_store.get(&workflow.task_id).await {
+            if matches!(view.status, orchestrator_core::TaskStatus::Ready | orchestrator_core::TaskStatus::Backlog) {
+                let _ = task_store.set_status(&workflow.task_id, orchestrator_core::TaskStatus::InProgress).await;
+                task_status_before_dispatch = Some(view.status);
             }
         }
     }
@@ -328,7 +332,7 @@ pub(crate) async fn start_workflow_with_runner(
     if let Err(error) = spawn_detached_workflow_runner(project_root, &workflow.id, &overrides) {
         let _ = hub.workflows().cancel(&workflow.id).await;
         if let Some(previous_status) = task_status_before_dispatch {
-            let _ = hub.tasks().set_status(&workflow.task_id, previous_status, false).await;
+            let _ = task_store.set_status(&workflow.task_id, previous_status).await;
         }
         return Err(error.context(format!("failed to start workflow runner for workflow '{}'", workflow.id)));
     }
@@ -392,8 +396,12 @@ pub(crate) async fn resume_workflow_with_runner(
     }
     ensure_workflow_runner_plugin(Path::new(project_root))?;
     register_workflow_runner_pid(Path::new(project_root), workflow_id, std::process::id())?;
+    // Route task-status projections through the installed subject backend when
+    // one owns `task` (portal), else the in-tree store.
+    let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
     let outcome = match dispatch_workflow_event(
         hub.clone(),
+        task_store.as_ref(),
         project_root,
         WorkflowEvent::Resume { workflow_id: workflow_id.to_string(), feedback },
     )
@@ -416,8 +424,13 @@ pub(crate) async fn resume_workflow_with_runner(
         if let Ok(repaused) = hub.workflows().pause(workflow_id).await {
             if repaused.status == orchestrator_core::WorkflowStatus::Paused {
                 if let Some(task_id) = orchestrator_core::workflow_task_id(&repaused) {
-                    let _ =
-                        orchestrator_core::project_task_workflow_paused(hub.clone(), &task_id, workflow_id, None).await;
+                    let _ = orchestrator_core::project_task_workflow_paused(
+                        task_store.as_ref(),
+                        &task_id,
+                        workflow_id,
+                        None,
+                    )
+                    .await;
                 }
             }
         }
@@ -656,8 +669,10 @@ pub(crate) async fn approve_manual_phase(
 ) -> Result<Value> {
     let _runner_pid_guard = WorkflowRunnerPidGuard::register(project_root, workflow_id)?;
     let approval_timestamp = Utc::now().to_rfc3339();
+    let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
     let outcome = dispatch_workflow_event(
         hub.clone(),
+        task_store.as_ref(),
         project_root,
         WorkflowEvent::ApproveManualPhase {
             workflow_id: workflow_id.to_string(),
@@ -776,8 +791,10 @@ pub(crate) async fn reject_manual_phase(
     phase_id: &str,
     note: &str,
 ) -> Result<Value> {
+    let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
     let outcome = dispatch_workflow_event(
         hub.clone(),
+        task_store.as_ref(),
         project_root,
         WorkflowEvent::RejectManualPhase {
             workflow_id: workflow_id.to_string(),

--- a/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/project_terminal_workflow_result.rs
+++ b/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/project_terminal_workflow_result.rs
@@ -91,5 +91,16 @@ pub(crate) async fn project_terminal_workflow_result(
         return;
     };
 
-    project_task_terminal_workflow_status(hub, task_id, workflow_status, failure_reason.map(ToOwned::to_owned)).await;
+    // Route the task-status projection through the installed subject backend
+    // when one owns `task` (portal); the in-tree `hub.tasks()` store is empty
+    // there, so a terminal projection into it would leave the plugin-backed
+    // task stuck InProgress.
+    let store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub).await;
+    project_task_terminal_workflow_status(
+        store.as_ref(),
+        task_id,
+        workflow_status,
+        failure_reason.map(ToOwned::to_owned),
+    )
+    .await;
 }

--- a/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
+++ b/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
@@ -16,6 +16,12 @@ pub(crate) async fn reconcile_completed_processes(
 ) -> CompletedProcessReconciliation {
     let plan = build_completion_reconciliation_plan(completed_processes);
 
+    // Route task-status projections through the installed subject backend when
+    // one owns `task` (portal); the in-tree `hub.tasks()` store is empty there,
+    // so projecting a terminal status into it left the plugin-backed task stuck
+    // InProgress until the 24h stale sweep.
+    let store = orchestrator_daemon_runtime::resolve_task_projection_store(root, hub.clone()).await;
+
     for fact in &plan.execution_facts {
         for event in &fact.runner_events {
             debug!(
@@ -34,7 +40,7 @@ pub(crate) async fn reconcile_completed_processes(
         // (`completed`/`failed`/`cancelled`).
         finalize_plugin_queue_entry(root, fact).await;
 
-        if !project_execution_fact(hub.clone(), root, fact).await {
+        if !project_execution_fact(store.as_ref(), fact).await {
             info!(
                 actor = protocol::ACTOR_DAEMON,
                 subject_id = %fact.subject_id,

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -324,6 +324,11 @@ pub async fn reconcile_manual_phase_timeouts(hub: Arc<dyn ServiceHub>, project_r
     let mut reconciled = 0usize;
     let now = chrono::Utc::now();
 
+    // Route task-status projections through the installed subject backend when
+    // one owns `task` (portal), else the in-tree store. Resolved once for the
+    // sweep.
+    let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
+
     for workflow in workflows {
         if workflow.status != WorkflowStatus::Paused {
             continue;
@@ -373,6 +378,7 @@ pub async fn reconcile_manual_phase_timeouts(hub: Arc<dyn ServiceHub>, project_r
         let reason = format!("manual phase '{}' timed out after {} seconds", phase_id, timeout_secs);
         let outcome = dispatch_workflow_event(
             hub.clone(),
+            task_store.as_ref(),
             project_root,
             WorkflowEvent::RejectManualPhase {
                 workflow_id: workflow.id.clone(),

--- a/crates/orchestrator-cli/src/services/runtime/workflow_mutation_surface/cancel_orphaned_running_workflow.rs
+++ b/crates/orchestrator-cli/src/services/runtime/workflow_mutation_surface/cancel_orphaned_running_workflow.rs
@@ -9,8 +9,10 @@ pub(crate) async fn cancel_orphaned_running_workflow(
     project_root: &str,
     workflow: &OrchestratorWorkflow,
 ) -> bool {
+    let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
     let outcome = match dispatch_workflow_event(
         hub.clone(),
+        task_store.as_ref(),
         project_root,
         WorkflowEvent::Cancel { workflow_id: workflow.id.clone() },
     )

--- a/crates/orchestrator-core/src/execution_projection.rs
+++ b/crates/orchestrator-core/src/execution_projection.rs
@@ -1,22 +1,23 @@
 mod project_requirement_workflow_status;
 mod project_task_terminal_workflow_status;
 mod projector_registry;
+mod task_projection_store;
 
 use std::path::Path;
-use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::Utc;
 use protocol::SubjectExecutionFact;
 
-use crate::{
-    load_schedule_state, save_schedule_state, services::ServiceHub, OrchestratorTask, TaskStatus, WorkflowStatus,
-};
+use crate::{load_schedule_state, save_schedule_state, TaskStatus, WorkflowStatus};
 
 pub use project_requirement_workflow_status::project_requirement_workflow_status;
 pub use project_task_terminal_workflow_status::project_task_terminal_workflow_status;
 pub use projector_registry::{
     builtin_execution_projector_registry, execution_fact_subject_kind, ExecutionProjector, ExecutionProjectorRegistry,
+};
+pub use task_projection_store::{
+    hub_task_projection_store, HubTaskProjectionStore, TaskProjectionStore, TaskProjectionView,
 };
 
 pub const WORKFLOW_RUNNER_BLOCKED_PREFIX: &str = "workflow runner failed: ";
@@ -36,29 +37,17 @@ pub const WORKFLOW_RUNNER_BLOCKED_PREFIX: &str = "workflow runner failed: ";
 /// string, so both bare and detail-bearing markers clear on resume.
 pub const WORKFLOW_PAUSED_REASON_PREFIX: &str = "paused by workflow ";
 
-pub async fn project_task_status(hub: Arc<dyn ServiceHub>, task_id: &str, status: TaskStatus) -> Result<()> {
-    hub.tasks().set_status(task_id, status, false).await?;
-    Ok(())
+pub async fn project_task_status(store: &dyn TaskProjectionStore, task_id: &str, status: TaskStatus) -> Result<()> {
+    store.set_status(task_id, status).await
 }
 
 pub async fn project_task_blocked_with_reason(
-    hub: Arc<dyn ServiceHub>,
-    task: &OrchestratorTask,
+    store: &dyn TaskProjectionStore,
+    task_id: &str,
     reason: String,
     blocked_by: Option<String>,
 ) -> Result<()> {
-    let mut updated = task.clone();
-    updated.status = TaskStatus::Blocked;
-    updated.paused = true;
-    updated.blocked_reason = Some(reason);
-    updated.blocked_at = Some(Utc::now());
-    updated.blocked_phase = None;
-    updated.blocked_by = blocked_by;
-    updated.metadata.updated_at = Utc::now();
-    updated.metadata.updated_by = protocol::ACTOR_DAEMON.to_string();
-    updated.metadata.version = updated.metadata.version.saturating_add(1);
-    hub.tasks().replace(updated).await?;
-    Ok(())
+    store.block_with_reason(task_id, reason, blocked_by).await
 }
 
 /// Build the `blocked_reason` marker for a paused workflow. The head is
@@ -89,15 +78,15 @@ pub fn is_workflow_paused_reason(reason: &str, workflow_id: &str) -> bool {
 /// and no ghost state can be left behind. `reason_detail` (when present)
 /// appends a human cause to the marker (e.g. a budget breach summary).
 pub async fn project_task_workflow_paused(
-    hub: Arc<dyn ServiceHub>,
+    store: &dyn TaskProjectionStore,
     task_id: &str,
     workflow_id: &str,
     reason_detail: Option<&str>,
 ) -> Result<()> {
-    let Ok(mut task) = hub.tasks().get(task_id).await else {
+    let Ok(view) = store.get(task_id).await else {
         return Ok(());
     };
-    if matches!(task.status, TaskStatus::Done | TaskStatus::Cancelled) {
+    if matches!(view.status, TaskStatus::Done | TaskStatus::Cancelled) {
         return Ok(());
     }
     // Never clobber a foreign blocked_reason (a real failure projection or
@@ -108,7 +97,7 @@ pub async fn project_task_workflow_paused(
     // (e.g. `animus workflow pause` on an already-paused workflow) must NOT
     // downgrade an enriched marker back to bare and lose the breach cause.
     let bare_marker = workflow_paused_reason(workflow_id, None);
-    if let Some(existing) = task.blocked_reason.as_deref() {
+    if let Some(existing) = view.blocked_reason.as_deref() {
         if !is_workflow_paused_reason(existing, workflow_id) {
             return Ok(());
         }
@@ -120,58 +109,42 @@ pub async fn project_task_workflow_paused(
             return Ok(());
         }
     }
-    task.blocked_reason = Some(workflow_paused_reason(workflow_id, reason_detail));
-    if task.blocked_by.is_none() {
-        task.blocked_by = Some(workflow_id.to_string());
-    }
-    task.metadata.updated_at = Utc::now();
-    task.metadata.updated_by = protocol::ACTOR_CORE.to_string();
-    task.metadata.version = task.metadata.version.saturating_add(1);
-    hub.tasks().replace(task).await?;
-    Ok(())
+    let set_blocked_by = if view.blocked_by.is_none() { Some(workflow_id.to_string()) } else { None };
+    store.annotate_blocked_reason(task_id, workflow_paused_reason(workflow_id, reason_detail), set_blocked_by).await
 }
 
 /// Clear the pause annotation written by [`project_task_workflow_paused`] when
 /// the workflow resumes. Only the matching marker is cleared — a genuine
 /// `blocked_reason` written by a failure projection is left alone.
 pub async fn project_task_workflow_pause_cleared(
-    hub: Arc<dyn ServiceHub>,
+    store: &dyn TaskProjectionStore,
     task_id: &str,
     workflow_id: &str,
 ) -> Result<()> {
-    let Ok(mut task) = hub.tasks().get(task_id).await else {
+    let Ok(view) = store.get(task_id).await else {
         return Ok(());
     };
     // Match both the bare `paused by workflow <id>` head and any enriched
     // `… — <detail>` variant (e.g. a budget breach summary). A genuine
     // `blocked_reason` written by a failure projection is left alone.
-    if !task.blocked_reason.as_deref().is_some_and(|reason| is_workflow_paused_reason(reason, workflow_id)) {
+    if !view.blocked_reason.as_deref().is_some_and(|reason| is_workflow_paused_reason(reason, workflow_id)) {
         return Ok(());
     }
-    task.blocked_reason = None;
-    if task.blocked_by.as_deref() == Some(workflow_id) {
-        task.blocked_by = None;
-    }
-    task.metadata.updated_at = Utc::now();
-    task.metadata.updated_by = protocol::ACTOR_CORE.to_string();
-    task.metadata.version = task.metadata.version.saturating_add(1);
-    hub.tasks().replace(task).await?;
-    Ok(())
+    let clear_blocked_by = view.blocked_by.as_deref() == Some(workflow_id);
+    store.clear_blocked_reason(task_id, clear_blocked_by).await
 }
 
 pub async fn project_task_workflow_start(
-    hub: Arc<dyn ServiceHub>,
+    store: &dyn TaskProjectionStore,
     task_id: &str,
     role: String,
     model: Option<String>,
     updated_by: String,
 ) -> Result<()> {
-    hub.tasks().set_status(task_id, TaskStatus::InProgress, false).await?;
-    hub.tasks().assign_agent(task_id, role, model, updated_by).await?;
-    Ok(())
+    store.start_workflow(task_id, role, model, updated_by).await
 }
 
-pub async fn project_task_execution_fact(hub: Arc<dyn ServiceHub>, _root: &str, fact: &SubjectExecutionFact) {
+pub async fn project_task_execution_fact(store: &dyn TaskProjectionStore, fact: &SubjectExecutionFact) {
     let Some(task_id) = fact.task_id.as_deref() else {
         return;
     };
@@ -186,7 +159,7 @@ pub async fn project_task_execution_fact(hub: Arc<dyn ServiceHub>, _root: &str, 
                 return;
             }
             WorkflowStatus::Cancelled => {
-                let _ = project_task_status(hub, task_id, TaskStatus::Cancelled).await;
+                let _ = project_task_status(store, task_id, TaskStatus::Cancelled).await;
                 return;
             }
             WorkflowStatus::Failed | WorkflowStatus::Escalated => {}
@@ -200,17 +173,20 @@ pub async fn project_task_execution_fact(hub: Arc<dyn ServiceHub>, _root: &str, 
     }
 
     if let Some(reason) = fact.failure_reason.clone() {
-        if let Ok(task) = hub.tasks().get(task_id).await {
-            let _ = project_task_blocked_with_reason(hub, &task, reason, None).await;
+        // Gate on the task being readable so a failure with a reason lands as
+        // a blocked-with-reason (matching the pre-routing behaviour); an
+        // unreadable task falls through to a plain Blocked set.
+        if store.get(task_id).await.is_ok() {
+            let _ = project_task_blocked_with_reason(store, task_id, reason, None).await;
             return;
         }
     }
 
-    let _ = project_task_status(hub, task_id, TaskStatus::Blocked).await;
+    let _ = project_task_status(store, task_id, TaskStatus::Blocked).await;
 }
 
-pub async fn project_execution_fact(hub: Arc<dyn ServiceHub>, root: &str, fact: &SubjectExecutionFact) -> bool {
-    match builtin_execution_projector_registry().project(hub.clone(), root, fact).await {
+pub async fn project_execution_fact(store: &dyn TaskProjectionStore, fact: &SubjectExecutionFact) -> bool {
+    match builtin_execution_projector_registry().project(store, fact).await {
         Ok(projected) => projected,
         Err(err) => {
             let kind = execution_fact_subject_kind(fact).unwrap_or("unknown");
@@ -295,6 +271,7 @@ mod tests {
     use super::{
         execution_fact_subject_kind, is_workflow_paused_reason, project_execution_fact,
         project_task_workflow_pause_cleared, project_task_workflow_paused, workflow_paused_reason,
+        HubTaskProjectionStore,
     };
     use crate::{
         services::ServiceHub, InMemoryServiceHub, OrchestratorTask, Priority, ResourceRequirements, Scope,
@@ -424,7 +401,7 @@ mod tests {
             runner_events: Vec::new(),
         };
 
-        let projected = project_execution_fact(hub.clone(), ".", &fact).await;
+        let projected = project_execution_fact(&HubTaskProjectionStore::new(hub.clone()), &fact).await;
 
         assert!(projected);
         let updated = hub.tasks().get("TASK-1").await.expect("task should exist");
@@ -450,7 +427,7 @@ mod tests {
             runner_events: Vec::new(),
         };
 
-        let projected = project_execution_fact(hub.clone(), ".", &fact).await;
+        let projected = project_execution_fact(&HubTaskProjectionStore::new(hub.clone()), &fact).await;
 
         assert!(projected);
         assert_eq!(execution_fact_subject_kind(&fact), Some(SUBJECT_KIND_TASK));
@@ -475,7 +452,7 @@ mod tests {
             runner_events: Vec::new(),
         };
 
-        let projected = project_execution_fact(hub, ".", &fact).await;
+        let projected = project_execution_fact(&HubTaskProjectionStore::new(hub), &fact).await;
 
         assert!(!projected);
     }
@@ -509,7 +486,7 @@ mod tests {
         let hub = Arc::new(InMemoryServiceHub::new());
         upsert_task(&hub, "TASK-1", TaskStatus::InProgress).await;
         project_task_workflow_paused(
-            hub.clone(),
+            &HubTaskProjectionStore::new(hub.clone()),
             "TASK-1",
             "wf-1",
             Some("budget exceeded ($7.50 > $5.00 max_cost_usd)"),
@@ -524,7 +501,7 @@ mod tests {
         assert_eq!(task.blocked_by.as_deref(), Some("wf-1"));
 
         // Resume clears the enriched marker.
-        project_task_workflow_pause_cleared(hub.clone(), "TASK-1", "wf-1").await.unwrap();
+        project_task_workflow_pause_cleared(&HubTaskProjectionStore::new(hub.clone()), "TASK-1", "wf-1").await.unwrap();
         let task = hub.tasks().get("TASK-1").await.unwrap();
         assert!(task.blocked_reason.is_none());
         assert!(task.blocked_by.is_none());
@@ -537,12 +514,17 @@ mod tests {
         // marker (not bail on "blocked_reason already set").
         let hub = Arc::new(InMemoryServiceHub::new());
         upsert_task(&hub, "TASK-1", TaskStatus::InProgress).await;
-        project_task_workflow_paused(hub.clone(), "TASK-1", "wf-1", None).await.unwrap();
+        project_task_workflow_paused(&HubTaskProjectionStore::new(hub.clone()), "TASK-1", "wf-1", None).await.unwrap();
         assert_eq!(hub.tasks().get("TASK-1").await.unwrap().blocked_reason.as_deref(), Some("paused by workflow wf-1"));
 
-        project_task_workflow_paused(hub.clone(), "TASK-1", "wf-1", Some("budget exceeded ($9 > $5 max_cost_usd)"))
-            .await
-            .unwrap();
+        project_task_workflow_paused(
+            &HubTaskProjectionStore::new(hub.clone()),
+            "TASK-1",
+            "wf-1",
+            Some("budget exceeded ($9 > $5 max_cost_usd)"),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             hub.tasks().get("TASK-1").await.unwrap().blocked_reason.as_deref(),
             Some("paused by workflow wf-1 — budget exceeded ($9 > $5 max_cost_usd)")
@@ -556,11 +538,16 @@ mod tests {
         // None) on the same already-paused workflow must NOT erase the cause.
         let hub = Arc::new(InMemoryServiceHub::new());
         upsert_task(&hub, "TASK-1", TaskStatus::InProgress).await;
-        project_task_workflow_paused(hub.clone(), "TASK-1", "wf-1", Some("budget exceeded ($9 > $5 max_cost_usd)"))
-            .await
-            .unwrap();
+        project_task_workflow_paused(
+            &HubTaskProjectionStore::new(hub.clone()),
+            "TASK-1",
+            "wf-1",
+            Some("budget exceeded ($9 > $5 max_cost_usd)"),
+        )
+        .await
+        .unwrap();
         // Generic re-pause with no detail.
-        project_task_workflow_paused(hub.clone(), "TASK-1", "wf-1", None).await.unwrap();
+        project_task_workflow_paused(&HubTaskProjectionStore::new(hub.clone()), "TASK-1", "wf-1", None).await.unwrap();
         assert_eq!(
             hub.tasks().get("TASK-1").await.unwrap().blocked_reason.as_deref(),
             Some("paused by workflow wf-1 — budget exceeded ($9 > $5 max_cost_usd)"),
@@ -578,7 +565,9 @@ mod tests {
         task.blocked_by = Some("wf-legacy".to_string());
         hub.tasks().replace(task).await.unwrap();
 
-        project_task_workflow_pause_cleared(hub.clone(), "TASK-1", "wf-legacy").await.unwrap();
+        project_task_workflow_pause_cleared(&HubTaskProjectionStore::new(hub.clone()), "TASK-1", "wf-legacy")
+            .await
+            .unwrap();
         let task = hub.tasks().get("TASK-1").await.unwrap();
         assert!(task.blocked_reason.is_none(), "old bare marker must still clear");
     }
@@ -591,13 +580,20 @@ mod tests {
         hub.tasks().replace(task).await.unwrap();
 
         // Pause annotation must not clobber a real failure reason.
-        project_task_workflow_paused(hub.clone(), "TASK-1", "wf-1", Some("budget exceeded")).await.unwrap();
+        project_task_workflow_paused(
+            &HubTaskProjectionStore::new(hub.clone()),
+            "TASK-1",
+            "wf-1",
+            Some("budget exceeded"),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             hub.tasks().get("TASK-1").await.unwrap().blocked_reason.as_deref(),
             Some("workflow runner failed: boom")
         );
         // Resume-clear must leave the foreign reason intact.
-        project_task_workflow_pause_cleared(hub.clone(), "TASK-1", "wf-1").await.unwrap();
+        project_task_workflow_pause_cleared(&HubTaskProjectionStore::new(hub.clone()), "TASK-1", "wf-1").await.unwrap();
         assert_eq!(
             hub.tasks().get("TASK-1").await.unwrap().blocked_reason.as_deref(),
             Some("workflow runner failed: boom")

--- a/crates/orchestrator-core/src/execution_projection/project_task_terminal_workflow_status.rs
+++ b/crates/orchestrator-core/src/execution_projection/project_task_terminal_workflow_status.rs
@@ -1,15 +1,13 @@
-use std::sync::Arc;
+use crate::{TaskStatus, WorkflowStatus};
 
-use crate::{services::ServiceHub, TaskStatus, WorkflowStatus};
-
-use super::{project_task_blocked_with_reason, project_task_status};
+use super::{project_task_blocked_with_reason, project_task_status, TaskProjectionStore};
 
 fn default_failure_reason(workflow_status: WorkflowStatus) -> String {
     format!("workflow ended with status {}", format!("{workflow_status:?}").to_ascii_lowercase())
 }
 
 pub async fn project_task_terminal_workflow_status(
-    hub: Arc<dyn ServiceHub>,
+    store: &dyn TaskProjectionStore,
     task_id: &str,
     workflow_status: WorkflowStatus,
     failure_reason: Option<String>,
@@ -31,19 +29,19 @@ pub async fn project_task_terminal_workflow_status(
         WorkflowStatus::Failed | WorkflowStatus::Escalated => {
             let reason = failure_reason.unwrap_or_else(|| default_failure_reason(workflow_status));
 
-            if let Ok(task) = hub.tasks().get(task_id).await {
-                let _ = project_task_blocked_with_reason(hub, &task, reason, None).await;
+            if store.get(task_id).await.is_ok() {
+                let _ = project_task_blocked_with_reason(store, task_id, reason, None).await;
             } else {
-                let _ = project_task_status(hub, task_id, TaskStatus::Blocked).await;
+                let _ = project_task_status(store, task_id, TaskStatus::Blocked).await;
             }
         }
         WorkflowStatus::Cancelled => {
-            if let Ok(task) = hub.tasks().get(task_id).await {
-                if !matches!(task.status, TaskStatus::Done | TaskStatus::Cancelled) {
-                    let _ = project_task_status(hub, task_id, TaskStatus::Cancelled).await;
+            if let Ok(view) = store.get(task_id).await {
+                if !matches!(view.status, TaskStatus::Done | TaskStatus::Cancelled) {
+                    let _ = project_task_status(store, task_id, TaskStatus::Cancelled).await;
                 }
             } else {
-                let _ = project_task_status(hub, task_id, TaskStatus::Cancelled).await;
+                let _ = project_task_status(store, task_id, TaskStatus::Cancelled).await;
             }
         }
         WorkflowStatus::Paused | WorkflowStatus::Running | WorkflowStatus::Pending => {}

--- a/crates/orchestrator-core/src/execution_projection/projector_registry.rs
+++ b/crates/orchestrator-core/src/execution_projection/projector_registry.rs
@@ -5,15 +5,13 @@ use anyhow::Result;
 use async_trait::async_trait;
 use protocol::{SubjectExecutionFact, SUBJECT_KIND_CUSTOM, SUBJECT_KIND_REQUIREMENT, SUBJECT_KIND_TASK};
 
-use crate::services::ServiceHub;
-
-use super::project_task_execution_fact;
+use super::{project_task_execution_fact, TaskProjectionStore};
 
 #[async_trait]
 pub trait ExecutionProjector: Send + Sync {
     fn kind(&self) -> &'static str;
 
-    async fn project(&self, hub: Arc<dyn ServiceHub>, root: &str, fact: &SubjectExecutionFact) -> Result<()>;
+    async fn project(&self, store: &dyn TaskProjectionStore, fact: &SubjectExecutionFact) -> Result<()>;
 }
 
 #[derive(Clone, Default)]
@@ -33,11 +31,11 @@ impl ExecutionProjectorRegistry {
         self
     }
 
-    pub async fn project(&self, hub: Arc<dyn ServiceHub>, root: &str, fact: &SubjectExecutionFact) -> Result<bool> {
+    pub async fn project(&self, store: &dyn TaskProjectionStore, fact: &SubjectExecutionFact) -> Result<bool> {
         let Some(projector) = self.projector_for_fact(fact) else {
             return Ok(false);
         };
-        projector.project(hub, root, fact).await?;
+        projector.project(store, fact).await?;
         Ok(true)
     }
 
@@ -74,8 +72,8 @@ impl ExecutionProjector for TaskExecutionProjector {
         SUBJECT_KIND_TASK
     }
 
-    async fn project(&self, hub: Arc<dyn ServiceHub>, root: &str, fact: &SubjectExecutionFact) -> Result<()> {
-        project_task_execution_fact(hub, root, fact).await;
+    async fn project(&self, store: &dyn TaskProjectionStore, fact: &SubjectExecutionFact) -> Result<()> {
+        project_task_execution_fact(store, fact).await;
         Ok(())
     }
 }
@@ -96,7 +94,7 @@ impl ExecutionProjector for NoopExecutionProjector {
         self.kind
     }
 
-    async fn project(&self, _hub: Arc<dyn ServiceHub>, _root: &str, _fact: &SubjectExecutionFact) -> Result<()> {
+    async fn project(&self, _store: &dyn TaskProjectionStore, _fact: &SubjectExecutionFact) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/orchestrator-core/src/execution_projection/task_projection_store.rs
+++ b/crates/orchestrator-core/src/execution_projection/task_projection_store.rs
@@ -1,0 +1,146 @@
+//! Task read/write surface the execution-projection layer drives.
+//!
+//! The status/annotation projections used to write directly through
+//! `hub.tasks()` (the legacy in-tree task store). On a plugin-backed / portal
+//! deployment that store is EMPTY — tasks live in the installed
+//! `subject_backend` plugin — so a finished/failed/cancelled/escalated run
+//! projected the task's terminal status into a store nothing reads, leaving the
+//! real (plugin-backed) subject stuck `InProgress` until the 24h stale sweep.
+//!
+//! [`TaskProjectionStore`] abstracts the exact task operations the projections
+//! need so the same projection LOGIC can target either the in-tree store
+//! ([`HubTaskProjectionStore`], the stock scaffold with no subject plugin) or
+//! the installed subject backend via the router (the CLI/daemon-runtime layer's
+//! `RouterTaskProjectionStore`, chosen when a plugin owns `task`). This mirrors
+//! the already-correct `RouterStaleTaskStore` pattern the daemon's stale
+//! reconciler uses.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+
+use crate::{services::ServiceHub, TaskStatus};
+
+/// Projection-relevant snapshot of a task, sourced from either the in-tree
+/// store or a subject backend plugin. Only the fields the status/annotation
+/// projections branch on are carried.
+#[derive(Debug, Clone)]
+pub struct TaskProjectionView {
+    /// Current lifecycle status.
+    pub status: TaskStatus,
+    /// Current `blocked_reason` annotation, if any.
+    pub blocked_reason: Option<String>,
+    /// Current `blocked_by` marker, if any.
+    pub blocked_by: Option<String>,
+}
+
+/// Task status/annotation write + read surface the execution projections drive.
+///
+/// The DECISION logic (terminal Blocked-vs-Cancelled, pause-marker
+/// upgrade/skip) stays in the projection functions; this trait only abstracts
+/// the IO so those writes reach whichever store actually backs `task` on the
+/// current deployment.
+#[async_trait]
+pub trait TaskProjectionStore: Send + Sync {
+    /// Read the projection-relevant fields for a task. `Err` when the task
+    /// cannot be read (absent / backend error) — callers treat that as
+    /// "task not present, skip", matching the old `hub.tasks().get` gating.
+    async fn get(&self, id: &str) -> Result<TaskProjectionView>;
+
+    /// Set the lifecycle status. No state-machine validation is applied,
+    /// matching the projection's historical `set_status(.., false)` contract.
+    async fn set_status(&self, id: &str, status: TaskStatus) -> Result<()>;
+
+    /// Transition to `Blocked` and record the failure reason + optional blocker.
+    async fn block_with_reason(&self, id: &str, reason: String, blocked_by: Option<String>) -> Result<()>;
+
+    /// Write the informational `blocked_reason` (and, when provided,
+    /// `blocked_by`) annotation WITHOUT changing the lifecycle status.
+    async fn annotate_blocked_reason(&self, id: &str, reason: String, set_blocked_by: Option<String>) -> Result<()>;
+
+    /// Clear the `blocked_reason` annotation. Also clears `blocked_by` when
+    /// `clear_blocked_by` is true.
+    async fn clear_blocked_reason(&self, id: &str, clear_blocked_by: bool) -> Result<()>;
+
+    /// Transition to `InProgress` and record the assigned agent role/model.
+    async fn start_workflow(&self, id: &str, role: String, model: Option<String>, updated_by: String) -> Result<()>;
+}
+
+/// In-tree task-store view. Behaviour is byte-identical to the pre-routing
+/// projections (metadata bumps, `updated_by` actor, `paused`/`blocked_at`
+/// bookkeeping); used by the stock scaffold (no subject plugin owning `task`)
+/// and the existing hub-based projection tests.
+pub struct HubTaskProjectionStore {
+    hub: Arc<dyn ServiceHub>,
+}
+
+impl HubTaskProjectionStore {
+    #[must_use]
+    pub fn new(hub: Arc<dyn ServiceHub>) -> Self {
+        Self { hub }
+    }
+}
+
+#[async_trait]
+impl TaskProjectionStore for HubTaskProjectionStore {
+    async fn get(&self, id: &str) -> Result<TaskProjectionView> {
+        let task = self.hub.tasks().get(id).await?;
+        Ok(TaskProjectionView { status: task.status, blocked_reason: task.blocked_reason, blocked_by: task.blocked_by })
+    }
+
+    async fn set_status(&self, id: &str, status: TaskStatus) -> Result<()> {
+        self.hub.tasks().set_status(id, status, false).await.map(|_| ())
+    }
+
+    async fn block_with_reason(&self, id: &str, reason: String, blocked_by: Option<String>) -> Result<()> {
+        let mut task = self.hub.tasks().get(id).await?;
+        task.status = TaskStatus::Blocked;
+        task.paused = true;
+        task.blocked_reason = Some(reason);
+        task.blocked_at = Some(Utc::now());
+        task.blocked_phase = None;
+        task.blocked_by = blocked_by;
+        task.metadata.updated_at = Utc::now();
+        task.metadata.updated_by = protocol::ACTOR_DAEMON.to_string();
+        task.metadata.version = task.metadata.version.saturating_add(1);
+        self.hub.tasks().replace(task).await.map(|_| ())
+    }
+
+    async fn annotate_blocked_reason(&self, id: &str, reason: String, set_blocked_by: Option<String>) -> Result<()> {
+        let mut task = self.hub.tasks().get(id).await?;
+        task.blocked_reason = Some(reason);
+        if let Some(blocked_by) = set_blocked_by {
+            task.blocked_by = Some(blocked_by);
+        }
+        task.metadata.updated_at = Utc::now();
+        task.metadata.updated_by = protocol::ACTOR_CORE.to_string();
+        task.metadata.version = task.metadata.version.saturating_add(1);
+        self.hub.tasks().replace(task).await.map(|_| ())
+    }
+
+    async fn clear_blocked_reason(&self, id: &str, clear_blocked_by: bool) -> Result<()> {
+        let mut task = self.hub.tasks().get(id).await?;
+        task.blocked_reason = None;
+        if clear_blocked_by {
+            task.blocked_by = None;
+        }
+        task.metadata.updated_at = Utc::now();
+        task.metadata.updated_by = protocol::ACTOR_CORE.to_string();
+        task.metadata.version = task.metadata.version.saturating_add(1);
+        self.hub.tasks().replace(task).await.map(|_| ())
+    }
+
+    async fn start_workflow(&self, id: &str, role: String, model: Option<String>, updated_by: String) -> Result<()> {
+        self.hub.tasks().set_status(id, TaskStatus::InProgress, false).await?;
+        self.hub.tasks().assign_agent(id, role, model, updated_by).await.map(|_| ())
+    }
+}
+
+/// Convenience: box a hub-backed store for callers that want a
+/// `Box<dyn TaskProjectionStore>` fallback.
+#[must_use]
+pub fn hub_task_projection_store(hub: Arc<dyn ServiceHub>) -> Box<dyn TaskProjectionStore> {
+    Box::new(HubTaskProjectionStore::new(hub))
+}

--- a/crates/orchestrator-core/src/lib.rs
+++ b/crates/orchestrator-core/src/lib.rs
@@ -55,12 +55,13 @@ pub use domain_state::{
     ErrorRecord, ErrorStore, HandoffRecord, HandoffStore, HistoryExecutionRecord, HistoryStore,
 };
 pub use execution_projection::{
-    builtin_execution_projector_registry, execution_fact_subject_kind, project_execution_fact,
-    project_requirement_workflow_status, project_schedule_dispatch_attempt, project_schedule_dispatch_missed,
-    project_schedule_execution_fact, project_task_blocked_with_reason, project_task_execution_fact,
-    project_task_status, project_task_terminal_workflow_status, project_task_workflow_pause_cleared,
-    project_task_workflow_paused, project_task_workflow_start, workflow_paused_reason, ExecutionProjector,
-    ExecutionProjectorRegistry, WORKFLOW_PAUSED_REASON_PREFIX, WORKFLOW_RUNNER_BLOCKED_PREFIX,
+    builtin_execution_projector_registry, execution_fact_subject_kind, hub_task_projection_store,
+    project_execution_fact, project_requirement_workflow_status, project_schedule_dispatch_attempt,
+    project_schedule_dispatch_missed, project_schedule_execution_fact, project_task_blocked_with_reason,
+    project_task_execution_fact, project_task_status, project_task_terminal_workflow_status,
+    project_task_workflow_pause_cleared, project_task_workflow_paused, project_task_workflow_start,
+    workflow_paused_reason, ExecutionProjector, ExecutionProjectorRegistry, HubTaskProjectionStore,
+    TaskProjectionStore, TaskProjectionView, WORKFLOW_PAUSED_REASON_PREFIX, WORKFLOW_RUNNER_BLOCKED_PREFIX,
 };
 pub use flavor::{
     list_available_flavor_names, load_flavor, locate_flavor_manifest, FlavorDefaults, FlavorManifest,

--- a/crates/orchestrator-core/src/services/tests.rs
+++ b/crates/orchestrator-core/src/services/tests.rs
@@ -2764,6 +2764,7 @@ async fn manual_phase_approval_resume_clears_task_pause_marker() {
     let root = temp.path().to_string_lossy().to_string();
     crate::dispatch_workflow_event(
         hub.clone(),
+        &crate::HubTaskProjectionStore::new(hub.clone()),
         &root,
         crate::WorkflowEvent::Pause { workflow_id: workflow.id.clone(), reason_detail: None },
     )
@@ -2778,6 +2779,7 @@ async fn manual_phase_approval_resume_clears_task_pause_marker() {
 
     crate::dispatch_workflow_event(
         hub.clone(),
+        &crate::HubTaskProjectionStore::new(hub.clone()),
         &root,
         crate::WorkflowEvent::ApproveManualPhase {
             workflow_id: workflow.id.clone(),

--- a/crates/orchestrator-core/src/workflow_events.rs
+++ b/crates/orchestrator-core/src/workflow_events.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use crate::{
     load_agent_runtime_config_or_default, project_task_status, project_task_terminal_workflow_status,
     project_task_workflow_pause_cleared, project_task_workflow_paused, services::ServiceHub, OrchestratorTask,
-    OrchestratorWorkflow, PhaseExecutionMode, PhaseManualDefinition, TaskStatus, WorkflowStatus,
+    OrchestratorWorkflow, PhaseExecutionMode, PhaseManualDefinition, TaskProjectionStore, TaskStatus, WorkflowStatus,
 };
 
 #[derive(Debug, Clone)]
@@ -50,6 +50,7 @@ pub struct WorkflowEventOutcome {
 
 pub async fn dispatch_workflow_event(
     hub: Arc<dyn ServiceHub>,
+    store: &dyn TaskProjectionStore,
     project_root: &str,
     event: WorkflowEvent,
 ) -> Result<WorkflowEventOutcome> {
@@ -63,8 +64,7 @@ pub async fn dispatch_workflow_event(
             let task = if let Some(task_id) =
                 (workflow.status == WorkflowStatus::Paused).then(|| workflow_task_id(&workflow)).flatten()
             {
-                let _ =
-                    project_task_workflow_paused(hub.clone(), &task_id, &workflow_id, reason_detail.as_deref()).await;
+                let _ = project_task_workflow_paused(store, &task_id, &workflow_id, reason_detail.as_deref()).await;
                 hub.tasks().get(&task_id).await.ok()
             } else {
                 None
@@ -81,7 +81,7 @@ pub async fn dispatch_workflow_event(
             // Clear the matching "paused by workflow <id>" annotation; a
             // genuine failure-projected blocked_reason is left alone.
             let task = if let Some(task_id) = workflow_task_id(&workflow) {
-                let _ = project_task_workflow_pause_cleared(hub.clone(), &task_id, &workflow_id).await;
+                let _ = project_task_workflow_pause_cleared(store, &task_id, &workflow_id).await;
                 hub.tasks().get(&task_id).await.ok()
             } else {
                 None
@@ -100,7 +100,7 @@ pub async fn dispatch_workflow_event(
             let task = if let Some(task_id) =
                 (workflow.status == WorkflowStatus::Cancelled).then(|| workflow_task_id(&workflow)).flatten()
             {
-                project_task_terminal_workflow_status(hub.clone(), &task_id, WorkflowStatus::Cancelled, None).await;
+                project_task_terminal_workflow_status(store, &task_id, WorkflowStatus::Cancelled, None).await;
                 hub.tasks().get(&task_id).await.ok()
             } else {
                 None
@@ -132,7 +132,7 @@ pub async fn dispatch_workflow_event(
                     // This is a resume path too: clear any "paused by
                     // workflow <id>" annotation left on the task by a pause.
                     if let Some(task_id) = workflow_task_id(&workflow) {
-                        let _ = project_task_workflow_pause_cleared(hub.clone(), &task_id, &workflow_id).await;
+                        let _ = project_task_workflow_pause_cleared(store, &task_id, &workflow_id).await;
                     }
                 }
                 WorkflowStatus::Running => {}
@@ -177,7 +177,7 @@ pub async fn dispatch_workflow_event(
                     // This is a resume path too: clear any "paused by
                     // workflow <id>" annotation left on the task by a pause.
                     if let Some(task_id) = workflow_task_id(&workflow) {
-                        let _ = project_task_workflow_pause_cleared(hub.clone(), &task_id, &workflow_id).await;
+                        let _ = project_task_workflow_pause_cleared(store, &task_id, &workflow_id).await;
                     }
                 }
                 WorkflowStatus::Running => {}
@@ -195,7 +195,7 @@ pub async fn dispatch_workflow_event(
             Ok(WorkflowEventOutcome { workflow: Some(updated), ..WorkflowEventOutcome::default() })
         }
         WorkflowEvent::StaleReset { task_id, reason } => {
-            project_task_status(hub.clone(), &task_id, TaskStatus::Ready).await?;
+            project_task_status(store, &task_id, TaskStatus::Ready).await?;
             let task = hub.tasks().get(&task_id).await.ok();
             let _ = reason;
             Ok(WorkflowEventOutcome { task, ..WorkflowEventOutcome::default() })
@@ -243,9 +243,9 @@ mod tests {
 
     use super::{dispatch_workflow_event, WorkflowEvent};
     use crate::{
-        services::ServiceHub, InMemoryServiceHub, OrchestratorTask, Priority, ResourceRequirements, Scope,
-        TaskMetadata, TaskStatus, TaskType, WorkflowMetadata, WorkflowRunInput, WorkflowStatus,
-        WORKFLOW_PAUSED_REASON_PREFIX,
+        services::ServiceHub, HubTaskProjectionStore, InMemoryServiceHub, OrchestratorTask, Priority,
+        ResourceRequirements, Scope, TaskMetadata, TaskStatus, TaskType, WorkflowMetadata, WorkflowRunInput,
+        WorkflowStatus, WORKFLOW_PAUSED_REASON_PREFIX,
     };
 
     async fn upsert_task(hub: &Arc<InMemoryServiceHub>, id: &str, status: TaskStatus) -> OrchestratorTask {
@@ -314,6 +314,7 @@ mod tests {
 
         let outcome = dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Pause { workflow_id: workflow_id.clone(), reason_detail: None },
         )
@@ -336,6 +337,7 @@ mod tests {
 
         dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Pause { workflow_id: workflow_id.clone(), reason_detail: None },
         )
@@ -343,6 +345,7 @@ mod tests {
         .expect("pause dispatch");
         dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Resume { workflow_id: workflow_id.clone(), feedback: None },
         )
@@ -365,6 +368,7 @@ mod tests {
 
         dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Resume { workflow_id, feedback: None },
         )
@@ -390,6 +394,7 @@ mod tests {
 
         dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Pause { workflow_id, reason_detail: None },
         )
@@ -411,10 +416,14 @@ mod tests {
         upsert_task(&hub, "TASK-4", TaskStatus::InProgress).await;
         let workflow_id = start_workflow_for_task(&hub, "TASK-4").await;
 
-        let outcome =
-            dispatch_workflow_event(hub.clone() as Arc<dyn ServiceHub>, ".", WorkflowEvent::Cancel { workflow_id })
-                .await
-                .expect("cancel dispatch");
+        let outcome = dispatch_workflow_event(
+            hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
+            ".",
+            WorkflowEvent::Cancel { workflow_id },
+        )
+        .await
+        .expect("cancel dispatch");
         assert_eq!(outcome.workflow.expect("workflow").status, WorkflowStatus::Cancelled);
 
         let task = hub.tasks().get("TASK-4").await.expect("task");
@@ -431,9 +440,14 @@ mod tests {
         upsert_task(&hub, "TASK-5", TaskStatus::Done).await;
         let workflow_id = start_workflow_for_task(&hub, "TASK-5").await;
 
-        dispatch_workflow_event(hub.clone() as Arc<dyn ServiceHub>, ".", WorkflowEvent::Cancel { workflow_id })
-            .await
-            .expect("cancel dispatch");
+        dispatch_workflow_event(
+            hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
+            ".",
+            WorkflowEvent::Cancel { workflow_id },
+        )
+        .await
+        .expect("cancel dispatch");
 
         let task = hub.tasks().get("TASK-5").await.expect("task");
         assert_eq!(task.status, TaskStatus::Done, "cancel must not regress an already-done task");
@@ -446,6 +460,7 @@ mod tests {
         let workflow_id = start_workflow_for_task(&hub, "TASK-6").await;
         dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Pause { workflow_id, reason_detail: None },
         )
@@ -481,6 +496,7 @@ mod tests {
 
         let outcome = dispatch_workflow_event(
             hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
             ".",
             WorkflowEvent::Pause { workflow_id, reason_detail: None },
         )
@@ -501,10 +517,14 @@ mod tests {
         let workflow_id = start_workflow_for_task(&hub, "TASK-9").await;
         complete_workflow(&hub, &workflow_id).await;
 
-        let outcome =
-            dispatch_workflow_event(hub.clone() as Arc<dyn ServiceHub>, ".", WorkflowEvent::Cancel { workflow_id })
-                .await
-                .expect("cancel dispatch");
+        let outcome = dispatch_workflow_event(
+            hub.clone() as Arc<dyn ServiceHub>,
+            &HubTaskProjectionStore::new(hub.clone()),
+            ".",
+            WorkflowEvent::Cancel { workflow_id },
+        )
+        .await
+        .expect("cancel dispatch");
         assert_eq!(outcome.workflow.expect("workflow").status, WorkflowStatus::Completed, "cancel is a no-op");
 
         let task = hub.tasks().get("TASK-9").await.expect("task");

--- a/crates/orchestrator-daemon-runtime/src/lib.rs
+++ b/crates/orchestrator-daemon-runtime/src/lib.rs
@@ -8,6 +8,7 @@ pub mod metrics;
 pub mod quotas;
 mod schedule;
 mod subject_dispatch;
+mod task_projection;
 mod tick;
 
 pub use audit::{
@@ -59,6 +60,7 @@ pub use subject_dispatch::{
     discover_subject_backends, resolve_subject_dispatch, subject_plugins_disable_env_set, SubjectDispatchResolution,
     SubjectPluginDispatch, SUBJECT_PLUGINS_DISABLE_ENV,
 };
+pub use task_projection::{resolve_task_projection_store, RouterTaskProjectionStore};
 pub use tick::{
     default_slim_project_tick_driver, run_project_tick, run_project_tick_at, BudgetBreachEvent,
     DefaultProjectTickServices, DefaultSlimProjectTickDriver, ProjectTickContext, ProjectTickExecutionOutcome,

--- a/crates/orchestrator-daemon-runtime/src/task_projection.rs
+++ b/crates/orchestrator-daemon-runtime/src/task_projection.rs
@@ -1,0 +1,481 @@
+//! Router-backed [`TaskProjectionStore`] for the daemon / CLI layer.
+//!
+//! The execution-projection layer in `orchestrator-core` writes task status +
+//! annotations through the [`TaskProjectionStore`] trait. On a plugin-backed /
+//! portal deployment the legacy in-tree store (`hub.tasks()`) is EMPTY — tasks
+//! live in the installed `subject_backend` plugin — so projecting a terminal
+//! status into it left the real subject stuck `InProgress`.
+//!
+//! [`RouterTaskProjectionStore`] routes those writes through the same
+//! `SubjectPluginDispatch` the rest of the subject surface uses
+//! (`task/status`, `task/update`, `task/get`), and
+//! [`resolve_task_projection_store`] selects it only when a backend actually
+//! owns `task`, falling back to the in-tree store otherwise. This clones the
+//! already-correct `RouterStaleTaskStore` pattern.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use orchestrator_core::services::ServiceHub;
+use orchestrator_core::{HubTaskProjectionStore, TaskProjectionStore, TaskProjectionView, TaskStatus};
+
+use crate::subject_dispatch::{resolve_subject_dispatch, SubjectPluginDispatch};
+
+/// The built-in `task` kind and the catch-all wildcard the router also serves
+/// `task/*` through.
+const TASK_KIND: &str = "task";
+const CATCH_ALL_KIND: &str = "*";
+
+/// Subject-router-backed task projection store. Every write routes
+/// `task/<verb>` through the installed `subject_backend` plugin.
+pub struct RouterTaskProjectionStore {
+    dispatch: SubjectPluginDispatch,
+}
+
+impl RouterTaskProjectionStore {
+    #[must_use]
+    pub fn new(dispatch: SubjectPluginDispatch) -> Self {
+        Self { dispatch }
+    }
+
+    /// `true` when a `subject_backend` plugin can serve the built-in `task`
+    /// kind (an explicit `task` kind or a `*` catch-all), so routing the
+    /// projections through it is meaningful.
+    #[must_use]
+    pub fn routes_tasks(dispatch: &SubjectPluginDispatch) -> bool {
+        dispatch.is_active() && dispatch.kinds().iter().any(|kind| kind == TASK_KIND || kind == CATCH_ALL_KIND)
+    }
+
+    async fn route(&self, method: &str, params: Value) -> Result<Value> {
+        self.dispatch
+            .route_call(method, Some(params))
+            .await
+            .map_err(|err| anyhow!("subject backend {method} failed ({}): {}", err.code, err.message))
+    }
+
+    /// Best-effort `task/update` patch for informational fields. A backend that
+    /// does not model the patched field (e.g. `blocked_reason`) must not fail
+    /// the projection — the load-bearing status transition already landed via
+    /// `task/status`.
+    async fn best_effort_update(&self, id: &str, patch: Value) {
+        if let Err(error) = self.route("task/update", json!({ "id": id, "patch": patch })).await {
+            tracing::debug!(task_id = %id, error = %error, "best-effort task/update annotation skipped");
+        }
+    }
+}
+
+#[async_trait]
+impl TaskProjectionStore for RouterTaskProjectionStore {
+    async fn get(&self, id: &str) -> Result<TaskProjectionView> {
+        let id = qualify_task_id(id);
+        let raw = self.route("task/get", json!({ "id": id })).await?;
+        let subject =
+            subject_object(&raw).ok_or_else(|| anyhow!("subject backend task/get returned no subject for '{id}'"))?;
+        Ok(TaskProjectionView {
+            status: parse_status(subject).unwrap_or(TaskStatus::InProgress),
+            blocked_reason: field_str(subject, "blocked_reason"),
+            blocked_by: field_str(subject, "blocked_by"),
+        })
+    }
+
+    async fn set_status(&self, id: &str, status: TaskStatus) -> Result<()> {
+        let id = qualify_task_id(id);
+        self.route("task/status", json!({ "id": &id, "status": wire_status(status) })).await?;
+        // Mirror the in-tree `apply_task_status`: any NON-blocked transition
+        // clears the blocked/paused bookkeeping. Without this, the `custom`
+        // fields written by `block_with_reason` / pause annotations would linger
+        // on the plugin-backed subject after e.g. a cancel or a stale-reset to
+        // Ready. Best-effort: a backend that clears them itself just no-ops.
+        if !status.is_blocked() {
+            self.best_effort_update(&id, json!({ "custom": clear_block_bookkeeping() })).await;
+        }
+        Ok(())
+    }
+
+    async fn block_with_reason(&self, id: &str, reason: String, blocked_by: Option<String>) -> Result<()> {
+        let id = qualify_task_id(id);
+        // Status is the load-bearing fix: propagate its error. The annotation
+        // fields are best-effort so a backend that does not model them still
+        // gets the terminal Blocked transition.
+        self.route("task/status", json!({ "id": &id, "status": wire_status(TaskStatus::Blocked) })).await?;
+        // `blocked_reason` / `blocked_by` / `paused` are not top-level
+        // `SubjectPatch` fields — carry them in the patch's `custom` map (the
+        // read side already looks there). An explicit `null` clears the key.
+        let custom = json!({
+            "blocked_reason": reason,
+            "blocked_by": blocked_by.map(Value::String).unwrap_or(Value::Null),
+            "paused": true,
+        });
+        self.best_effort_update(&id, json!({ "custom": custom })).await;
+        Ok(())
+    }
+
+    async fn annotate_blocked_reason(&self, id: &str, reason: String, set_blocked_by: Option<String>) -> Result<()> {
+        let id = qualify_task_id(id);
+        // Informational only (no status change). Route the annotation through
+        // the patch's `custom` map; a backend that does not model it degrades
+        // to a no-op.
+        let mut custom = serde_json::Map::new();
+        custom.insert("blocked_reason".to_string(), json!(reason));
+        if let Some(blocked_by) = set_blocked_by {
+            custom.insert("blocked_by".to_string(), json!(blocked_by));
+        }
+        self.best_effort_update(&id, json!({ "custom": Value::Object(custom) })).await;
+        Ok(())
+    }
+
+    async fn clear_blocked_reason(&self, id: &str, clear_blocked_by: bool) -> Result<()> {
+        let id = qualify_task_id(id);
+        // An explicit JSON `null` in the patch's `custom` map clears the field.
+        let mut custom = serde_json::Map::new();
+        custom.insert("blocked_reason".to_string(), Value::Null);
+        if clear_blocked_by {
+            custom.insert("blocked_by".to_string(), Value::Null);
+        }
+        self.best_effort_update(&id, json!({ "custom": Value::Object(custom) })).await;
+        Ok(())
+    }
+
+    async fn start_workflow(&self, id: &str, role: String, model: Option<String>, _updated_by: String) -> Result<()> {
+        let id = qualify_task_id(id);
+        // The InProgress transition is the load-bearing fix (finding 2); the
+        // agent assignment is best-effort annotation. `assignee` is a top-level
+        // `SubjectPatch` field; the model lands in `custom`. InProgress is a
+        // non-blocked status, so also clear any lingering blocked/paused
+        // bookkeeping (matching the in-tree `apply_task_status`).
+        self.route("task/status", json!({ "id": &id, "status": wire_status(TaskStatus::InProgress) })).await?;
+        let mut custom = clear_block_bookkeeping();
+        custom.insert("assignee_model".to_string(), json!(model));
+        self.best_effort_update(&id, json!({ "assignee": format!("agent:{role}"), "custom": custom })).await;
+        Ok(())
+    }
+}
+
+/// Choose the task projection store: the subject router when a `subject_backend`
+/// plugin owns `task` (production / portal), else the in-tree store (stock
+/// scaffold / no plugins). A routing-discovery failure falls back to the
+/// in-tree store so a transient plugin problem never takes the projection down.
+pub async fn resolve_task_projection_store(root: &str, hub: Arc<dyn ServiceHub>) -> Box<dyn TaskProjectionStore> {
+    match resolve_subject_dispatch(std::path::Path::new(root)).await {
+        Ok(resolution) if RouterTaskProjectionStore::routes_tasks(&resolution.selected) => {
+            Box::new(RouterTaskProjectionStore::new(resolution.selected))
+        }
+        _ => Box::new(HubTaskProjectionStore::new(hub)),
+    }
+}
+
+/// Qualify a task id to the `task:<native>` form the subject router / backend
+/// keys subjects under. Projection callers hand us the workflow's `task_id`,
+/// which may be the BARE native id (`TASK-1`, e.g. from `workflow run
+/// --task-id`) or already qualified (`task:TASK-1`); routing a bare id through
+/// `task/get` / `task/status` misses or is rejected by the backend. An id
+/// already carrying a `<kind>:` qualifier is passed through unchanged.
+fn qualify_task_id(id: &str) -> String {
+    if id.contains(':') {
+        id.to_string()
+    } else {
+        format!("{TASK_KIND}:{id}")
+    }
+}
+
+/// `custom` patch that clears the blocked/paused bookkeeping this store writes
+/// (`blocked_reason`, `blocked_by`, `paused`). An explicit JSON `null` clears a
+/// custom field; `paused` is reset to `false`. Mirrors the in-tree
+/// `apply_task_status` cleanup on a non-blocked transition.
+fn clear_block_bookkeeping() -> serde_json::Map<String, Value> {
+    let mut custom = serde_json::Map::new();
+    custom.insert("blocked_reason".to_string(), Value::Null);
+    custom.insert("blocked_by".to_string(), Value::Null);
+    custom.insert("paused".to_string(), Value::Bool(false));
+    custom
+}
+
+/// Wire status token the subject_backend plugin expects. `TaskStatus`
+/// serializes kebab-case, matching the `SubjectStatus` vocabulary.
+fn wire_status(status: TaskStatus) -> String {
+    serde_json::to_value(status).ok().and_then(|value| value.as_str().map(str::to_string)).unwrap_or_default()
+}
+
+/// Unwrap a `<kind>/get` response into the subject object (top-level or
+/// `{ "subject": { ... } }` wrapped).
+fn subject_object(value: &Value) -> Option<&serde_json::Map<String, Value>> {
+    if let Some(inner) = value.get("subject").and_then(Value::as_object) {
+        return Some(inner);
+    }
+    value.as_object().filter(|map| map.contains_key("id"))
+}
+
+/// Parse the subject's `status` string into a [`TaskStatus`], tolerating
+/// `in_progress` / casing variants.
+fn parse_status(subject: &serde_json::Map<String, Value>) -> Option<TaskStatus> {
+    let raw = subject.get("status").and_then(Value::as_str)?;
+    let normalized = raw.trim().to_ascii_lowercase().replace('_', "-");
+    serde_json::from_value::<TaskStatus>(json!(normalized)).ok()
+}
+
+/// Read a string field from the subject object, checking the top level first
+/// then a nested `custom` map (where some backends persist annotations).
+fn field_str(subject: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    subject
+        .get(key)
+        .and_then(Value::as_str)
+        .or_else(|| subject.get("custom").and_then(|c| c.get(key)).and_then(Value::as_str))
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_status_is_kebab_case() {
+        assert_eq!(wire_status(TaskStatus::InProgress), "in-progress");
+        assert_eq!(wire_status(TaskStatus::Blocked), "blocked");
+        assert_eq!(wire_status(TaskStatus::Cancelled), "cancelled");
+        assert_eq!(wire_status(TaskStatus::Ready), "ready");
+    }
+
+    #[test]
+    fn subject_object_unwraps_both_shapes() {
+        let wrapped = json!({ "subject": { "id": "task:T1", "status": "blocked" } });
+        assert!(subject_object(&wrapped).unwrap().contains_key("status"));
+        let bare = json!({ "id": "task:T1", "status": "in-progress" });
+        assert!(subject_object(&bare).unwrap().contains_key("status"));
+        assert!(subject_object(&json!({ "ok": true })).is_none());
+    }
+
+    #[test]
+    fn parse_status_tolerates_underscore_and_case() {
+        let s = json!({ "status": "In_Progress" });
+        assert_eq!(parse_status(s.as_object().unwrap()), Some(TaskStatus::InProgress));
+    }
+
+    #[test]
+    fn field_str_reads_top_level_and_custom() {
+        let top = json!({ "blocked_reason": "boom" });
+        assert_eq!(field_str(top.as_object().unwrap(), "blocked_reason"), Some("boom".to_string()));
+        let nested = json!({ "custom": { "blocked_by": "wf-1" } });
+        assert_eq!(field_str(nested.as_object().unwrap(), "blocked_by"), Some("wf-1".to_string()));
+        let empty = json!({ "blocked_reason": "" });
+        assert_eq!(field_str(empty.as_object().unwrap(), "blocked_reason"), None);
+    }
+
+    #[test]
+    fn routes_tasks_requires_active_dispatch_owning_task() {
+        // An empty dispatch never routes tasks (stock scaffold / no plugins).
+        assert!(!RouterTaskProjectionStore::routes_tasks(&SubjectPluginDispatch::empty()));
+    }
+
+    // --- Router-routing integration tests ------------------------------------
+
+    use animus_plugin_protocol::{
+        InitializeResult, PluginCapabilities, PluginInfo, RpcRequest, RpcResponse, PLUGIN_KIND_SUBJECT_BACKEND,
+    };
+    use orchestrator_plugin_host::{PluginHost, SubjectRouter};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use tokio::io::{duplex, AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    /// One routed call the recording backend observed: `(method, id)`.
+    type RoutedCall = (String, String);
+
+    /// A fake `task` subject backend that records every routed `(method, id)`
+    /// and answers `task/get` with a minimal in-progress subject.
+    async fn recording_task_host(recorded: Arc<Mutex<Vec<RoutedCall>>>) -> PluginHost {
+        let (host_reader, mut plugin_writer) = duplex(8192);
+        let (plugin_reader, host_writer) = duplex(8192);
+
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(plugin_reader);
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).await.expect("read line") == 0 {
+                    break;
+                }
+                let request: RpcRequest = serde_json::from_str(line.trim()).expect("parse request");
+                let response = match request.method.as_str() {
+                    "initialize" => RpcResponse::ok(
+                        request.id,
+                        serde_json::json!(InitializeResult {
+                            protocol_version: "1.0.0".to_string(),
+                            plugin_info: PluginInfo {
+                                name: "tasks".to_string(),
+                                version: "0.1.0".to_string(),
+                                plugin_kind: PLUGIN_KIND_SUBJECT_BACKEND.to_string(),
+                                plugin_kinds: vec![],
+                                description: None,
+                            },
+                            capabilities: PluginCapabilities {
+                                subject_kinds: vec!["task".to_string()],
+                                methods: vec![
+                                    "task/get".to_string(),
+                                    "task/status".to_string(),
+                                    "task/update".to_string(),
+                                ],
+                                ..PluginCapabilities::default()
+                            },
+                            kind_capabilities: std::collections::HashMap::new(),
+                        }),
+                    ),
+                    "initialized" => continue,
+                    method => {
+                        let routed_id = request
+                            .params
+                            .as_ref()
+                            .and_then(|p| p.get("id"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        recorded.lock().unwrap().push((method.to_string(), routed_id));
+                        let body = if method == "task/get" {
+                            serde_json::json!({ "id": "task:TASK-1", "kind": "task", "status": "in-progress" })
+                        } else {
+                            serde_json::json!({ "ok": true })
+                        };
+                        RpcResponse::ok(request.id, body)
+                    }
+                };
+                let mut encoded = serde_json::to_string(&response).expect("encode response");
+                encoded.push('\n');
+                plugin_writer.write_all(encoded.as_bytes()).await.expect("write response");
+            }
+        });
+
+        PluginHost::from_streams("tasks", host_reader, host_writer)
+    }
+
+    async fn router_store_over_task_backend(recorded: Arc<Mutex<Vec<RoutedCall>>>) -> RouterTaskProjectionStore {
+        let mut hosts = HashMap::new();
+        hosts.insert("tasks".to_string(), recording_task_host(recorded).await);
+        let router = SubjectRouter::from_initialized_hosts(hosts).await.expect("router builds");
+        let dispatch = SubjectPluginDispatch::from_router(router, vec!["task".to_string()], 1);
+        assert!(RouterTaskProjectionStore::routes_tasks(&dispatch), "a backend owning `task` must route");
+        RouterTaskProjectionStore::new(dispatch)
+    }
+
+    fn methods(recorded: &Arc<Mutex<Vec<RoutedCall>>>) -> Vec<String> {
+        recorded.lock().unwrap().iter().map(|(method, _)| method.clone()).collect()
+    }
+
+    #[tokio::test]
+    async fn set_status_to_non_blocked_clears_bookkeeping() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let store = router_store_over_task_backend(recorded.clone()).await;
+
+        store.set_status("task:TASK-1", TaskStatus::Cancelled).await.expect("status routes");
+
+        // A non-blocked transition routes the status AND a clear-annotation
+        // update, matching the in-tree `apply_task_status` cleanup.
+        assert_eq!(methods(&recorded), vec!["task/status".to_string(), "task/update".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn set_status_to_blocked_does_not_emit_clear_update() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let store = router_store_over_task_backend(recorded.clone()).await;
+
+        store.set_status("task:TASK-1", TaskStatus::Blocked).await.expect("status routes");
+
+        // Blocking must NOT clear the bookkeeping it (or a sibling projection)
+        // is establishing.
+        assert_eq!(methods(&recorded), vec!["task/status".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn bare_task_id_is_qualified_before_routing() {
+        // The load-bearing P1 fix: a bare native id (as carried by
+        // `workflow run --task-id TASK-1`) must be qualified to `task:TASK-1`
+        // before it hits the backend, or `task/status` misses the subject.
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let store = router_store_over_task_backend(recorded.clone()).await;
+
+        store.set_status("TASK-1", TaskStatus::InProgress).await.expect("status routes");
+
+        // Every routed call carries the qualified id.
+        assert!(
+            recorded.lock().unwrap().iter().all(|(_, id)| id == "task:TASK-1"),
+            "all routed ids must be qualified: {:?}",
+            recorded.lock().unwrap()
+        );
+        assert_eq!(recorded.lock().unwrap()[0], ("task/status".to_string(), "task:TASK-1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn block_with_reason_routes_status_then_annotation() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let store = router_store_over_task_backend(recorded.clone()).await;
+
+        store.block_with_reason("task:TASK-1", "boom".to_string(), Some("wf-1".to_string())).await.expect("blocks");
+
+        // The load-bearing status transition routes first, the annotation second.
+        assert_eq!(methods(&recorded), vec!["task/status".to_string(), "task/update".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn get_reads_the_task_backend_status() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let store = router_store_over_task_backend(recorded.clone()).await;
+
+        let view = store.get("task:TASK-1").await.expect("get routes");
+        assert_eq!(view.status, TaskStatus::InProgress);
+        assert_eq!(methods(&recorded), vec!["task/get".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn start_workflow_routes_in_progress_transition() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let store = router_store_over_task_backend(recorded.clone()).await;
+
+        store.start_workflow("task:TASK-1", "impl".to_string(), None, "daemon".to_string()).await.expect("starts");
+
+        assert_eq!(methods(&recorded), vec!["task/status".to_string(), "task/update".to_string()]);
+    }
+
+    #[test]
+    fn qualify_task_id_adds_task_prefix_to_bare_ids_only() {
+        assert_eq!(qualify_task_id("TASK-1"), "task:TASK-1");
+        assert_eq!(qualify_task_id("task:TASK-1"), "task:TASK-1");
+        // An already-qualified id of any kind is passed through unchanged.
+        assert_eq!(qualify_task_id("blog:BLOG-1"), "blog:BLOG-1");
+    }
+
+    #[tokio::test]
+    async fn resolve_falls_back_to_in_tree_store_when_no_backend_owns_task() {
+        use orchestrator_core::{InMemoryServiceHub, Priority, TaskCreateInput, TaskStatus, TaskType};
+        use protocol::test_utils::EnvVarGuard;
+
+        // Force discovery to surface no subject backend, so the resolver must
+        // fall back to the in-tree store.
+        let _disable = EnvVarGuard::set(crate::SUBJECT_PLUGINS_DISABLE_ENV, Some("1"));
+        let temp = tempfile::tempdir().expect("temp dir");
+        let root = temp.path().to_string_lossy().to_string();
+
+        let hub: Arc<dyn ServiceHub> = Arc::new(InMemoryServiceHub::new());
+        let task = hub
+            .tasks()
+            .create(TaskCreateInput {
+                title: "fallback".to_string(),
+                description: "in-tree fallback".to_string(),
+                task_type: Some(TaskType::Feature),
+                priority: Some(Priority::Medium),
+                created_by: Some("test".to_string()),
+                tags: Vec::new(),
+                linked_requirements: Vec::new(),
+                linked_architecture_entities: Vec::new(),
+            })
+            .await
+            .expect("create task");
+
+        let store = resolve_task_projection_store(&root, hub.clone()).await;
+        store.set_status(&task.id, TaskStatus::Blocked).await.expect("fallback write");
+
+        // The write landed in the in-tree hub — proof the fallback store is
+        // hub-backed, not a no-op / plugin route.
+        let after = hub.tasks().get(&task.id).await.expect("task still present");
+        assert_eq!(after.status, TaskStatus::Blocked);
+    }
+}

--- a/crates/orchestrator-plugin-host/src/subject_router.rs
+++ b/crates/orchestrator-plugin-host/src/subject_router.rs
@@ -833,7 +833,15 @@ impl SubjectRouter {
             Some(kind) => self.plugin_for_kind(kind).map(|name| vec![name.to_string()]).unwrap_or_default(),
             None => {
                 let mut names: Vec<String> = Vec::new();
-                for name in self.exact_kinds.values().chain(self.glob_kinds.iter().map(|(_, n)| n)) {
+                // Include the catch-all (`*`) backend alongside the exact/glob
+                // plugins: an unscoped watch must receive events for every
+                // mounted backend, including the wildcard that serves
+                // runtime-declared dynamic kinds (e.g. a portal `declare_kind`).
+                // Omitting it dropped all catch-all-served kinds from the merged
+                // `subject/changed` stream.
+                for name in
+                    self.exact_kinds.values().chain(self.glob_kinds.iter().map(|(_, n)| n)).chain(self.catch_all.iter())
+                {
                     if !names.iter().any(|existing| existing == name) {
                         names.push(name.clone());
                     }
@@ -1509,6 +1517,42 @@ done
             assert!(router.is_subject_method("task/list"));
             assert!(!router.is_subject_method("blog/list"));
             assert!(!router.is_subject_method("config/load"));
+        }
+
+        #[test]
+        fn unscoped_watch_includes_catch_all_backend() {
+            // An unscoped (`kind = None`) watch must ask every mounted backend
+            // to watch — including the `*` catch-all that serves runtime dynamic
+            // kinds — so the merged `subject/changed` stream does not silently
+            // drop catch-all-served kinds.
+            let dir = tempfile::tempdir().unwrap();
+            let log = dir.path().join("spawns.log");
+            let specs = vec![spec(dir.path(), "tasks", "task", &log), spec(dir.path(), "baas", "*", &log)];
+            let router = SubjectRouter::from_lazy_specs(specs, KindAliasMap::default()).expect("router builds");
+
+            let mut names = router.watch_plugin_names(None);
+            names.sort();
+            assert_eq!(
+                names,
+                vec!["baas".to_string(), "tasks".to_string()],
+                "unscoped watch must include the catch-all"
+            );
+
+            // A scoped watch is unchanged: it resolves the single owning plugin.
+            assert_eq!(router.watch_plugin_names(Some("task")), vec!["tasks".to_string()]);
+        }
+
+        #[test]
+        fn unscoped_watch_dedupes_multi_kind_backend() {
+            // A backend claiming several kinds is watched only once, and the
+            // catch-all is not double-counted when it is the same plugin name.
+            let dir = tempfile::tempdir().unwrap();
+            let log = dir.path().join("spawns.log");
+            let specs = vec![spec(dir.path(), "tasks", "task", &log), spec(dir.path(), "reqs", "requirement", &log)];
+            let router = SubjectRouter::from_lazy_specs(specs, KindAliasMap::default()).expect("router builds");
+            let mut names = router.watch_plugin_names(None);
+            names.sort();
+            assert_eq!(names, vec!["reqs".to_string(), "tasks".to_string()]);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Fixes the split-brain where task-status **OUTPUT** paths wrote to the legacy in-tree store (), which is **empty on a plugin-backed / portal deployment** (tasks live in the installed  plugin). The dispatch/enqueue INPUT and stale-reconcile paths were already routed (TASK-215…260); this closes the remaining OUTPUT/read-back gap. Symptom: when a run failed/cancelled/escalated, the queue finalized via the plugin but the task projected into a store nothing reads, so the plugin-backed subject sat **InProgress until the 24h stale sweep**. Same bug class as TASK-215/228/245/256/260. Part of REQUIREMENT-039.

## What changed

**Finding 1 — task-status projections (HIGH, execution-correctness)**
- New  trait in  abstracts the task read/write IO the execution projections drive. The **decision logic** (terminal Blocked-vs-Cancelled, pause-marker upgrade/skip) stays in the projection functions; only the write sink is swappable.
-  — byte-identical in-tree behaviour (metadata bumps, actor, / bookkeeping); used by the stock scaffold and existing tests.
-  () — routes , ,  through .
-  selects the router **only when a backend owns ** (or the  catch-all), else the in-tree store; a discovery failure falls back to in-tree. Clones the existing  pattern.
- All CLI/daemon OUTPUT call sites now resolve + route through the store: completion reconcile, terminal projection, budget-cap enforcement, and  ( gained a store param).

**Finding 2 —  Ready→InProgress (HIGH)**
- The dispatched-task transition (and its spawn-failure revert) in  now routes through the store, so it lands on the plugin instead of silently no-opping on the empty in-tree store.

**Finding 4 — unscoped  (MED, one-liner)**
-  now includes the  catch-all backend (de-duped), so the merged  stream no longer drops catch-all-served dynamic kinds (the portal live feed). Scoped watches unchanged.

### Router write correctness (from codex self-vet)
- **Bare ids are qualified** to  before routing (a  carries a bare id; the backend keys ).
- Annotations (///) are written into the  map — they are **not** top-level patch fields — and the read side reads  too.
- Non-blocked transitions **clear** the blocked/paused bookkeeping in , mirroring the in-tree  cleanup. Status writes are load-bearing (error propagated); annotations are best-effort (a backend that doesn't model them no-ops).

## Deferred → TASK-282
Finding 3 (daemon tick metrics/snapshot task reads) and the LOW items (inverted enqueue probe, fixed-kind projector registry) need full  reconstruction from the plugin wire (no wire→ converter exists today) — a larger/riskier change than this execution-correctness fix, tracked separately.

## Testing
- New router-routing tests (recording fake  backend): /// route the expected methods; bare ids are qualified; non-blocked transitions emit the clear-update while Blocked does not; empty dispatch falls back to the in-tree hub.
- Finding-4 tests: unscoped watch includes the catch-all and de-dupes multi-kind backends.
-  (406) and  (1319) unit suites pass; existing projection/workflow-event behaviour preserved.  and  clean on all touched crates.
- Pre-existing, unrelated failures (confirmed matching the known sets, none touch task projection): ~24 daemon-runtime trigger/schedule/preflight tests and 2 provider-mock testkit e2e tests that need unbuilt fixtures.

### Codex self-vet
- Round 1: 1×P1 (bare-id qualification), 1×P2 (annotations must use ) — both fixed.
- Round 2: 0×P1, 1×P2 (clear bookkeeping on non-blocked routed transitions) — fixed inline.
