### PR TITLE
fix(orchestrator-core): emit bare native id for plugin-resolved subjects

### DIFF
--- a/crates/orchestrator-core/src/subject_adapter/adapter.rs
+++ b/crates/orchestrator-core/src/subject_adapter/adapter.rs
@@ -306,12 +306,23 @@ fn build_context_from_plugin(
     fallback_title: Option<&str>,
     fallback_description: Option<&str>,
 ) -> Result<SubjectContext> {
+    // The dispatch layer records built-in task/requirement subjects with a
+    // QUALIFIED id (`task:TASK-411`) so their queue key stays in lockstep with
+    // the `--task-id` path (see
+    // `orchestrator-cli::services::operations::subject_id_dispatch::subject_ref_preserving_key`).
+    // A plugin-resolved `SubjectRef` therefore carries that qualified form in its
+    // `id` field. `SubjectContext::subject_id` MUST instead be the BARE native id:
+    // the in-tree task adapter emits it bare (its store keys on the bare id), and
+    // the workflow runner sets its `{{subject_native_id}}` template var from this
+    // field and requires the bare id (a `:` yields an invalid git branch name like
+    // `animus/task:TASK-411`). Strip the leading `<kind>:` qualifier to match.
+    let native_id = strip_leading_kind_prefix(subject.id(), subject.kind());
     let title = response
         .get("title")
         .and_then(serde_json::Value::as_str)
         .map(ToOwned::to_owned)
         .or_else(|| fallback_title.map(ToOwned::to_owned))
-        .unwrap_or_else(|| subject.id().to_string());
+        .unwrap_or_else(|| native_id.to_string());
     let description = response
         .get("description")
         .and_then(serde_json::Value::as_str)
@@ -338,12 +349,49 @@ fn build_context_from_plugin(
     attributes.insert(SUBJECT_ATTR_PLUGIN_RESOLVED.to_string(), "true".to_string());
     Ok(SubjectContext {
         subject_kind: subject.kind().to_string(),
-        subject_id: subject.id().to_string(),
+        subject_id: native_id.to_string(),
         subject_title: title,
         subject_description: description,
         attributes,
         task: None,
     })
+}
+
+/// Strip a leading `<kind>:` qualifier from a subject id, yielding the BARE
+/// native id the backend actually stores (`task:TASK-411` -> `TASK-411`).
+///
+/// A plugin-resolved built-in subject arrives with a qualified `id` field
+/// because the dispatch layer keeps built-in task/requirement ids qualified for
+/// queue-key parity with the `--task-id` path (see
+/// `orchestrator-cli::services::operations::subject_id_dispatch::subject_ref_preserving_key`).
+/// Downstream (the workflow runner's `{{subject_native_id}}`, git branch names)
+/// requires the bare native id.
+///
+/// The id may be qualified with either the subject's full native kind
+/// (`animus.task:TASK-1`) or its short user-facing alias — the trailing dotted
+/// segment (`task:TASK-1`, which is what a router-resolved `queue enqueue`
+/// records). A leading `<prefix>:` is stripped only when `<prefix>`
+/// case-insensitively equals the subject's `kind` OR that kind's last dotted
+/// segment, so a bare id (no prefix) or an unrelated `foo:` prefix (a genuine
+/// colon in a local id) passes through unchanged.
+///
+/// Mirrors
+/// `orchestrator-daemon-runtime::dispatch::build_runner_command_from_dispatch::strip_leading_kind_prefix`
+/// verbatim; duplicated (not shared) because `orchestrator-daemon-runtime`
+/// depends on `orchestrator-core`, not the reverse.
+fn strip_leading_kind_prefix<'a>(id: &'a str, kind: &str) -> &'a str {
+    let Some((prefix, rest)) = id.split_once(':') else {
+        return id;
+    };
+    if rest.is_empty() {
+        return id;
+    }
+    let short = kind.rsplit('.').next().unwrap_or(kind);
+    if prefix.eq_ignore_ascii_case(kind) || prefix.eq_ignore_ascii_case(short) {
+        rest
+    } else {
+        id
+    }
 }
 
 #[must_use]
