### PR TITLE
Update Cargo.lock for rc.16 (fix --locked release build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,7 +2782,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.7.0-rc.15"
+version = "0.7.0-rc.16"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",


### PR DESCRIPTION
The rc.16 version bump didn't update Cargo.lock; the release CI builds with --locked and failed with 'cannot update the lock file'. Sync the lock's orchestrator-cli entry to 0.7.0-rc.16.