### PR TITLE
ao-cli v0.7.0: finish TASK-228 systematically — migrate ALL role resolution to serves_kind/discover_by_kind (TASK-275)

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_plugin.rs
@@ -1701,7 +1701,17 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
     };
 
     if let Some(manifest_for_check) = source_manifest.as_ref() {
-        enforce_provider_tool_policy(manifest_for_check, req.allow_shadow_builtin, provenance.owner.as_deref())?;
+        // Resolve the name this install will actually be dispatched under so the
+        // reserved-provider guard checks the same string runtime discovery will
+        // (override / release basename / source basename), not just the manifest
+        // name (codex round-5/6 P1).
+        let effective_name = effective_install_name(req.name.as_deref(), &default_name, &source_path)?;
+        enforce_provider_tool_policy(
+            manifest_for_check,
+            Some(effective_name.as_str()),
+            req.allow_shadow_builtin,
+            provenance.owner.as_deref(),
+        )?;
         if let (Some(owner), Some(repo)) = (provenance.owner.as_deref(), provenance.repo.as_deref()) {
             enforce_manifest_name_matches_repo(manifest_for_check, owner, repo, req.force)?;
         }
@@ -1725,21 +1735,10 @@ pub(crate) async fn run_plugin_install(req: PluginInstallRequest) -> Result<Plug
         SignaturePolicyOutcome::Proceed => {}
     }
 
-    let (plugin_name, name_override_for_yaml) = match req.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
-        Some(name) => (name.to_string(), Some(name.to_string())),
-        None => {
-            let derived = if !default_name.is_empty() {
-                default_name
-            } else {
-                source_path
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .ok_or_else(|| invalid_input_error("could not derive plugin name from source path"))?
-                    .to_string()
-            };
-            (derived, None)
-        }
-    };
+    let plugin_name = effective_install_name(req.name.as_deref(), &default_name, &source_path)?;
+    // The YAML `name_override` is recorded ONLY when the operator passed an
+    // explicit `--name`; a source-derived default name is not an override.
+    let name_override_for_yaml = req.name.as_deref().map(str::trim).filter(|n| !n.is_empty()).map(str::to_string);
 
     let install_dir = scope_paths.install_dir.clone();
     let installed_path = install_dir.join(&plugin_name);