@@ -1948,5 +1996,76 @@ mod tests {
         assert!(msg.contains("not resolvable"), "expected combined error message, got: {msg}");
         assert!(msg.contains("in-tree"), "expected in-tree error context, got: {msg}");
         assert!(msg.contains("plugin"), "expected plugin error context, got: {msg}");
+    }
+
+    // ---------------------------------------------------------------------
+    // Plugin-resolved subjects must expose the BARE native id in
+    // `SubjectContext::subject_id`. The dispatch layer keeps built-in
+    // task/requirement ids QUALIFIED (`task:TASK-411`) for queue-key parity, so
+    // `SubjectRef::id()` on the plugin path is qualified; the workflow runner
+    // feeds `subject_id` into `{{subject_native_id}}` and a `:` breaks git branch
+    // names (`animus/task:TASK-411`). These pin the strip so the plugin path
+    // matches the in-tree adapter's bare-id convention.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn build_context_from_plugin_strips_qualified_task_prefix() {
+        // Built-in task kind is namespaced (`animus.task`) but the qualified id
+        // uses the short alias prefix (`task:`); the native id must come out bare.
+        let subject = SubjectRef::new(SUBJECT_KIND_TASK, "task:TASK-411");
+        let ctx = build_context_from_plugin(&subject, serde_json::json!({}), None, None).unwrap();
+        assert_eq!(ctx.subject_kind, SUBJECT_KIND_TASK);
+        assert_eq!(ctx.subject_id, "TASK-411", "subject_id must be the bare native id");
+        // No plugin/fallback title -> falls back to the bare native id, not the
+        // qualified form.
+        assert_eq!(ctx.subject_title, "TASK-411");
+        assert_eq!(ctx.attributes.get(SUBJECT_ATTR_PLUGIN_RESOLVED).map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn build_context_from_plugin_strips_full_namespaced_kind_prefix() {
+        // A backend may echo the id qualified with the FULL native kind.
+        let subject = SubjectRef::new(SUBJECT_KIND_REQUIREMENT, "animus.requirement:REQ-7");
+        let ctx = build_context_from_plugin(&subject, serde_json::json!({}), None, None).unwrap();
+        assert_eq!(ctx.subject_id, "REQ-7");
+    }
+
+    #[test]
+    fn build_context_from_plugin_keeps_bare_dynamic_id() {
+        // Dynamic kinds are stored bare already: nothing to strip.
+        let subject = SubjectRef::new("transcript", "TRANSCRIPT-001");
+        let ctx = build_context_from_plugin(&subject, serde_json::json!({}), None, None).unwrap();
+        assert_eq!(ctx.subject_kind, "transcript");
+        assert_eq!(ctx.subject_id, "TRANSCRIPT-001");
+    }
+
+    #[test]
+    fn build_context_from_plugin_strips_qualified_dynamic_prefix() {
+        // A qualified dynamic id still de-qualifies to its bare native form.
+        let subject = SubjectRef::new("transcript", "transcript:TRANSCRIPT-001");
+        let ctx = build_context_from_plugin(&subject, serde_json::json!({}), None, None).unwrap();
+        assert_eq!(ctx.subject_id, "TRANSCRIPT-001");
+    }
+
+    #[test]
+    fn build_context_from_plugin_preserves_unrelated_colon_id() {
+        // An id whose colon prefix does NOT match the kind (or its short alias)
+        // is a genuine part of the native id and must survive untouched.
+        let subject = SubjectRef::new("blog", "draft:2024:post-1");
+        let ctx = build_context_from_plugin(&subject, serde_json::json!({}), None, None).unwrap();
+        assert_eq!(ctx.subject_id, "draft:2024:post-1");
+    }
+
+    #[test]
+    fn strip_leading_kind_prefix_only_strips_matching_kind() {
+        assert_eq!(strip_leading_kind_prefix("task:TASK-244", "animus.task"), "TASK-244");
+        assert_eq!(strip_leading_kind_prefix("animus.task:TASK-244", "animus.task"), "TASK-244");
+        assert_eq!(strip_leading_kind_prefix("requirement:REQ-1", "animus.requirement"), "REQ-1");
+        // Bare id: unchanged.
+        assert_eq!(strip_leading_kind_prefix("TASK-244", "animus.task"), "TASK-244");
+        // Unrelated prefix: unchanged.
+        assert_eq!(strip_leading_kind_prefix("foo:BAR-1", "animus.task"), "foo:BAR-1");
+        // Empty native segment: unchanged (defensive).
+        assert_eq!(strip_leading_kind_prefix("task:", "animus.task"), "task:");
     }
 }


### PR DESCRIPTION
## Summary

 in  constructed the  with .

For **plugin-resolved** subjects (the path used when subject data lives in a  plugin — e.g. a nested node proxying an upstream board),  returns the **kind-qualified** id (). The dispatch layer deliberately keeps built-in task/requirement ids qualified so their queue key stays in lockstep with the  enqueue path (see ).

The workflow runner (, ) sets its  template var from , and that var **must be the bare native id** (). A qualified value:
- produces **invalid git branch names** ( — colon is illegal in a ref name), and
- breaks workspace/path assumptions downstream.

The in-tree (non-plugin) adapter path already emits the **bare** id (its store keys on the bare id, so a qualified id would miss the lookup entirely). This change makes the plugin-resolved path consistent with it.

## Fix

- Strip the leading  qualifier from  before storing it as  (and as the title fallback).
- Precision: a prefix is stripped **only** when it case-insensitively equals the subject's  **or** that kind's short last-dotted-segment alias ( for , since the qualified form uses the bare alias  while  returns the namespaced ). Bare ids and ids with an *unrelated* colon prefix pass through unchanged.
- The helper  mirrors the existing one in  verbatim. It is duplicated (not shared) because  depends on , not the reverse, and the original is a private fn.

## Tests

Adds unit tests for  /  covering: short-alias-qualified task ( → ), full-namespaced-qualified requirement ( → ), already-bare dynamic kind, qualified dynamic kind, and an unrelated-colon id that must survive untouched.

## ⚠️ Needs node/CI build + test validation

