### PR TITLE
Broker honors workflow-level environment so a run shares ONE node (rc.16, REQ-051)

### DIFF
--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.7.0-rc.15"
+version = "0.7.0-rc.16"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -773,6 +773,16 @@ pub(super) async fn handle_daemon_run(args: DaemonRunArgs, project_root: &str, j
     // bind failure is non-fatal — the runner then falls back to its own
     // per-phase environment path.
     process_manager.environment_routing = workflow_config.config.environment_routing.clone();
+    // Map each workflow's `environment:` override (id -> environment id, lowercased
+    // keys) so the broker gate can honor a workflow-level environment even when no
+    // kind-level routing rule exists — the common deploy shape. Without this the
+    // broker never engaged and each phase prepared its own node. TASK-431 / REQ-051.
+    process_manager.workflow_environments = workflow_config
+        .config
+        .workflows
+        .iter()
+        .filter_map(|workflow| workflow.environment.as_ref().map(|env| (workflow.id.to_ascii_lowercase(), env.clone())))
+        .collect();
     match orchestrator_daemon_runtime::EnvironmentBroker::start(project_root).await {
         Ok(broker) => {
             process_manager = process_manager.with_environment_broker(broker);

--- a/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
@@ -205,6 +205,13 @@ pub struct ProcessManager {
     /// Drives the daemon-side decision of whether a dispatch routes to a
     /// non-local environment (and thus through the [`EnvironmentBroker`]).
     pub environment_routing: Option<animus_config_protocol::workflow_types::EnvironmentRouting>,
+    /// Per-workflow `environment:` overrides (workflow id -> environment plugin
+    /// id, lowercased keys). The broker gate resolves the dispatch's workflow to
+    /// its `environment:` and feeds it to `resolve_environment` as `workflow_env`
+    /// — without this a workflow-level environment (the only environment config
+    /// on many deployments) was invisible to the daemon, so the broker never
+    /// engaged and each phase prepared its OWN node. See TASK-431 / REQ-051.
+    pub workflow_environments: std::collections::HashMap<String, String>,
     /// REQ-048: the cross-phase ephemeral-environment broker. When wired AND the
     /// dispatch routes to a non-local environment, the daemon sets the four
     /// `ANIMUS_ENVIRONMENT_BROKER_*` env vars on the runner so it acquires the
@@ -245,6 +252,7 @@ impl ProcessManager {
             pipe_root: None,
             workflow_concurrency_max,
             environment_routing: None,
+            workflow_environments: std::collections::HashMap::new(),
             environment_broker: None,
         }
     }
@@ -552,15 +560,25 @@ impl ProcessManager {
         command: &mut Command,
     ) -> Option<String> {
         let broker = self.environment_broker.as_ref()?;
-        // Config-level routing only (kind rules + default): the daemon dispatches
-        // per phase and cannot know the phase's harness/`environment:` override
-        // here, and the node is per-RUN anyway, so a single run-level environment
-        // is the correct granularity for the broker decision.
+        // The daemon dispatches per phase and cannot know a PHASE-level
+        // `environment:` override here, but the node is per-RUN anyway, so a
+        // single run-level environment is the correct granularity. Feed the
+        // dispatch's WORKFLOW-level `environment:` as `workflow_env` (the runner
+        // does the same when it resolves each phase) so a workflow-level
+        // environment engages the broker even with no kind-level routing rule —
+        // otherwise the broker never fired and every phase owned its own node.
+        // See TASK-431 / REQ-051.
+        let workflow_ref = dispatch.workflow_ref.trim();
+        let workflow_env = if workflow_ref.is_empty() {
+            None
+        } else {
+            self.workflow_environments.get(&workflow_ref.to_ascii_lowercase()).map(String::as_str)
+        };
         let environment_id = orchestrator_config::workflow_config::resolve_environment(
             dispatch.subject_kind(),
             None,
             None,
-            None,
+            workflow_env,
             self.environment_routing.as_ref(),
         )?;
         if is_local_environment(&environment_id) {


### PR DESCRIPTION
Fixes TASK-431: coding-workflow phases each ran on a SEPARATE ephemeral node, so code-open-pr saw no changes and opened no PR.

**Root cause:** `ProcessManager::configure_environment_broker` gated the daemon broker on `resolve_environment(subject_kind, None, None, /*workflow_env=*/None, environment_routing)`. On deployments whose only environment config is workflow-level (`workflows[].environment`, no kind-level routing rule), that returns `None` → broker disengages → each per-phase runner prepares its own node → no shared workspace.

**Fix:** thread a workflow-id → environment map into `ProcessManager` (populated in `daemon_run` next to `environment_routing`) and pass the dispatch's workflow-level environment as `workflow_env`, mirroring how the runner resolves each phase. A workflow with an `environment:` now engages the broker (keyed per subject) so all phases share one node; workflows without one stay local.

Verified: touched crates compile; daemon-runtime lib tests show the same 293-pass/27-fail as the clean rc.15 base (pre-existing test-isolation failures, unrelated). Bump orchestrator-cli 0.7.0-rc.16. REQUIREMENT-051.