@@ -2563,7 +2562,10 @@ fn rename_eligible_native_kind(manifest: &PluginManifest) -> Option<String> {
 /// declared kinds collides with an existing install, not just the
 /// primary.
 fn all_rename_eligible_native_kinds(manifest: &PluginManifest) -> Vec<String> {
-    if manifest.plugin_kind != "subject_backend" {
+    // v0.7 multi-kind: a plugin serving `subject_backend` as a NON-primary
+    // `plugin_kinds` role is routed by the daemon, so its declared
+    // `subject_kind:*` capabilities must also be collision-checked at install.
+    if !manifest.serves_kind("subject_backend") {
         return Vec::new();
     }
     let mut out: Vec<String> = Vec::new();
@@ -2616,7 +2618,10 @@ fn current_subject_kinds_for_collision_check(
     };
     let mut out: Vec<String> = Vec::new();
     for plugin in discovered {
-        if plugin.name == current_plugin_name || plugin.manifest.plugin_kind != "subject_backend" {
+        // v0.7 multi-kind: include plugins that serve `subject_backend` as a
+        // secondary role — the daemon routes them, so their claimed kinds count
+        // toward the collision inventory.
+        if plugin.name == current_plugin_name || !plugin.manifest.serves_kind("subject_backend") {
             continue;
         }
         let lock_entry = lockfile.find(&plugin.name);
@@ -5148,15 +5153,55 @@ fn probe_manifest(binary_path: &Path) -> Result<PluginManifest> {
 /// (`launchapp-dev`): a canonical `animus-provider-<tool>` from that org is the
 /// rightful first-party provider, not a squatter, so it installs with NO flag.
 /// Any other source claiming a reserved name must pass `--allow-shadow-builtin`.
+/// Resolve the name discovery will record for an install — the same value the
+/// SubjectRouter / `discover_*` paths later see as `DiscoveredPlugin::name` and
+/// (for providers) strip to compute `provider_tool`. Precedence mirrors the
+/// install-name binding: explicit `--name` override, else the source-derived
+/// `default_name` (release/repo basename), else the source file basename.
+/// Extracted so the reserved-name guard and the install-name binding key off
+/// one shared derivation and cannot drift (codex round-5/6 P1).
+fn effective_install_name(name_override: Option<&str>, default_name: &str, source_path: &Path) -> Result<String> {
+    match name_override.map(str::trim).filter(|n| !n.is_empty()) {
+        Some(name) => Ok(name.to_string()),
+        None if !default_name.is_empty() => Ok(default_name.to_string()),
+        None => source_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .map(str::to_string)
+            .ok_or_else(|| invalid_input_error("could not derive plugin name from source path")),
+    }
+}
+
 fn enforce_provider_tool_policy(
     manifest: &PluginManifest,
+    effective_installed_name: Option<&str>,
     allow_shadow_builtin: bool,
     owner: Option<&str>,
 ) -> Result<()> {
-    if manifest.plugin_kind != animus_plugin_protocol::PLUGIN_KIND_PROVIDER {
+    // v0.7 multi-kind: the reserved-name guard must fire whenever the plugin
+    // SERVES the provider role — primary `plugin_kind` OR a secondary
+    // `plugin_kinds` entry — because runtime `discover_provider_plugins` now
+    // dispatches secondary-role providers too. Gating on the primary field
+    // alone would let a consolidated plugin named `animus-provider-claude`
+    // (primary e.g. `subject_backend`, `plugin_kinds: ["provider"]`) install
+    // without `--allow-shadow-builtin` and then hijack the `claude` dispatch
+    // path.
+    if !manifest.serves_kind(animus_plugin_protocol::PLUGIN_KIND_PROVIDER) {
         return Ok(());
     }
-    let derived_tool = manifest.name.strip_prefix("animus-provider-").unwrap_or(manifest.name.as_str());
+    // Derive the reserved-tool check from the EFFECTIVE installed name (the
+    // name discovery records as `DiscoveredPlugin::name` and
+    // `discover_provider_plugins` strips to compute `provider_tool` at
+    // dispatch) — NOT `manifest.name`. Callers pass the resolved install name
+    // (see `effective_install_name`: `--name` override, else release/basename
+    // default); unit tests pass `None` to fall back to the manifest name.
+    // Checking `manifest.name` alone would let a non-reserved manifest
+    // installed under a reserved dispatch name (`--name animus-provider-claude`,
+    // or a release/repo basename of `animus-provider-claude`) slip through and
+    // hijack the `claude` provider path.
+    let effective_name =
+        effective_installed_name.map(str::trim).filter(|n| !n.is_empty()).unwrap_or(manifest.name.as_str());
+    let derived_tool = effective_name.strip_prefix("animus-provider-").unwrap_or(effective_name);
     if !is_reserved_provider_tool(derived_tool) {
         return Ok(());
     }
@@ -8170,21 +8215,22 @@ name = "same"
     #[test]
     fn install_refuses_reserved_provider_tool_without_flag() {
         let manifest = provider_manifest("animus-provider-claude");
-        let err = enforce_provider_tool_policy(&manifest, false, None).expect_err("must refuse claude provider plugin");
+        let err =
+            enforce_provider_tool_policy(&manifest, None, false, None).expect_err("must refuse claude provider plugin");
         assert!(format!("{err}").contains("reserved first-party provider name"));
     }
 
     #[test]
     fn install_allows_reserved_with_explicit_flag() {
         let manifest = provider_manifest("animus-provider-codex");
-        let ok = enforce_provider_tool_policy(&manifest, true, None);
+        let ok = enforce_provider_tool_policy(&manifest, None, true, None);
         assert!(ok.is_ok(), "--allow-shadow-builtin must let install through");
     }
 
     #[test]
     fn install_allows_non_reserved_provider_plugin() {
         let manifest = provider_manifest("animus-provider-mock");
-        let ok = enforce_provider_tool_policy(&manifest, false, None);
+        let ok = enforce_provider_tool_policy(&manifest, None, false, None);
         assert!(ok.is_ok(), "non-reserved provider tools must install without the override");
     }
 
@@ -8192,8 +8238,98 @@ name = "same"
     fn install_skips_provider_check_for_non_provider_plugins() {
         let mut manifest = provider_manifest("animus-provider-claude");
         manifest.plugin_kind = animus_plugin_protocol::PLUGIN_KIND_SUBJECT_BACKEND.to_string();
-        let ok = enforce_provider_tool_policy(&manifest, false, None);
+        let ok = enforce_provider_tool_policy(&manifest, None, false, None);
         assert!(ok.is_ok(), "subject backends are never gated by reserved provider tools");
+    }
+
+    /// v0.7 multi-kind regression (codex round-4 P1): the reserved-name guard
+    /// must fire when `provider` is a SECONDARY declared role, not just the
+    /// primary `plugin_kind`. Otherwise a consolidated plugin named
+    /// `animus-provider-claude` (primary `subject_backend`,
+    /// `plugin_kinds: ["provider"]`) — which runtime `discover_provider_plugins`
+    /// now dispatches — could install without `--allow-shadow-builtin` and
+    /// hijack the `claude` provider dispatch path.
+    #[test]
+    fn install_refuses_reserved_provider_tool_declared_as_secondary_role() {
+        let mut manifest = provider_manifest("animus-provider-claude");
+        manifest.plugin_kind = animus_plugin_protocol::PLUGIN_KIND_SUBJECT_BACKEND.to_string();
+        manifest.plugin_kinds = vec![animus_plugin_protocol::PLUGIN_KIND_PROVIDER.to_string()];
+        let err = enforce_provider_tool_policy(&manifest, None, false, None)
+            .expect_err("must refuse a secondary-role provider claiming a reserved name");
+        assert!(format!("{err}").contains("reserved first-party provider name"));
+        // ...and the explicit override still lets it through.
+        assert!(
+            enforce_provider_tool_policy(&manifest, None, true, None).is_ok(),
+            "--allow-shadow-builtin must still permit the secondary-role provider"
+        );
+    }
+
+    /// Codex round-5 P2 regression: the reserved-name guard checks the
+    /// EFFECTIVE installed name (`--name`/`name_override`), not just the
+    /// manifest name. A non-reserved manifest installed as
+    /// `--name animus-provider-claude` would otherwise pass the guard and then
+    /// be dispatched as the `claude` provider (runtime derives `provider_tool`
+    /// from the recorded install name).
+    #[test]
+    fn install_refuses_reserved_name_override_over_non_reserved_manifest() {
+        let manifest = provider_manifest("animus-provider-mock");
+        // Without the override the non-reserved manifest installs freely.
+        assert!(
+            enforce_provider_tool_policy(&manifest, None, false, None).is_ok(),
+            "non-reserved manifest with no override must install"
+        );
+        // With a reserved `--name` override it must be refused.
+        let err = enforce_provider_tool_policy(&manifest, Some("animus-provider-claude"), false, None)
+            .expect_err("reserved --name override must be refused");
+        assert!(format!("{err}").contains("reserved first-party provider name"));
+        // ...and the explicit opt-in still lets it through.
+        assert!(
+            enforce_provider_tool_policy(&manifest, Some("animus-provider-claude"), true, None).is_ok(),
+            "--allow-shadow-builtin must permit a reserved --name override"
+        );
+    }
+
+    /// codex round-6 P1: the reserved-name guard must also fire for a
+    /// source-DERIVED install name (release/repo basename) even when `--name`
+    /// is omitted — `effective_install_name` resolves that basename and the
+    /// runtime dispatches under it, so a repo basename of
+    /// `animus-provider-claude` with a non-reserved manifest must be refused.
+    #[test]
+    fn effective_install_name_resolves_basename_and_guards_reserved_default() {
+        let source = std::path::Path::new("/tmp/x/animus-provider-claude");
+        // No override, empty default_name -> basename.
+        assert_eq!(effective_install_name(None, "", source).unwrap(), "animus-provider-claude");
+        // No override, non-empty default_name -> default_name wins.
+        assert_eq!(effective_install_name(None, "animus-provider-mock", source).unwrap(), "animus-provider-mock");
+        // Explicit override wins over both.
+        assert_eq!(
+            effective_install_name(Some("animus-provider-gemini"), "animus-provider-mock", source).unwrap(),
+            "animus-provider-gemini"
+        );
+
+        // Guard fires against the resolved default/basename name with NO --name.
+        let manifest = provider_manifest("animus-provider-mock");
+        let resolved = effective_install_name(None, "animus-provider-claude", source).unwrap();
+        let err = enforce_provider_tool_policy(&manifest, Some(resolved.as_str()), false, None)
+            .expect_err("reserved release/basename default must be refused without --allow-shadow-builtin");
+        assert!(format!("{err}").contains("reserved first-party provider name"));
+    }
+
+    /// v0.7 multi-kind regression (codex round-4 P2): a plugin serving
+    /// `subject_backend` as a SECONDARY role still contributes its declared
+    /// `subject_kind:*` capabilities to install-time collision detection.
+    #[test]
+    fn rename_eligible_kinds_cover_secondary_subject_backend_role() {
+        let mut manifest = provider_manifest("animus-plugin-consolidated");
+        manifest.plugin_kind = animus_plugin_protocol::PLUGIN_KIND_QUEUE.to_string();
+        manifest.plugin_kinds = vec![animus_plugin_protocol::PLUGIN_KIND_SUBJECT_BACKEND.to_string()];
+        manifest.capabilities = vec!["subject_kind:task".to_string(), "subject_kind:requirement".to_string()];
+        let kinds = all_rename_eligible_native_kinds(&manifest);
+        assert_eq!(
+            kinds,
+            vec!["task".to_string(), "requirement".to_string()],
+            "secondary-role subject_backend must expose its subject_kind capabilities for collision checks"
+        );
     }
 
     #[test]
@@ -8203,17 +8339,17 @@ name = "same"
         let manifest = provider_manifest("animus-provider-claude");
         let trusted = BUILTIN_TRUSTED_ORGS[0];
         assert!(
-            enforce_provider_tool_policy(&manifest, false, Some(trusted)).is_ok(),
+            enforce_provider_tool_policy(&manifest, None, false, Some(trusted)).is_ok(),
             "first-party {trusted}/animus-provider-claude must install without --allow-shadow-builtin"
         );
         // An untrusted org claiming the same reserved name is still blocked.
         assert!(
-            enforce_provider_tool_policy(&manifest, false, Some("attacker")).is_err(),
+            enforce_provider_tool_policy(&manifest, None, false, Some("attacker")).is_err(),
             "an untrusted org claiming a reserved provider name must still be rejected"
         );
         // ...unless the operator explicitly opts in.
         assert!(
-            enforce_provider_tool_policy(&manifest, true, Some("attacker")).is_ok(),
+            enforce_provider_tool_policy(&manifest, None, true, Some("attacker")).is_ok(),
             "--allow-shadow-builtin is the explicit opt-in for non-first-party reserved names"
         );
     }
@@ -8225,7 +8361,7 @@ name = "same"
             let repo_basename = slug.rsplit('/').next().unwrap_or(slug);
             let manifest = provider_manifest(repo_basename);
 
-            let curated_install = enforce_provider_tool_policy(&manifest, true, None);
+            let curated_install = enforce_provider_tool_policy(&manifest, None, true, None);
             assert!(
                 curated_install.is_ok(),
                 "curated install-defaults (allow_shadow_builtin=true) must accept '{repo_basename}'"
@@ -8234,7 +8370,7 @@ name = "same"
             let derived_tool = repo_basename.strip_prefix("animus-provider-").unwrap_or(repo_basename);
             if is_reserved_provider_tool(derived_tool) {
                 at_least_one_reserved = true;
-                let user_install = enforce_provider_tool_policy(&manifest, false, None);
+                let user_install = enforce_provider_tool_policy(&manifest, None, false, None);
                 assert!(
                     user_install.is_err(),
                     "user-typed install MUST still be blocked for reserved name '{repo_basename}'"
@@ -8266,8 +8402,9 @@ name = "same"
         let req =
             PluginInstallRequest { source: Some("attacker/animus-provider-claude".to_string()), ..Default::default() };
         assert!(!req.allow_shadow_builtin, "user-default request must NOT bypass shadow-builtin guard");
-        let err = enforce_provider_tool_policy(&manifest, req.allow_shadow_builtin, Some("attacker"))
-            .expect_err("user-typed install of reserved name must still be rejected");
+        let err =
+            enforce_provider_tool_policy(&manifest, req.name.as_deref(), req.allow_shadow_builtin, Some("attacker"))
+                .expect_err("user-typed install of reserved name must still be rejected");
         assert!(format!("{err}").contains("reserved first-party provider name"));
     }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_web.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_web.rs
@@ -381,7 +381,7 @@ async fn describe_host(plugin: &DiscoveredPlugin, host: &PluginHost, project_roo
     // by treating METHOD_NOT_FOUND / METHOD_NOT_SUPPORTED as a deprecation
     // warning + continue, but new plugins MUST honor the spec to actually
     // bind.
-    let is_transport_kind = plugin.manifest.plugin_kind == TRANSPORT_PLUGIN_KIND;
+    let is_transport_kind = plugin.manifest.serves_kind(TRANSPORT_PLUGIN_KIND);
     let start_reply = if is_transport_kind { drive_transport_start(plugin, host, project_root).await? } else { None };
 
     let mut url = start_reply.as_ref().and_then(bind_url_for_kind_from_info);
@@ -395,7 +395,7 @@ async fn describe_host(plugin: &DiscoveredPlugin, host: &PluginHost, project_roo
             url = extract_url(&value);
         }
     }
-    let serves_ui = plugin.manifest.plugin_kind == WEB_UI_PLUGIN_KIND || plugin_advertises_web_ui(plugin);
+    let serves_ui = plugin.manifest.serves_kind(WEB_UI_PLUGIN_KIND) || plugin_advertises_web_ui(plugin);
     Ok(SpawnedTransport {
         name: plugin.name.clone(),
         kind: plugin.manifest.plugin_kind.clone(),
@@ -573,16 +573,19 @@ fn partition_transport_plugins(
     let mut web_ui_plugins: Vec<DiscoveredPlugin> = Vec::new();
     for plugin in discovered {
         let advertises_web_ui = plugin_advertises_web_ui(&plugin);
-        match plugin.manifest.plugin_kind.as_str() {
-            WEB_UI_PLUGIN_KIND => web_ui_plugins.push(plugin),
-            TRANSPORT_PLUGIN_KIND => {
-                if advertises_web_ui {
-                    web_ui_plugins.push(plugin);
-                } else {
-                    api_plugins.push(plugin);
-                }
+        // v0.7 multi-kind: bin by served ROLE (primary `plugin_kind` OR any
+        // additional `plugin_kinds`) rather than the primary field alone, so a
+        // consolidated plugin serving `web_ui` / `transport_backend` as a
+        // secondary role is still surfaced to the browser / API path. web_ui
+        // wins when a plugin serves both.
+        if plugin.manifest.serves_kind(WEB_UI_PLUGIN_KIND) {
+            web_ui_plugins.push(plugin);
+        } else if plugin.manifest.serves_kind(TRANSPORT_PLUGIN_KIND) {
+            if advertises_web_ui {
+                web_ui_plugins.push(plugin);
+            } else {
+                api_plugins.push(plugin);
             }
-            _ => {}
         }
     }
     api_plugins.sort_by_key(|p| {

--- a/crates/orchestrator-core/src/services/daemon_impl.rs
+++ b/crates/orchestrator-core/src/services/daemon_impl.rs
@@ -303,34 +303,52 @@ fn active_flavor_for_project(project_root: &Path) -> Option<String> {
 /// surfacing it as healthy here would produce a false-green; match the
 /// `animus plugin status` executability semantics exactly.
 ///
-/// v0.5.9: previously delegated to `discover_provider_plugins`, which
-/// ran the full `discover_plugins` pipeline — including a `--manifest`
-/// probe on every installed plugin. With 30+ subject-backend plugins
-/// installed, `animus daemon status` was spending ~3s probing binaries
-/// it didn't care about just to confirm one provider was alive. Walk
-/// the plugin install dir directly: any `animus-provider-*` entry that's
-/// executable counts. No spawn, no probe, no manifest read.
-fn provider_plugins_healthy_for(_project_root: &Path) -> bool {
-    use orchestrator_plugin_host::plugin_install_dir;
+/// v0.7 multi-kind: two-tier resolution so a common-case status/health call
+/// stays probe-free while an out-of-tree or renamed provider is no longer a
+/// health false-negative.
+///
+/// 1. FAST PATH (v0.5.9): walk the plugin install dir for an executable
+///    `animus-provider-*` binary. No spawn, no `--manifest` probe — so the
+///    hot `animus daemon status` path stays sub-second even with 30+ plugins
+///    installed. Any provider under the canonical filename resolves here.
+/// 2. ROLE FALLBACK (v0.7): only when the filename walk finds nothing do we
+///    pay for manifest-based [`orchestrator_plugin_host::discover_by_kind`],
+///    which resolves a plugin declaring the `provider` role as its primary
+///    `plugin_kind` OR a secondary `plugin_kinds` entry — even under a
+///    non-`animus-provider-` binary name. The manifest cache keeps the warm
+///    path cheap; the cold cost is bounded to installs that have no
+///    canonically-named provider at all.
+///
+/// A path that exists but has lost its execute bit fails to spawn at run
+/// time, so both tiers gate on executability to match the
+/// `animus plugin status` semantics exactly (no false-green).
+fn provider_plugins_healthy_for(project_root: &Path) -> bool {
+    use orchestrator_plugin_host::{discover_by_kind, plugin_install_dir};
+
+    // Tier 1: canonical-filename fast path (no probe).
     let dir = plugin_install_dir();
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return false;
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let Some(name_str) = name.to_str() else {
-            continue;
-        };
-        if !name_str.starts_with("animus-provider-") {
-            continue;
-        }
-        let path = entry.path();
-        let candidate = if path.is_dir() { path.join(name_str) } else { path };
-        if is_binary_executable(&candidate) {
-            return true;
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name_str) = name.to_str() else {
+                continue;
+            };
+            if !name_str.starts_with("animus-provider-") {
+                continue;
+            }
+            let path = entry.path();
+            let candidate = if path.is_dir() { path.join(name_str) } else { path };
+            if is_binary_executable(&candidate) {
+                return true;
+            }
         }
     }
-    false
+
+    // Tier 2: role-based fallback (probe-backed) — catches renamed/out-of-tree
+    // providers only when the fast path found nothing.
+    discover_by_kind(project_root, animus_plugin_protocol::PLUGIN_KIND_PROVIDER)
+        .map(|providers| providers.iter().any(|plugin| is_binary_executable(&plugin.path)))
+        .unwrap_or(false)
 }
 
 #[cfg(unix)]

--- a/crates/orchestrator-daemon-runtime/src/daemon/plugin_preflight_wiring.rs
+++ b/crates/orchestrator-daemon-runtime/src/daemon/plugin_preflight_wiring.rs
@@ -180,7 +180,7 @@ pub fn workflow_runner_warnings(project_root: &str) -> Vec<String> {
     };
     plugins
         .iter()
-        .filter(|p| p.manifest.plugin_kind == "workflow_runner")
+        .filter(|p| p.manifest.serves_kind("workflow_runner"))
         .filter_map(|p| orchestrator_core::workflow_runner_underpin_warning(&p.name, &p.manifest.version))
         .collect()
 }
@@ -196,7 +196,7 @@ pub fn queue_warnings(project_root: &str) -> Vec<String> {
     };
     plugins
         .iter()
-        .filter(|p| p.manifest.plugin_kind == "queue")
+        .filter(|p| p.manifest.serves_kind("queue"))
         .filter_map(|p| orchestrator_core::queue_underpin_warning(&p.name, &p.manifest.version))
         .collect()
 }

--- a/crates/orchestrator-daemon-runtime/src/log_storage.rs
+++ b/crates/orchestrator-daemon-runtime/src/log_storage.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use orchestrator_logging::Logger;
-use orchestrator_plugin_host::{discover_plugins, DiscoveredPlugin, PluginHost, PluginSpawnOptions};
+use orchestrator_plugin_host::{discover_by_kind, DiscoveredPlugin, PluginHost, PluginSpawnOptions};
 use serde_json::Value;
 use tokio::sync::RwLock as TokioRwLock;
 
@@ -109,9 +109,13 @@ pub fn log_storage_disable_env_set() -> bool {
 }
 
 /// Filter the project's installed plugins down to log storage backends.
+///
+/// v0.7 multi-kind: matches a plugin's primary `plugin_kind` OR any of its
+/// additional `plugin_kinds` via [`discover_by_kind`], so a consolidated
+/// plugin that serves `log_storage_backend` as a secondary role is resolved
+/// instead of silently falling back to file logging.
 pub fn discover_log_storage_backends(project_root: &Path) -> Result<Vec<DiscoveredPlugin>> {
-    let plugins = discover_plugins(project_root)?;
-    Ok(plugins.into_iter().filter(|p| p.manifest.plugin_kind == PLUGIN_KIND_LOG_STORAGE_BACKEND).collect())
+    discover_by_kind(project_root, PLUGIN_KIND_LOG_STORAGE_BACKEND)
 }
 
 /// Outcome of [`resolve_log_storage_dispatch`].

--- a/crates/orchestrator-daemon-runtime/src/schedule/trigger_supervisor.rs
+++ b/crates/orchestrator-daemon-runtime/src/schedule/trigger_supervisor.rs
@@ -40,7 +40,7 @@ use chrono::Utc;
 use orchestrator_core::workflow_config::TriggerType;
 use orchestrator_core::WebhookEvent;
 use orchestrator_logging::Logger;
-use orchestrator_plugin_host::{discover_plugins, DiscoveredPlugin, PluginHost, PluginSpawnOptions, PluginStderrSink};
+use orchestrator_plugin_host::{discover_by_kind, DiscoveredPlugin, PluginHost, PluginSpawnOptions, PluginStderrSink};
 use serde_json::json;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
@@ -143,9 +143,13 @@ impl TriggerSupervisor {
 }
 
 /// Filter the project's installed plugins down to trigger backends.
+///
+/// v0.7 multi-kind: matches a plugin's primary `plugin_kind` OR any of its
+/// additional `plugin_kinds` via [`discover_by_kind`], so a consolidated
+/// plugin that serves `trigger_backend` as a secondary role is still spawned
+/// instead of its webhook/event triggers silently never firing.
 pub fn discover_trigger_plugins(project_root: &Path) -> Result<Vec<DiscoveredPlugin>> {
-    let plugins = discover_plugins(project_root)?;
-    Ok(plugins.into_iter().filter(|p| p.manifest.plugin_kind == PLUGIN_KIND_TRIGGER_BACKEND).collect())
+    discover_by_kind(project_root, PLUGIN_KIND_TRIGGER_BACKEND)
 }
 
 /// Outcome reported by one trigger plugin session.

--- a/crates/orchestrator-daemon-runtime/src/subject_dispatch.rs
+++ b/crates/orchestrator-daemon-runtime/src/subject_dispatch.rs
@@ -41,7 +41,7 @@ use anyhow::{Context, Result};
 use futures_core::Stream;
 use futures_util::StreamExt;
 use orchestrator_plugin_host::{
-    discover_plugins, DiscoveredPlugin, KindAliasMap, PluginLockfile, SubjectPluginSpec, SubjectRouter,
+    discover_by_kind, DiscoveredPlugin, KindAliasMap, PluginLockfile, SubjectPluginSpec, SubjectRouter,
 };
 use serde_json::Value;
 
@@ -478,9 +478,12 @@ pub fn subject_plugins_disable_env_set() -> bool {
 }
 
 /// Filter the project's installed plugins down to subject backends.
+///
+/// v0.7 multi-kind: matches a plugin's primary `plugin_kind` OR any of its
+/// additional `plugin_kinds` via [`discover_by_kind`], so a consolidated
+/// plugin that serves `subject_backend` as a secondary role is still routed.
 pub fn discover_subject_backends(project_root: &Path) -> Result<Vec<DiscoveredPlugin>> {
-    let plugins = discover_plugins(project_root)?;
-    Ok(plugins.into_iter().filter(|p| p.manifest.plugin_kind == PLUGIN_KIND_SUBJECT_BACKEND).collect())
+    discover_by_kind(project_root, PLUGIN_KIND_SUBJECT_BACKEND)
 }
 
 /// Outcome of [`resolve_subject_dispatch`].

--- a/crates/orchestrator-plugin-host/src/discovery.rs
+++ b/crates/orchestrator-plugin-host/src/discovery.rs
@@ -1548,6 +1548,84 @@ mod tests {
         assert_eq!(by_kind[0].name, "a-workflow-runner-default");
     }
 
+    /// v0.7 multi-kind regression: a consolidated plugin whose PRIMARY
+    /// `plugin_kind` is `subject_backend` but which ALSO declares
+    /// `log_storage_backend` as a NON-primary `plugin_kinds` entry MUST be
+    /// resolved by [`discover_by_kind`] for that secondary role. This is the
+    /// property TASK-275 exists to guarantee: role resolution keys off
+    /// `PluginManifest::serves_kind`, not the single primary field.
+    ///
+    /// Drives the real `discover_by_kind` entry point (not a hand-rolled
+    /// `serves_kind` filter) so a regression that reverted it to
+    /// `plugin_kind ==` matching would fail here.
+    #[cfg(unix)]
+    #[test]
+    fn discover_by_kind_resolves_non_primary_declared_role() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _config_dir = EnvVarGuard::set("ANIMUS_CONFIG_DIR", temp.path().join("animus-home"));
+
+        // Install the plugin into a scanned $ANIMUS_PLUGIN_DIR so the real
+        // `discover_by_kind` -> `discover_plugins` pipeline picks it up. Clear
+        // $ANIMUS_PLUGIN_PATH so a developer/CI environment pointing at extra
+        // plugin dirs can't leak unrelated plugins into the `len() == 1` and
+        // `provider`-is-empty assertions below (keeps the test hermetic).
+        let install_dir = temp.path().join("install-dir");
+        fs::create_dir_all(&install_dir).expect("mkdir install dir");
+        let _plugin_dir = EnvVarGuard::set("ANIMUS_PLUGIN_DIR", &install_dir);
+        let _clear_plugin_path = EnvVarGuard::set("ANIMUS_PLUGIN_PATH", "");
+
+        // Consolidated plugin: primary kind subject_backend, additional kinds
+        // include log_storage_backend + queue (served as NON-primary roles).
+        let name = "animus-plugin-consolidated-backend";
+        let path = install_dir.join(name);
+        let manifest = serde_json::json!({
+            "name": name,
+            "version": "0.1.0",
+            "plugin_kind": "subject_backend",
+            "plugin_kinds": ["log_storage_backend", "queue"],
+            "description": "test",
+            "protocol_version": "1.0.0",
+            "capabilities": []
+        });
+        fs::write(&path, format!("#!/bin/sh\nprintf '{}\\n'\n", manifest)).expect("write plugin");
+        let mut perms = fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod");
+
+        let project_root = temp.path().join("project");
+        fs::create_dir_all(&project_root).expect("mkdir project root");
+
+        // Resolved via the REAL helper for the NON-primary declared role.
+        let as_log_storage = discover_by_kind(&project_root, "log_storage_backend").expect("discover log_storage");
+        assert_eq!(
+            as_log_storage.len(),
+            1,
+            "discover_by_kind must resolve the consolidated plugin for its non-primary log_storage_backend role"
+        );
+        assert_eq!(as_log_storage[0].name, name);
+
+        // Still resolved for its PRIMARY role too.
+        assert_eq!(
+            discover_by_kind(&project_root, "subject_backend").expect("discover subject_backend").len(),
+            1,
+            "discover_by_kind must still resolve the plugin for its primary subject_backend role"
+        );
+        // And for its other secondary role.
+        assert_eq!(
+            discover_by_kind(&project_root, "queue").expect("discover queue").len(),
+            1,
+            "discover_by_kind must resolve the plugin for its second non-primary queue role"
+        );
+        // NOT resolved for a role it does not declare.
+        assert!(
+            discover_by_kind(&project_root, "provider").expect("discover provider").is_empty(),
+            "discover_by_kind must not resolve the plugin for an undeclared role"
+        );
+    }
+
     #[test]
     fn configured_plugin_can_use_non_prefixed_binary() {
         let _guard = ENV_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/crates/orchestrator-plugin-host/src/session/plugin_backend.rs
+++ b/crates/orchestrator-plugin-host/src/session/plugin_backend.rs
@@ -1246,12 +1246,15 @@ impl DiscoveredProviderPlugin {
 /// the provider-kind plugins. Provider tool name defaults to the plugin name minus the
 /// `animus-provider-` prefix.
 pub fn discover_provider_plugins(project_root: &std::path::Path) -> Vec<DiscoveredProviderPlugin> {
-    use crate::discover_plugins;
+    use crate::discover_by_kind;
     let project_root = project_root.to_path_buf();
-    discover_plugins(&project_root)
+    // v0.7 multi-kind: `discover_by_kind` matches a plugin's primary
+    // `plugin_kind` OR any of its additional `plugin_kinds`, so a
+    // consolidated plugin that serves `provider` as a secondary role is
+    // resolved for agent dispatch.
+    discover_by_kind(&project_root, animus_plugin_protocol::PLUGIN_KIND_PROVIDER)
         .unwrap_or_default()
         .into_iter()
-        .filter(|plugin| plugin.manifest.plugin_kind == animus_plugin_protocol::PLUGIN_KIND_PROVIDER)
         .map(|plugin| {
             let provider_tool = plugin
                 .name


### PR DESCRIPTION
## Summary

Finishes the TASK-228 `serves_kind` fix **systematically** (TASK-275, part of REQUIREMENT-039). Every remaining role resolver that filtered on the single `manifest.plugin_kind ==` field now matches a plugin's **primary kind OR any declared secondary `plugin_kinds`** via `orchestrator_plugin_host::discover_by_kind` / `PluginManifest::serves_kind`. A consolidated multi-role plugin is now resolved for the non-primary roles it declares.

Branched from `release/0.7` at `v0.7.0-rc.8`.

## Runtime role resolvers migrated

| Site | Severity | Effect of the old bug |
|------|----------|-----------------------|
| `log_storage::discover_log_storage_backends` | HIGH | Secondary-kind log_storage plugin missed → silent fallback to file logging |
| `trigger_supervisor::discover_trigger_plugins` | HIGH | Secondary-kind trigger backend never spawned → webhook/event triggers silently never fired |
| `plugin_backend::discover_provider_plugins` | MED | Agent dispatch missed secondary-role providers |
| `subject_dispatch::discover_subject_backends` | MED | Latent; subject_backend is primary for the shipped consolidated plugin |
| `ops_web` transport/web_ui partition + `describe_host` | MED | Secondary-role transport/web_ui mis-binned |
| `plugin_preflight_wiring` runner/queue underpin warnings | LOW | Warnings skipped a secondary-role runner/queue |

`daemon_impl::provider_plugins_healthy_for` uses a **two-tier resolve**: the cheap canonical-filename fast path first (preserves the v0.5.9 probe-free `daemon status` path), then a role-based `discover_by_kind` fallback only when the fast path finds nothing — fixing the health false-negative for renamed / out-of-tree providers without regressing the hot path.

## Install-time gates aligned with the widened runtime resolution

Because runtime now dispatches secondary-role plugins, the install-time validators that gated on the primary field alone were inconsistent (found during codex review):

- `enforce_provider_tool_policy` now fires for **secondary-role** providers and checks the **effective installed name** (`--name` override, else release/repo basename via the new `effective_install_name` helper), so a non-reserved manifest cannot claim a reserved provider dispatch name via `--name` or a `animus-provider-<reserved>` repo basename.
- Subject-kind collision checks (`all_rename_eligible_native_kinds`, `current_subject_kinds_for_collision_check`) include secondary-role subject backends.

## Kept (intentionally not migrated)

`plugin_registry` `DEFAULT_*` / `default_subject_repo_for_kind` (install recommendations), `flavor.rs` `required[]` (install set; satisfaction is role-based elsewhere), `fix_command_for` suggestions, and the `control/dispatch.rs` health-probe **display label** (reports the primary kind; the probe iterates all plugins unfiltered).

## Tests

- `discover_by_kind_resolves_non_primary_declared_role` — drives the **real** `discover_by_kind` for a plugin declaring a role only in secondary `plugin_kinds`; hermetic against `ANIMUS_PLUGIN_DIR` / `ANIMUS_PLUGIN_PATH`.
- Install-policy regressions: secondary-role provider refused; reserved `--name` override refused; reserved release/basename default refused; secondary-role subject-kind collision detected.

## Verification

- `cargo build` / `fmt --check` / `clippy -D warnings`: clean on all touched crates.
- Tests: plugin-host 208, core 406, cli 1323+10 pass. daemon-runtime 274 pass / 24 fail — the 24 are **pre-existing on rc.8** (workflow-config `unknown phase 'requirements'` fixtures), unrelated to this change (verified identical count on the clean base).
- `codex review --uncommitted` (high effort): run to convergence; final pass clean. Rounds surfaced and fixed a provider-health perf regression (P2), the reserved-name shadow bypass for secondary roles / `--name` override / basename default (P1), and the subject-kind collision gap (P2).