Per project policy, ao-cli builds/tests run on ephemeral nodes/CI, **not locally** — this change was **not** compiled or tested here.  was applied (file parses clean) but  / 
running 361 tests
test daemon_config::tests::daemon_project_config_serializes_none_runtime_fields_omitted ... ok
test config::tests::falls_through_to_cwd_when_cli_arg_missing ... ok
test doctor::tests::path_is_executable_requires_execute_permission ... ok
test config::tests::cli_project_root_wins ... ok
test daemon_config::tests::resolve_silent_threshold_defaults_when_unset ... ok
test daemon_config::tests::load_daemon_project_config_defaults_when_missing ... ok
test daemon_config::tests::daemon_project_config_deserializes_missing_runtime_fields_as_none ... ok
test daemon_config::tests::resolve_silent_threshold_reads_configured_value ... ok
test config::tests::cache_kill_switch_disables_caching ... ok
test domain_state::tests::history_record_round_trips_run_id ... ok
test domain_state::tests::history_record_without_run_id_still_loads_and_omits_field ... ok
test daemon_config::tests::daemon_project_config_round_trips_runtime_fields ... ok
test execution_projection::project_requirement_workflow_status::tests::requirement_task_generation_run_projects_in_progress ... ok
test execution_projection::project_requirement_workflow_status::tests::requirement_task_generation_projects_planned ... ok
test execution_projection::project_requirement_workflow_status::tests::unrelated_workflow_ref_does_not_mutate_requirement_status ... ok
test execution_projection::tests::foreign_blocked_reason_is_not_clobbered_or_cleared ... ok
test execution_projection::tests::detail_less_repause_does_not_downgrade_enriched_marker ... ok
test execution_projection::tests::bare_pause_marker_is_upgraded_to_carry_budget_detail ... ok
test execution_projection::tests::is_workflow_paused_reason_matches_bare_and_enriched_markers ... ok
test execution_projection::tests::old_bare_marker_still_clears_on_resume ... ok
test execution_projection::tests::paused_marker_carries_budget_detail_and_resume_clears_it ... ok
test execution_projection::tests::project_execution_fact_reports_unknown_subject_kind_as_unprojected ... ok
test execution_projection::tests::project_execution_fact_does_not_auto_mark_task_done_on_success ... ok
test execution_projection::tests::project_execution_fact_does_not_auto_mark_done_for_legacy_facts ... ok
test config::tests::falls_back_to_current_dir_outside_git_repo ... ok
test daemon_config::tests::daemon_project_config_preserves_unknown_fields ... ok
test execution_projection::tests::workflow_paused_reason_formats_bare_and_enriched ... ok
test flavor::tests::all_plugin_slugs_collects_required_and_optional_recommendations ... ok
test flavor::tests::bundled_default_flavor_required_set_covers_daemon_preflight_roles ... ok
test flavor::tests::parses_and_validates_v1_manifest ... ok
test flavor::tests::rejects_unknown_schema ... ok
test flavor::tests::required_plugins_tags_each_slug_with_its_role ... ok
test daemon_config::tests::daemon_project_config_loads_legacy_idle_timeout_field ... ok
test flavor::tests::bundled_fallback_loads_when_no_manifest_on_disk ... ok
test daemon_config::tests::daemon_project_config_loads_legacy_auto_policy_fields ... ok
test doctor::tests::run_for_project_marks_invalid_daemon_config_as_fail ... ok
test doctor::tests::run_for_project_marks_expected_core_files_as_ok_when_present ... ok
test doctor::tests::run_for_project_marks_non_directory_ao_path_as_fail ... ok
test doctor::tests::run_for_project_marks_project_root_file_as_fail ... ok
test plugin_preflight::tests::auto_install_failure_fix_command_includes_allow_shadow_builtin ... ok
test plugin_preflight::tests::flavor_manifest_error_fails_preflight_even_with_no_missing_roles ... ok
test plugin_preflight::tests::flavor_manifest_error_leads_rendered_message_and_suppresses_install_advice ... ok
test plugin_preflight::tests::install_target_for_resolves_role_labels_to_repo_specs ... ok
test plugin_preflight::tests::install_target_for_resolves_workflow_runner_and_queue_roles ... ok
test plugin_preflight::tests::missing_roles_without_flavor_error_keep_install_advice_template ... ok
test plugin_preflight::tests::multiple_missing_roles_render_one_composed_flavor_fix_command ... ok
test plugin_preflight::tests::preflight_refuses_when_workflow_runner_or_queue_plugin_missing ... ok
test plugin_preflight::tests::preflight_satisfied_when_subject_backend_covers_all_required_kinds ... ok
test plugin_preflight::tests::preflight_with_auto_install_but_install_still_does_not_cover_role_reports_missing ... ok
test plugin_preflight::tests::preflight_with_auto_install_installs_missing_plugin_and_marks_satisfied ... ok
test plugin_preflight::tests::preflight_with_no_plugins_and_no_auto_install_reports_missing_with_fix_commands ... ok
test plugin_preflight::tests::preflight_with_provider_installed_marks_provider_role_satisfied ... ok
test plugin_preflight::tests::provider_missing_preflight_suggests_command_that_actually_works ... ok
test plugin_preflight::tests::queue_underpin_warning_fires_below_floor ... ok
test plugin_preflight::tests::queue_underpin_warning_ignores_unparseable_versions ... ok
test plugin_preflight::tests::queue_underpin_warning_silent_at_or_above_floor ... ok
test plugin_preflight::tests::single_missing_role_keeps_per_role_fix_without_composed_command ... ok
test plugin_preflight::tests::summarize_with_lock_is_identity_when_lockfile_absent ... ok
test plugin_preflight::tests::summarize_with_lock_translates_native_subject_kind_to_installed_kind ... ok
test plugin_preflight::tests::workflow_runner_underpin_warning_fires_below_floor ... ok
test plugin_preflight::tests::workflow_runner_underpin_warning_ignores_unparseable_versions ... ok
test plugin_preflight::tests::workflow_runner_underpin_warning_silent_at_or_above_floor ... ok
test plugin_registry::tests::all_provider_plugins_have_non_empty_tags ... ok
test plugin_registry::tests::all_subject_plugins_have_non_empty_tags ... ok
test plugin_registry::tests::provider_default_is_claude_at_curated_tag ... ok
test plugin_registry::tests::subject_kind_requirement_resolves_to_subject_requirements ... ok
test plugin_registry::tests::subject_kind_task_resolves_to_subject_default ... ok
test plugin_registry::tests::unknown_subject_kind_returns_none ... ok
test doctor::tests::run_for_project_reports_warns_for_missing_bootstrap_files ... ok
test principal::tests::bootstrap_refuses_to_overwrite_existing_file ... ok
test principal::tests::enforce_mode_admin_role_allows_everything ... ok
test principal::tests::enforce_mode_daemon_always_allowed ... ok
test principal::tests::enforce_mode_denies_unknown_principal ... ok
test principal::tests::enforce_mode_viewer_role_allows_only_reads ... ok
test principal::tests::principal_id_and_kind_labels_are_stable ... ok
test principal::tests::principal_serializes_with_kind_tag ... ok
test principal::tests::rbac_mode_serializes_kebab_case ... ok
test principal::tests::resolve_by_os_user_walks_os_users_list ... ok
test principal::tests::single_user_mode_allows_everything ... ok
test runtime_contract::tests::build_launch_contract_enforces_machine_output_for_supported_tools ... ok
test runtime_contract::tests::build_launch_contract_preserves_opencode_glm_and_minimax_models ... ok
test runtime_contract::tests::build_launch_contract_supports_resume_mode ... ok
test principal::tests::bootstrap_writes_default_file_when_absent ... ok
test runtime_contract::tests::build_runtime_contract_enforces_mcp_only_when_supported_tool_has_endpoint ... ok
test runtime_contract::tests::build_runtime_contract_includes_rich_cli_shape ... ok
test runtime_contract::tests::cli_tool_flags_resolve_from_config_supplied_tool_metadata ... ok
test execution_projection::tests::project_schedule_dispatch_missed_does_not_update_last_run ... ok
test secret_device_store::tests::file_is_not_plaintext ... ok
test execution_projection::tests::project_schedule_dispatch_attempt_updates_last_run_and_run_count ... ok
test secret_keysource::tests::device_id_is_deterministic_and_binds_to_machine_material ... ok
test secret_keysource::tests::key_source_kind_parse_round_trips ... ok
test model_quality::tests::suppression_requires_min_attempts ... ok
test secret_keysource::tests::user_key_accepts_hex_and_base64_and_rejects_wrong_length ... ok
test secret_store::tests::enforce_cap_fails_over_limit ... ok
test secret_store::tests::enforce_cap_passes_under_limit ... ok
test secret_store::tests::keychain_service_name_includes_scope ... ok
test secret_device_store::tests::round_trip_set_get_list_delete ... ok
test secret_store::tests::mock_store_round_trip ... ok
test secret_store::tests::snapshot_returns_all_pairs ... ok
test secret_store::tests::validate_key_accepts_standard_env_shape ... ok
test secret_store::tests::validate_key_rejects_bad_shapes ... ok
test model_quality::tests::suppression_triggers_at_threshold ... ok
test model_quality::tests::suppression_is_phase_scoped ... ok
test services::daemon_impl::tests::daemon_health_cache_expires_after_ttl ... ok
test secret_device_store::tests::tamper_fails_closed ... ok
test services::daemon_impl::tests::daemon_health_cache_returns_stored_value_within_ttl ... ok
test secret_device_store::tests::wrong_device_key_cannot_decrypt ... ok
test execution_projection::tests::project_schedule_dispatch_missed_then_attempt_separates_counters ... ok
test model_quality::tests::unknown_verdict_counts_as_fail ... ok
test services::daemon_impl::tests::daemon_health_cache_keys_isolate_by_project_root ... ok
test services::daemon_impl::tests::parse_runtime_pause_state_defaults_when_unpaused_or_invalid ... ok
test services::daemon_impl::tests::parse_runtime_pause_state_reads_paused_record ... ok
test config::tests::repeat_calls_hit_in_process_cache ... ok
test services::planning_shared::requirement_lifecycle::tests::requirement_lifecycle_can_rework_then_approve ... ok
test services::planning_shared::requirement_lifecycle::tests::requirement_lifecycle_happy_path_approves ... ok
test services::planning_shared::requirement_lifecycle::tests::requirement_lifecycle_respects_rework_budget ... ok
test services::review_impl::tests::request_handoff_requires_run_id ... ok
test config::tests::resolves_repo_root_from_git_subdirectory ... ok
test config::tests::cached_cwd_lookup_preserves_git_repo_source ... ok
test services::state_store::tests::mutation_loader_rejects_invalid_core_state_json ... ok
test services::state_store::tests::mutation_loader_returns_default_when_state_file_is_missing ... ok
test services::tests::execute_requirements_blocks_when_vision_constraints_are_not_covered ... ok
test model_quality::tests::suppression_clears_after_recovery ... ok
test services::tests::execute_requirements_can_include_wont_with_opt_in ... ok
test services::tests::execute_requirements_excludes_wont_by_default ... ok
test model_quality::tests::rework_verdict_increments_reworks_not_fails ... ok
test services::tests::execute_requirements_generates_stable_task_titles ... ok
test services::tests::execute_requirements_runs_requirement_state_machine_before_task_materialization ... ok
test services::tests::execute_requirements_maps_requirement_priority_to_task_priority ... ok
test secret_store::tests::keyring_store_index_round_trip ... ok
test model_quality::tests::advance_verdict_lifts_suppression_over_time ... ok
test services::daemon_impl::tests::fast_snapshot_returns_stopped_for_empty_project ... ok
test services::daemon_impl::tests::fast_snapshot_does_not_open_sqlite ... ok
test services::review_impl::tests::transcript_path_uses_project_state_dir ... ok
test services::schedule_state::tests::load_missing_schedule_state_returns_default ... ok
test services::schedule_state::tests::save_and_load_schedule_state_round_trip ... ok
test services::daemon_impl::tests::fast_snapshot_matches_full_snapshot_status_for_empty_project ... ok
test services::daemon_impl::tests::file_hub_start_does_not_spawn_runner_sidecar ... ok
test services::daemon_impl::tests::file_hub_start_sets_running ... ok
test config::tests::relative_cli_arg_keys_include_cwd ... ok
test config::tests::resolves_primary_repo_root_from_linked_worktree ... ok
test services::tests::file_hub_bootstraps_architecture_docs_file ... ok
test services::tests::file_hub_bootstraps_workflow_yaml_with_phase_catalog ... ok
test config::tests::cli_project_root_dot_in_linked_worktree_resolves_primary_repo_root ... ok
test services::tests::file_hub_errors_when_requested_pipeline_is_missing_from_config ... ok
test secret_keysource::tests::passphrase_is_deterministic_per_salt_and_varies_by_salt ... ok
test services::daemon_impl::tests::daemon_health_cache_invalidated_by_lifecycle_mutations ... ok
test services::tests::file_hub_explicit_git_bootstrap_initializes_repository_and_head ... ok
test services::tests::file_hub_new_bootstraps_ao_without_initializing_git_repository ... ok
test services::tests::file_hub_mutations_fail_closed_for_invalid_core_state_json ... ok
test services::tests::file_hub_new_bootstraps_base_configs_for_project_path ... ok
test services::tests::in_memory_hub_with_project_root_engages_plugin_fallback ... ok
test services::tests::in_memory_hub_without_project_root_skips_plugin_fallback ... ok
test services::tests::file_hub_new_does_not_rewrite_existing_core_state_on_boot ... ok
test services::tests::file_hub_daemon_mutation_interleaves_with_task_create_without_lost_updates ... ok
test services::tests::planning_draft_requirements_preserves_vision_constraints_when_max_is_small ... ok
test services::tests::file_hub_concurrent_task_creates_keep_unique_ids ... ok
test services::tests::planning_service_drafts_and_executes_requirements ... ok
test services::tests::planning_service_query_filters_and_sorts_requirements ... ok
test services::tests::requirements_refine_propagates_research_metadata_to_tasks ... ok
test services::tests::set_status_from_blocked_to_ready_clears_paused_and_blocked_fields ... ok
test services::tests::task_filter_supports_linked_architecture_entity ... ok
test services::tests::task_priority_policy_reports_active_high_budget_overflow ... ok
test services::tests::task_priority_rebalance_plan_is_deterministic_and_budget_compliant ... ok
test services::tests::task_priority_rebalance_rejects_conflicting_override_task_ids ... ok
test services::tests::task_service_query_returns_stable_paginated_priority_order ... ok
test services::tests::task_service_rejects_unknown_architecture_entities ... ok
test services::tests::task_service_supports_priority_checklists_and_dependencies ... ok
test services::tests::update_status_from_on_hold_to_in_progress_clears_paused_and_blocked_fields ... ok
test services::tests::file_hub_recompiles_repo_workflow_yaml_on_startup ... ok
test services::tests::workflow_service_query_filters_by_status_and_reference ... ok
test services::trigger_state::tests::load_missing_trigger_state_returns_default ... ok
test services::trigger_state::tests::lock_trigger_state_is_exclusive ... ok
test services::tests::file_hub_subject_resolver_engages_plugin_fallback ... ok
test state_machine_parity::workflow_failed_state_can_resume_for_retry ... ok
test services::trigger_state::tests::save_and_load_trigger_state_round_trip ... ok
test state_machines::engine::tests::builtin_workflow_machine_marks_merge_conflict_as_non_terminal ... ok
test state_machines::engine::tests::compile_builtin_document ... ok
test state_machines::engine::tests::evaluate_guard_checks_correct_phase ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_at_limit ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_no_reworks_yet ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_over_limit ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_when_under_limit ... ok
test state_machines::engine::tests::evaluate_guard_rework_budget_available_with_zero_max ... ok
test state_machines::engine::tests::evaluate_guard_unknown_guard_passes ... ok
test state_machines::engine::tests::full_lifecycle_happy_path ... ok
test state_machines::engine::tests::full_lifecycle_with_rework ... ok
test state_machines::engine::tests::guard_blocked_falls_through_to_unguarded ... ok
test state_machines::engine::tests::guard_blocked_returns_error ... ok
test state_machines::engine::tests::no_transition_cancelled_start ... ok
test state_machines::engine::tests::no_transition_completed_phase_started ... ok
test state_machines::engine::tests::no_transition_failed_gates_passed ... ok
test services::tests::file_hub_concurrent_requirement_upserts_keep_unique_ids ... ok
test state_machines::engine::tests::no_transition_idle_phase_succeeded ... ok
test state_machines::engine::tests::no_transition_paused_phase_succeeded ... ok
test state_machines::engine::tests::no_transition_run_phase_start ... ok
test state_machines::engine::tests::requirement_guard_blocks_transition_when_budget_exceeded ... ok
test state_machines::engine::tests::requirement_lifecycle_blocks_rework_when_budget_exceeded ... ok
test state_machines::engine::tests::requirement_lifecycle_uses_evaluate_guard_for_rework_budget ... ok
test state_machines::engine::tests::state_unchanged_on_guard_blocked_error ... ok
test state_machines::engine::tests::state_unchanged_on_no_transition_error ... ok
test state_machines::engine::tests::valid_cancel_from_idle ... ok
test state_machines::engine::tests::valid_apply_transition_no_more_phases ... ok
test state_machines::engine::tests::valid_cancel_from_paused ... ok
test state_machines::engine::tests::valid_cancel_from_run_phase ... ok
test state_machines::engine::tests::valid_evaluate_gates_gates_passed ... ok
test state_machines::engine::tests::valid_evaluate_transition_phase_started ... ok
test state_machines::engine::tests::valid_idle_start ... ok
test state_machines::engine::tests::valid_pause_from_evaluate_gates ... ok
test state_machines::engine::tests::valid_pause_from_idle ... ok
test state_machines::engine::tests::valid_pause_from_run_phase ... ok
test state_machines::engine::tests::valid_run_phase_phase_failed ... ok
test state_machines::engine::tests::valid_run_phase_phase_skipped ... ok
test state_machines::engine::tests::valid_run_phase_phase_succeeded ... ok
test state_machines::engine::tests::workflow_apply_uses_ordered_first_match ... ok
test services::tests::file_hub_persists_tasks ... ok
test services::tests::file_hub_persists_planning_artifacts ... ok
test state_machines::tests::invalid_file_falls_back_in_json_mode ... ok
test state_machines::validator::tests::builtin_definition_validates ... ok
test state_machines::validator::tests::invalid_guard_reference_is_rejected ... ok
test state_machines::validator::tests::machine_missing_executor_required_transition_is_rejected ... ok
test state_machines::tests::strict_mode_errors_when_file_is_invalid ... ok
test state_machines::tests::missing_file_falls_back_in_json_mode ... ok
test store::tests::fsync_dir_succeeds_on_existing_directory ... ok
test subject_adapter::adapter::tests::build_context_from_plugin_keeps_bare_dynamic_id ... ok
test subject_adapter::adapter::tests::build_context_from_plugin_preserves_unrelated_colon_id ... ok
test subject_adapter::adapter::tests::build_context_from_plugin_strips_full_namespaced_kind_prefix ... ok
test subject_adapter::adapter::tests::build_context_from_plugin_strips_qualified_dynamic_prefix ... ok
test subject_adapter::adapter::tests::build_context_from_plugin_strips_qualified_task_prefix ... ok
test state_machine_parity::workflow_transition_matrix_matches_legacy_behavior ... ok
test subject_adapter::adapter::tests::builtin_project_adapter_returns_project_root_for_requirement_subjects ... ok
test subject_adapter::adapter::tests::builtin_subject_resolver_uses_requirement_adapter_registry ... ok
test subject_adapter::adapter::tests::ensure_execution_cwd_routes_in_tree_task_through_adapter_even_after_task_take ... ok
test subject_adapter::adapter::tests::ensure_execution_cwd_uses_project_root_for_plugin_owned_task ... ok
test store::tests::fsync_rename_promotes_temp_to_final_and_makes_it_readable ... ok
test subject_adapter::adapter::tests::managed_worktree_mcp_config_falls_back_to_primary_repo_manifest_path ... ok
test subject_adapter::adapter::tests::resolve_falls_back_to_plugin_when_in_tree_requirement_adapter_errors ... ok
test subject_adapter::adapter::tests::resolve_falls_back_to_plugin_when_in_tree_task_adapter_errors ... ok
test subject_adapter::adapter::tests::resolve_reports_both_errors_when_fallback_also_misses ... ok
test subject_adapter::adapter::tests::strip_leading_kind_prefix_only_strips_matching_kind ... ok
test types::tests::phase_decision_deserializes_with_expected_defaults ... ok
test types::tests::phase_decision_deserializes_unknown_verdict_with_fallback ... ok
test types::tests::phase_decision_no_changes_needed_evidence_serializes ... ok
test types::tests::phase_decision_serializes_with_evidence_payload ... ok
test types::tests::requirement_priority_to_task_priority_mapping_is_stable ... ok
test types::tests::task_status_deserializes_contract_aliases_and_helpers_stay_consistent ... ok
test types::tests::task_type_as_str_matches_canonical_serialization_and_aliases ... ok
test workflow::journal_client::tests::actor_blob_key_is_stripped_before_deserialization ... ok
test store::tests::write_json_atomic_round_trip_persists_value_durably ... ok
test workflow::journal_client::tests::durable_journal_inactive_without_plugin ... ok
test state_machines::tests::write_state_machines_document_is_atomic_and_readable ... ok
test workflow::journal_client::tests::import_is_a_noop_for_sqlite_backend ... ok
test workflow::journal_client::tests::journal_run_round_trips_through_blob ... ok
test workflow::journal_client::tests::kill_switch_forces_sqlite ... ok
test workflow::journal_client::tests::no_plugin_installed_resolves_to_sqlite ... ok
test workflow::journal_client::tests::subject_id_blob_key_is_stripped_before_deserialization ... ok
test workflow::journal_client::tests::to_journal_run_records_subject_id_for_generic_baas_kind ... ok
test workflow::journal_client::tests::to_journal_run_records_subject_id_for_task_kind ... ok
test workflow::phase_plan::tests::phase_plan_fallback_normalizes_legacy_refs ... ok
Initialized empty Git repository in /private/var/folders/_t/qq6w856d3p5_tnsm80nw5k240000gn/T/ao-subject-adapter-task-1784227415581584000/.git/
test services::tests::file_hub_persists_workflows_with_machine_state ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_legacy_workflow_config_exists_without_v2 ... ok
test services::tests::file_hub_yaml_only_repo_executes_workflow_without_json_config ... ok
test services::tests::file_hub_uses_custom_pipeline_from_workflow_config_v2 ... ok
test workflow::journal_client::tests::import_empty_sqlite_writes_marker_and_imports_nothing ... ok
test workflow::journal_client::tests::import_skips_when_marker_present ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_pipeline_is_missing_from_config ... ok
test services::tests::persist_dirty_to_sqlite_rolls_back_all_entities_on_partial_failure ... ok
test services::tests::file_hub_delete_requirement_removes_sqlite_row_and_does_not_resurrect ... ok
test services::tests::file_hub_complete_phase_with_decision_honors_rework_routing ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_workflow_config_is_invalid ... ok
test workflow::tests::advance_can_follow_agent_selected_target_when_yaml_allows_it ... ok
test workflow::tests::advance_ignores_agent_target_phase_and_uses_default_order ... ok
test workflow::tests::backoff_calculation ... ok
test workflow::tests::bootstrap_derives_status_from_machine_state ... ok
test workflow::tests::cancel_keeps_status_synced_with_machine_state ... ok
test workflow::tests::default_max_attempts_is_3_when_no_config ... ok
test workflow::tests::executor_backoff_delay_for_phase_returns_correct_values ... ok
test workflow::tests::failed_phase_keeps_status_synced_with_machine_state ... ok
test workflow::tests::lifecycle_does_not_pause_completed_workflow ... ok
test workflow::tests::lifecycle_double_pause_is_noop ... ok
test workflow::tests::lifecycle_marks_completed_workflow_as_merge_conflict ... ok
test workflow::tests::lifecycle_resolves_merge_conflict_and_clears_failure_reason ... ok
test workflow::tests::lifecycle_resume_on_running_is_noop ... ok
test workflow::tests::lifecycle_skip_already_done_completes_workflow_early ... ok
test workflow::tests::lifecycle_skip_duplicate_cancels_workflow_early ... ok
test workflow::phase_plan::tests::resolve_phase_plan_errors_when_workflow_config_is_missing ... ok
test services::tests::execute_requirements_skips_tasks_with_active_workflow_on_file_hub ... ok
test workflow::tests::machine_state_to_workflow_status_mapping ... ok
test workflow::tests::merge_conflict_blocks_phase_failure_with_actionable_error ... ok
test workflow::tests::merge_conflict_blocks_phase_success_with_actionable_error ... ok
test workflow::tests::no_on_verdict_uses_default_advance_behavior ... ok
test workflow::tests::on_verdict_advance_skips_to_configured_phase ... ok
test workflow::tests::on_verdict_rework_routes_to_configured_phase ... ok
test workflow::tests::phase_failure_while_paused_records_failure_and_resume_restarts ... ok
test workflow::tests::phase_with_max_attempts_1_escalates_immediately_on_rework ... ok
test workflow::tests::phase_with_max_attempts_5_allows_more_retries ... ok
test workflow::tests::resume_clears_failure_and_can_complete_after_retry ... ok
[main (root-commit) 224e821] init
 1 file changed, 1 insertion(+)
 create mode 100644 README.md
