### PR TITLE
feat(cli): --data JSON on subject create/update/batch for structured field writes

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/subject_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/subject_types.rs
@@ -135,6 +135,12 @@ pub(crate) struct SubjectCreateArgs {
     /// Optional free-form body / description.
     #[arg(long, value_name = "BODY")]
     pub body: Option<String>,
+    /// Structured custom fields as a JSON object, merged into the subject's
+    /// `data` (e.g. `--data '{"source":"krisp","occurred_at":"2026-07-09T21:00:00Z"}'`).
+    /// Lets command-phase / scripted callers set declared kind fields that
+    /// have no dedicated flag. Merges with (does not replace) other fields.
+    #[arg(long, value_name = "JSON")]
+    pub data: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -164,6 +170,12 @@ pub(crate) struct SubjectUpdateArgs {
     /// long-form content onto a subject (e.g. an agent's findings).
     #[arg(long, value_name = "BODY")]
     pub body: Option<String>,
+    /// Structured custom fields as a JSON object, merged into the subject's
+    /// `data` (e.g. `--data '{"source":"krisp","occurred_at":"2026-07-09T21:00:00Z"}'`).
+    /// Lets command-phase / scripted callers set declared kind fields that
+    /// have no dedicated flag. Merges with (does not replace) other fields.
+    #[arg(long, value_name = "JSON")]
+    pub data: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_command_args.rs
@@ -42,6 +42,7 @@ pub(super) fn build_subject_create_args(input: &SubjectCreateInput) -> Vec<Strin
         args.push(input.labels.join(","));
     }
     push_opt(&mut args, "--body", input.body.clone());
+    push_opt(&mut args, "--data", input.data.as_ref().map(|v| v.to_string()));
     args
 }
 
@@ -62,6 +63,7 @@ pub(super) fn build_subject_update_args(input: &SubjectUpdateInput) -> Vec<Strin
         args.push(input.labels.join(","));
     }
     push_opt(&mut args, "--body", input.body.clone());
+    push_opt(&mut args, "--data", input.data.as_ref().map(|v| v.to_string()));
     args
 }
 
@@ -73,6 +75,7 @@ pub(super) fn build_subject_batch_create_item_args(kind: &str, item: &SubjectBat
         priority: item.priority.clone(),
         labels: item.labels.clone(),
         body: item.body.clone(),
+        data: item.data.clone(),
         project_root: None,
     })
 }
@@ -87,6 +90,7 @@ pub(super) fn build_subject_batch_update_item_args(kind: &str, item: &SubjectBat
         priority: item.priority.clone(),
         labels: item.labels.clone(),
         body: None,
+        data: item.data.clone(),
         project_root: None,
     })
 }