test workflow::tests::load_stale_task_summaries_matches_in_progress_status ... ok
test workflow::phase_plan::tests::resolve_phase_plan_prefers_explicit_config_pipeline_before_alias_normalization ... ok
test workflow::tests::rework_restart_refreshes_phase_started_at ... ok
test workflow::tests::rework_routes_to_prior_phase_by_id ... ok
test workflow::tests::rework_with_nonexistent_target_falls_back_to_current_phase ... ok
test workflow::tests::rework_without_target_reruns_current_phase ... ok
test workflow::phase_plan::tests::resolve_phase_plan_requires_pack_install_for_canonical_requirement_workflow_refs ... ok
test workflow::tests::load_workflow_ref_index_decodes_compressed_workflow_blobs ... ok
test workflow::tests::select_workflow_prune_candidates_applies_status_keep_last_and_age ... ok
test workflow::tests::select_workflow_prune_candidates_saturates_oversized_age ... ok
test workflow::tests::select_workflow_prune_candidates_skips_non_terminal_runs ... ok
test workflow::tests::skip_guard_evaluator_supports_not_equals ... ok
test workflow::tests::skip_guarded_phase_any_matching_guard_causes_skip ... ok
test workflow::tests::skip_guarded_phase_does_not_skip_when_guard_does_not_match ... ok
test workflow::tests::skip_guarded_phase_skips_first_phase_on_bootstrap ... ok
test workflow::tests::skip_guarded_phase_skips_when_task_type_matches ... ok
test workflow::tests::skip_guarded_phase_with_empty_skip_if_runs_normally ... ok
test workflow::tests::skip_guarded_phases_skips_consecutive_phases ... ok
test workflow::tests::state_machine_allows_resume_from_failed ... ok
test workflow::tests::state_machine_enters_merge_conflict_from_completed ... ok
test workflow::tests::state_machine_resolves_merge_conflict_to_completed ... ok
test workflow::tests::state_machine_transitions ... ok
test workflow::phase_plan::tests::resolve_phase_plan_requires_pack_install_for_optional_pack_workflows ... ok
test workflow::journal_client::tests::import_copies_runs_and_checkpoints_and_writes_marker ... ok
test services::tests::workflow_service_exposes_decisions_and_checkpoints ... ok
test workflow::tests::resume_manager_detects_resumable_running_workflow ... ok
test services::tests::file_hub_run_persists_actor_for_lifecycle_continuation ... ok
test services::tests::file_hub_auto_prunes_checkpoints_on_completion_when_enabled ... ok
test workflow::tests::resume_manager_detects_interrupted_failed_and_escalated_workflows ... ok
test workflow::tests::state_manager_prune_runs_rejects_non_terminal_status_filter ... ok
test workflow::phase_plan::tests::resolve_phase_plan_resolves_actor_private_workflow_only_for_that_actor ... ok
test services::tests::file_hub_completion_remains_successful_when_auto_prune_errors ... ok
test workflow::phase_plan::tests::resolve_phase_plan_uses_config_default_pipeline_when_none_is_requested ... ok
test services::tests::planning_execute_starts_workflows_with_config_phase_plan ... ok
test workflow::tests::status_stays_in_sync_through_lifecycle_transitions ... ok
test workflow::tests::sync_status_derives_from_machine_state ... ok
test workflow_events::tests::cancel_leaves_done_task_untouched ... ok
test workflow_events::tests::cancel_of_completed_workflow_leaves_task_untouched ... ok
test workflow_events::tests::cancel_projects_task_to_cancelled ... ok
test workflow_events::tests::pause_annotates_task_with_pause_marker_without_flipping_status ... ok
test workflow_events::tests::pause_does_not_overwrite_existing_blocked_reason ... ok
test workflow_events::tests::pause_marker_prefix_is_stable ... ok
test workflow_events::tests::pause_of_completed_workflow_does_not_annotate_task ... ok
test workflow_events::tests::ready_reset_clears_pause_marker_after_workflow_pause ... ok
test workflow::tests::state_manager_delete_run_rejects_active_workflow ... ok
test workflow_events::tests::resume_clears_pause_marker ... ok
test workflow_runner_registry::tests::reused_pid_after_restart_is_never_live ... ok
test workflow_events::tests::resume_preserves_foreign_blocked_reason ... ok
test workflow::tests::save_checkpoint_skips_numbers_of_orphan_checkpoint_rows ... ok
test workflow::phase_plan::tests::resolve_phase_plan_uses_config_phases_for_standard_pipeline ... ok
test subject_adapter::adapter::tests::builtin_project_adapter_provisions_task_worktree_via_task_adapter ... ok
test workflow::tests::save_checkpoint_rolls_back_checkpoint_row_when_workflow_save_fails ... ok
test workflow::tests::state_manager_prune_runs_dry_run_previews_without_deleting ... ok
test workflow::tests::state_manager_cleanup_deletes_terminal_workflows_with_null_timestamps ... ok
test workflow::tests::state_manager_cleanup_deletes_old_terminal_workflows ... ok
test workflow::tests::state_manager_delete_run_removes_row_and_storage ... ok
test workflow::phase_plan::tests::resolve_phase_plan_uses_machine_installed_pack_workflows ... ok
test workflow::tests::state_manager_prune_dry_run_keeps_checkpoint_files_and_metadata ... ok
test workflow::tests::state_manager_saves_checkpoints ... ok
test workflow::tests::state_manager_prunes_checkpoints_older_than_age ... ok
test workflow::tests::state_manager_prune_runs_deletes_terminal_runs_and_storage ... ok
test workflow::tests::state_manager_prunes_to_keep_last_per_phase ... ok
test workflow::tests::state_manager_prunes_legacy_checkpoints_by_inferred_phase ... ok
test services::tests::manual_phase_approval_resume_clears_task_pause_marker ... ok

test result: ok. 361 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.20s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s still need to run on a node/CI before merge.