@@ -128,8 +132,8 @@ pub(super) fn validate_subject_batch_update_input(
         if item.id.trim().is_empty() {
             return Err(format!("{tool_name}: item[{i}].id must not be empty"));
         }
-        if item.status.is_none() && item.priority.is_none() && item.labels.is_empty() {
-            return Err(format!("{tool_name}: item[{i}] requires at least one of status / priority / labels"));
+        if item.status.is_none() && item.priority.is_none() && item.labels.is_empty() && item.data.is_none() {
+            return Err(format!("{tool_name}: item[{i}] requires at least one of status / priority / labels / data"));
         }
     }
     Ok(())

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/subject_inputs.rs
@@ -41,6 +41,12 @@ pub(super) struct SubjectCreateInput {
     pub(super) labels: Vec<String>,
     #[serde(default)]
     pub(super) body: Option<String>,
+    /// Structured custom fields as a JSON object, merged into the subject's
+    /// `data` (declared kind fields that have no dedicated arg, e.g. a
+    /// transcript's `source`, `occurred_at`, `participants`). Merges with —
+    /// does not replace — the other fields.
+    #[serde(default)]
+    pub(super) data: Option<serde_json::Value>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }
@@ -63,6 +69,11 @@ pub(super) struct SubjectUpdateInput {
     /// detail views.
     #[serde(default)]
     pub(super) body: Option<String>,
+    /// Structured custom fields as a JSON object, merged into the subject's
+    /// `data` (declared kind fields that have no dedicated arg). Merges with —
+    /// does not replace — the other fields.
+    #[serde(default)]
+    pub(super) data: Option<serde_json::Value>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }
@@ -78,6 +89,10 @@ pub(super) struct SubjectBatchCreateItem {
     pub(super) labels: Vec<String>,
     #[serde(default)]
     pub(super) body: Option<String>,
+    /// Structured custom fields as a JSON object, merged into the subject's
+    /// `data` (declared kind fields that have no dedicated arg).
+    #[serde(default)]
+    pub(super) data: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -99,6 +114,10 @@ pub(super) struct SubjectBatchUpdateItem {
     pub(super) priority: Option<String>,
     #[serde(default)]
     pub(super) labels: Vec<String>,
+    /// Structured custom fields as a JSON object, merged into the subject's
+    /// `data` (declared kind fields that have no dedicated arg).
+    #[serde(default)]
+    pub(super) data: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -251,7 +251,14 @@ fn validate_workflow_run_multiple_rejects_over_max() {
 }
 
 fn batch_create_item(title: &str) -> SubjectBatchCreateItem {
-    SubjectBatchCreateItem { title: title.to_string(), status: None, priority: None, labels: Vec::new(), body: None }
+    SubjectBatchCreateItem {
+        title: title.to_string(),
+        status: None,
+        priority: None,
+        labels: Vec::new(),
+        body: None,
+        data: None,
+    }
 }
 
 fn batch_update_item(id: &str, status: Option<&str>) -> SubjectBatchUpdateItem {
@@ -260,6 +267,7 @@ fn batch_update_item(id: &str, status: Option<&str>) -> SubjectBatchUpdateItem {
         status: status.map(str::to_string),
         priority: None,
         labels: Vec::new(),
+        data: None,
     }
 }
 
@@ -1636,6 +1644,7 @@ fn mcp_subject_create_builds_labels_csv() {
         priority: Some("p1".to_string()),
         labels: vec!["bug".to_string(), "urgent".to_string()],
         body: Some("Body text".to_string()),
+        data: None,
         project_root: None,
     };
     let args = build_subject_create_args(&input);
@@ -1668,6 +1677,7 @@ fn mcp_subject_update_requires_at_least_one_field_args() {
         priority: None,
         labels: vec![],
         body: None,
+        data: None,
         project_root: None,
     };
     let args = build_subject_update_args(&input);
@@ -1700,6 +1710,7 @@ fn mcp_subject_update_forwards_title_flag() {
         priority: None,
         labels: vec![],
         body: None,
+        data: None,
         project_root: None,
     };
     let args = build_subject_update_args(&input);
@@ -1716,6 +1727,63 @@ fn mcp_subject_update_forwards_title_flag() {
             "Renamed title".to_string(),
         ]
     );
+}
+
+#[test]
+fn mcp_subject_create_forwards_data_flag() {
+    // A `data` object input must reach the CLI as `--data <json>` so an MCP
+    // caller can set declared kind fields that have no dedicated arg.
+    let input = SubjectCreateInput {
+        kind: "transcript".to_string(),
+        title: "Weekly sync".to_string(),
+        status: None,
+        priority: None,
+        labels: vec![],
+        body: None,
+        data: Some(json!({ "source": "krisp" })),
+        project_root: None,
+    };
+    let args = build_subject_create_args(&input);
+    let idx = args.iter().position(|a| a == "--data").expect("--data forwarded");
+    let rendered: Value = serde_json::from_str(&args[idx + 1]).expect("data flag is valid json");
+    assert_eq!(rendered.pointer("/source").and_then(Value::as_str), Some("krisp"));
+}
+
+#[test]
+fn mcp_subject_update_forwards_data_flag() {
+    let input = SubjectUpdateInput {
+        kind: "transcript".to_string(),
+        id: "TRANSCRIPT-1".to_string(),
+        title: None,
+        status: None,
+        priority: None,
+        labels: vec![],
+        body: None,
+        data: Some(json!({ "occurred_at": "2026-07-09T21:00:00Z" })),
+        project_root: None,
+    };
+    let args = build_subject_update_args(&input);
+    let idx = args.iter().position(|a| a == "--data").expect("--data forwarded");
+    let rendered: Value = serde_json::from_str(&args[idx + 1]).expect("data flag is valid json");
+    assert_eq!(rendered.pointer("/occurred_at").and_then(Value::as_str), Some("2026-07-09T21:00:00Z"));
+}
+
+#[test]
+fn mcp_subject_batch_update_item_forwards_data() {
+    let item = SubjectBatchUpdateItem {
+        id: "TRANSCRIPT-1".to_string(),
+        status: None,
+        priority: None,
+        labels: Vec::new(),
+        data: Some(json!({ "summary": "done" })),
+    };
+    // A data-only batch-update item is valid and forwards `--data`.
+    validate_subject_batch_update_input("animus.subject.batch-update", "transcript", std::slice::from_ref(&item))
+        .expect("data-only item is valid");
+    let args = build_subject_batch_update_item_args("transcript", &item);
+    let idx = args.iter().position(|a| a == "--data").expect("--data forwarded");
+    let rendered: Value = serde_json::from_str(&args[idx + 1]).expect("data flag is valid json");
+    assert_eq!(rendered.pointer("/summary").and_then(Value::as_str), Some("done"));
 }
 
 #[test]

--- a/crates/orchestrator-cli/src/services/operations/ops_subject.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_subject.rs
@@ -24,6 +24,30 @@ const MAX_BATCH_SIZE: usize = 100;
 /// results) is identical.
 const CLI_BATCH_RESULT_SCHEMA: &str = "animus.cli.batch.result.v1";
 
+/// Parse the `--data` flag value into a JSON object map, ready to merge into a
+/// subject's `data` custom fields. Rejects any non-object JSON (arrays,
+/// scalars) so callers get an actionable `InvalidInput` instead of the backend
+/// silently ignoring a malformed channel.
+fn parse_data_object(raw: &str) -> Result<serde_json::Map<String, Value>> {
+    let value: Value = serde_json::from_str(raw)
+        .map_err(|err| invalid_input_error(format!("--data must be a valid JSON object: {err}")))?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Err(invalid_input_error("--data must be a JSON object")),
+    }
+}
+
+/// Validate an already-parsed batch item `data` value is a JSON object and
+/// return it as a map. Batch items carry `data` as a `Value` decoded from the
+/// items file (not a string flag), so this validates the shape without
+/// re-parsing. `label` names the offending item for the error message.
+fn batch_data_object(value: &Value, label: &str) -> Result<serde_json::Map<String, Value>> {
+    match value {
+        Value::Object(map) => Ok(map.clone()),
+        _ => Err(invalid_input_error(format!("{label} must be a JSON object"))),
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct SubjectCallResponse {
     kind: String,
@@ -156,6 +180,9 @@ async fn handle_subject_create(args: SubjectCreateArgs, project_root: &str, json
     if let Some(body) = args.body.as_deref() {
         payload.insert("body".to_string(), json!(body));
     }
+    if let Some(data) = args.data.as_deref() {
+        payload.insert("data".to_string(), Value::Object(parse_data_object(data)?));
+    }
     let params = Some(Value::Object(payload));
     dispatch(&kind, "create", params, project_root, json).await
 }
@@ -186,9 +213,12 @@ async fn handle_subject_update(args: SubjectUpdateArgs, project_root: &str, json
     if let Some(body) = args.body.as_deref() {
         patch.insert("body".to_string(), json!(body));
     }
+    if let Some(data) = args.data.as_deref() {
+        patch.insert("custom".to_string(), Value::Object(parse_data_object(data)?));
+    }
     if patch.is_empty() {
         return Err(invalid_input_error(
-            "subject update requires at least one of --title / --status / --priority / --labels / --body",
+            "subject update requires at least one of --title / --status / --priority / --labels / --body / --data",
         ));
     }
     let params = Some(json!({ "id": id, "patch": Value::Object(patch) }));
@@ -209,6 +239,8 @@ struct BatchCreateItem {
     labels: Vec<String>,
     #[serde(default)]
     body: Option<String>,
+    #[serde(default)]
+    data: Option<Value>,
 }
 
 /// One item of a `subject batch-update` request. Mirrors the MCP
@@ -222,6 +254,8 @@ struct BatchUpdateItem {
     priority: Option<String>,
     #[serde(default)]
     labels: Vec<String>,
+    #[serde(default)]
+    data: Option<Value>,
 }
 
 /// Read and deserialize a JSON items array from `--file`. Accepts either a
@@ -421,6 +455,12 @@ async fn handle_subject_batch_create(args: SubjectBatchCreateArgs, project_root:
         if let Some(body) = item.body.as_deref() {
             payload.insert("body".to_string(), json!(body));
         }
+        if let Some(data) = item.data.as_ref() {
+            payload.insert(
+                "data".to_string(),
+                Value::Object(batch_data_object(data, &format!("{tool_name}: item[{i}].data"))?),
+            );
+        }
         calls.push((item.title.trim().to_string(), Some(Value::Object(payload))));
     }
     run_subject_batch(tool_name, &kind, "create", calls, args.on_error, project_root, json).await
@@ -452,9 +492,15 @@ async fn handle_subject_batch_update(args: SubjectBatchUpdateArgs, project_root:
         if !item.labels.is_empty() {
             patch.insert("labels".to_string(), json!(item.labels));
         }
+        if let Some(data) = item.data.as_ref() {
+            patch.insert(
+                "custom".to_string(),
+                Value::Object(batch_data_object(data, &format!("{tool_name}: item[{i}].data"))?),
+            );
+        }
         if patch.is_empty() {
             return Err(invalid_input_error(format!(
-                "{tool_name}: item[{i}] requires at least one of status / priority / labels"
+                "{tool_name}: item[{i}] requires at least one of status / priority / labels / data"
             )));
         }
         calls.push((id.to_string(), Some(json!({ "id": id, "patch": Value::Object(patch) }))));
@@ -1273,6 +1319,71 @@ mod tests {
         assert_eq!(subject_field_str(&s, "id"), "task:T-1");
         assert_eq!(subject_field_str(&s, "title"), "--");
         assert_eq!(subject_field_str(&s, "missing"), "--");
+    }
+
+    #[test]
+    fn parse_data_object_accepts_object_and_rejects_non_object() {
+        let map = parse_data_object(r#"{"source":"krisp","occurred_at":"2026-07-09T21:00:00Z"}"#)
+            .expect("valid object parses");
+        assert_eq!(map.get("source").and_then(Value::as_str), Some("krisp"));
+        assert_eq!(map.get("occurred_at").and_then(Value::as_str), Some("2026-07-09T21:00:00Z"));
+
+        // Non-object JSON (array, scalar) and malformed JSON all error as InvalidInput.
+        for raw in [r#"[1,2,3]"#, r#""just a string""#, "42", "{not json}"] {
+            let err = parse_data_object(raw).expect_err("non-object / malformed rejected");
+            assert_eq!(crate::classify_cli_error_kind(&err), crate::CliErrorKind::InvalidInput, "raw: {raw}");
+            assert!(err.to_string().contains("--data"), "error names the flag: {err}");
+        }
+    }
+
+    #[test]
+    fn create_payload_carries_parsed_data_object() {
+        // Mirror the payload build in handle_subject_create: a valid --data
+        // object lands at top-level `data` for the BaaS `payload.data` channel.
+        let mut payload = serde_json::Map::new();
+        payload.insert("title".to_string(), json!("Weekly sync"));
+        payload.insert("data".to_string(), Value::Object(parse_data_object(r#"{"source":"krisp"}"#).expect("parses")));
+        let params = Value::Object(payload);
+        assert_eq!(params.pointer("/data/source").and_then(Value::as_str), Some("krisp"));
+    }
+
+    #[test]
+    fn update_patch_carries_parsed_data_at_custom() {
+        // Mirror handle_subject_update: --data lands at `patch.custom` for the
+        // BaaS `payload.patch.custom` channel.
+        let mut patch = serde_json::Map::new();
+        patch.insert("custom".to_string(), Value::Object(parse_data_object(r#"{"summary":"done"}"#).expect("parses")));
+        let params = json!({ "id": "transcript:TRANSCRIPT-1", "patch": Value::Object(patch) });
+        assert_eq!(params.pointer("/patch/custom/summary").and_then(Value::as_str), Some("done"));
+    }
+
+    #[test]
+    fn batch_data_object_validates_shape() {
+        let map = batch_data_object(&json!({ "participants": ["a", "b"] }), "item[0].data").expect("object ok");
+        assert_eq!(map.get("participants").and_then(Value::as_array).map(|a| a.len()), Some(2));
+        let err = batch_data_object(&json!([1, 2]), "item[3].data").expect_err("array rejected");
+        assert_eq!(crate::classify_cli_error_kind(&err), crate::CliErrorKind::InvalidInput);
+        assert!(err.to_string().contains("item[3].data must be a JSON object"), "got: {err}");
+    }
+
+    #[test]
+    fn batch_create_item_threads_data_into_payload() {
+        // A batch-create item carrying `data` (already-parsed Value from the
+        // items file) threads it through to the per-item create payload.
+        let item = BatchCreateItem {
+            title: "Weekly sync".to_string(),
+            status: None,
+            priority: None,
+            labels: Vec::new(),
+            body: None,
+            data: Some(json!({ "source": "krisp" })),
+        };
+        let mut payload = serde_json::Map::new();
+        payload.insert("title".to_string(), json!(item.title.trim()));
+        if let Some(data) = item.data.as_ref() {
+            payload.insert("data".to_string(), Value::Object(batch_data_object(data, "item[0].data").expect("object")));
+        }
+        assert_eq!(Value::Object(payload).pointer("/data/source").and_then(Value::as_str), Some("krisp"));
     }
 
     #[test]

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -327,10 +327,10 @@ animus
 ├── subject                  List, get, create, update, status, and delete subjects via installed subject_backend plugins
 │   ├── list                 List subjects for a given kind via the active subject_backend plugin
 │   ├── get                  Fetch a single subject by id from the active subject_backend plugin
-│   ├── create               Create a subject through the active subject_backend plugin
-│   ├── batch-create         Create up to 100 subjects from a JSON `--file` items array; `--on-error stop|continue`; exits non-zero when any item failed (payload under `/error/details`); mirrors the `animus.subject.batch-create` MCP tool
-│   ├── update               Update a subject through the active subject_backend plugin (`--title` renames it; `--status` / `--priority` / `--labels` / `--body`)
-│   ├── batch-update         Patch up to 100 subjects from a JSON `--file` items array; `--on-error stop|continue`; exits non-zero when any item failed (payload under `/error/details`); mirrors the `animus.subject.batch-update` MCP tool
+│   ├── create               Create a subject through the active subject_backend plugin (`--data '{..}'` sets structured custom fields — declared kind fields with no dedicated flag — merged into the subject's `data`)
+│   ├── batch-create         Create up to 100 subjects from a JSON `--file` items array (each item may carry a `data` object); `--on-error stop|continue`; exits non-zero when any item failed (payload under `/error/details`); mirrors the `animus.subject.batch-create` MCP tool
+│   ├── update               Update a subject through the active subject_backend plugin (`--title` renames it; `--status` / `--priority` / `--labels` / `--body`; `--data '{..}'` sets structured custom fields merged into the subject's `data` via `patch.custom`)
+│   ├── batch-update         Patch up to 100 subjects from a JSON `--file` items array (each item may carry a `data` object → `patch.custom`; a data-only item is valid); `--on-error stop|continue`; exits non-zero when any item failed (payload under `/error/details`); mirrors the `animus.subject.batch-update` MCP tool
 │   ├── next                 Return the highest-priority Ready subject for the given kind
 │   ├── status               Set the status of a subject by id through the active subject_backend
 │   └── delete               Delete a subject by id; requires --yes to confirm (otherwise prints preview)

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -160,12 +160,12 @@ plugin (e.g. `linear`, `jira`, `github-issue`).
 |---|---|---|
 | `animus.subject.list` | List subjects for a kind via the active `subject_backend` plugin. Returns a bounded page by default (`limit` defaults to 50; pass `limit: 0` to remove the cap); the result carries `next_cursor` (and `total` when the backend reports it) — pass `cursor` to fetch the next page. | `kind`, `status`, `limit`, `cursor`, `project_root` |
 | `animus.subject.get` | Fetch a subject by wire id (`<kind>:<native_id>`) | `kind`, `id`, `project_root` |
-| `animus.subject.create` | Create a subject through the active `subject_backend` plugin | `kind`, `title`, `priority`, `status`, `labels[]`, `body`, `project_root` |
-| `animus.subject.update` | Update a subject through the active `subject_backend` plugin | `kind`, `id`, `title`, `priority`, `status`, `labels[]`, `body`, `project_root` |
+| `animus.subject.create` | Create a subject through the active `subject_backend` plugin. `data` is a JSON object of structured custom fields (declared kind fields with no dedicated arg, e.g. a transcript's `source` / `occurred_at`) merged into the subject's `data`. | `kind`, `title`, `priority`, `status`, `labels[]`, `body`, `data`, `project_root` |
+| `animus.subject.update` | Update a subject through the active `subject_backend` plugin. `data` is a JSON object of structured custom fields merged into the subject's `data` (via `patch.custom`). | `kind`, `id`, `title`, `priority`, `status`, `labels[]`, `body`, `data`, `project_root` |
 | `animus.subject.next` | Return the highest-priority Ready subject for the given kind | `kind`, `project_root` |
 | `animus.subject.status` | Set the status of a subject by id through the active `subject_backend` | `kind`, `id`, `status`, `project_root` |
-| `animus.subject.batch-create` | Create up to 100 subjects of one kind in a single call (per-item dispatch) | `kind`, `items[]` (`title`, `status`, `priority`, `labels[]`, `body`), `on_error`, `project_root` |
-| `animus.subject.batch-update` | Patch up to 100 subjects of one kind in a single call (per-item dispatch) | `kind`, `items[]` (`id`, `status`, `priority`, `labels[]`), `on_error`, `project_root` |
+| `animus.subject.batch-create` | Create up to 100 subjects of one kind in a single call (per-item dispatch) | `kind`, `items[]` (`title`, `status`, `priority`, `labels[]`, `body`, `data`), `on_error`, `project_root` |
+| `animus.subject.batch-update` | Patch up to 100 subjects of one kind in a single call (per-item dispatch). A per-item `data` object (→ `patch.custom`) makes a data-only item valid. | `kind`, `items[]` (`id`, `status`, `priority`, `labels[]`, `data`), `on_error`, `project_root` |
 
 ---
 


### PR DESCRIPTION
## What

Adds an optional `--data <JSON>` object flag to `animus subject create` / `subject update`, a matching per-item `data` field on the batch verbs (`batch-create` / `batch-update`), and full MCP-tool parity — so structured custom fields can finally be written deterministically from command-phase / scripted callers.

## Why — the BaaS-accepts-but-CLI-never-sends gap

The subject backend (the Postgres BaaS plugin) already merges structured custom fields into a subject's `data` jsonb via `collectIncomingData(payload)` — from `payload.data`, `payload.custom`, `payload.patch.custom`, non-reserved top-level keys, and `payload.body`.

But no `animus` CLI/MCP surface ever SENT structured data: every create/update/batch path reserialized through a fixed struct carrying only `{title, status, priority, labels, body}`. So declared kind fields with no dedicated flag — a transcript's `source_id`, `occurred_at`, `participants`, `recording_url`, `raw_transcript`, `action_items`, `summary`, `tags` — could not be written deterministically. This closes that gap.

## Merge semantics

- **create** → parsed object placed at top-level `payload["data"]` (BaaS `payload.data` channel).
- **update** → parsed object placed at `patch["custom"]` (BaaS `payload.patch.custom` channel; update params are `{id, patch}`).
- **batch-create item** → same as create (`payload["data"]`).
- **batch-update item** → same as update (`patch["custom"]`); a data-only update item is now valid.

`--data` must be a JSON **object**; arrays / scalars / malformed JSON error as `InvalidInput`. It merges with (does not replace) the other fields. Batch items carry `data` as an already-parsed `Value` from the items file and are validated (not re-parsed).

## Surfaces touched

- CLI: `SubjectCreateArgs` / `SubjectUpdateArgs` gain `--data`; `BatchCreateItem` / `BatchUpdateItem` gain a `data` field.
- MCP: `data` added to `SubjectCreateInput`, `SubjectUpdateInput`, `SubjectBatchCreateItem`, `SubjectBatchUpdateItem`; threaded through the arg builders and the batch-update presence check. Schema is auto-derived from the input structs (schemars).
- Docs: `docs/reference/cli/index.md` + `docs/reference/mcp-tools.md`.
- Tests: unit coverage for object/non-object parsing, create→`data`, update→`patch.custom`, batch threading, and MCP arg forwarding.

## Enabler for

Deterministic transcript ingestion (TASK-285) + mining (TASK-286). REQUIREMENT-039.

## Verification

- `cargo animus-fmt` / `cargo animus-lint` (clippy) / `cargo animus-bin-check`: clean.
- `cargo test -p orchestrator-cli` bin unit tests: 1336 passed, 0 failed (incl. 8 new). The 2 `plugin_agent_run_e2e` failures are pre-existing environmental (missing `animus-provider-mock` testkit binary), unrelated to this change.
- Codex self-vet (`codex review --uncommitted`, high effort): 1 round, no P1/P2 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
