### PR TITLE
feat(daemon): resume delegated coding runs across restart + liveness-gated node-leak fix (TASK-933/793/811, rc.28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ name = "animus-runtime-shared"
 version = "0.1.0"
 dependencies = [
  "animus-actor",
+ "animus-environment-protocol",
  "animus-plugin-protocol 0.1.18",
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.7.0-rc.27"
+version = "0.7.0-rc.28"
 dependencies = [
  "animus-actor",
  "animus-control-protocol",

--- a/crates/animus-runtime-shared/Cargo.toml
+++ b/crates/animus-runtime-shared/Cargo.toml
@@ -37,6 +37,11 @@ thiserror = "2"
 zstd = "0.13"
 animus-actor             = { workspace = true }
 animus-plugin-protocol   = { workspace = true }
+# TASK-933/793/811: the phase session checkpoint now carries the delegated
+# environment binding (plugin id + prepared-context handle) so a daemon
+# restart can reap/reattach the node by handle instead of leaking it. Only
+# the wire types (`EnvironmentHandle`) are used here — no plugin RPC.
+animus-environment-protocol = { workspace = true }
 orchestrator-plugin-host = { workspace = true }
 
 # When vendored inside the ao-cli workspace this crate uses the in-tree

--- a/crates/animus-runtime-shared/src/phase_session.rs
+++ b/crates/animus-runtime-shared/src/phase_session.rs
@@ -45,6 +45,44 @@ pub struct SessionCheckpoint {
     pub blocked_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request: Option<Value>,
+    /// The delegated environment context this phase is bound to, if any.
+    /// Persisted right after `environment/prepare` succeeds so a daemon
+    /// restart can teardown/reattach the node BY HANDLE instead of leaking
+    /// it. `None` for local (non-delegated) runs.
+    ///
+    /// Backward-compat: `#[serde(default, skip_serializing_if = ...)]` means
+    /// an older out-of-tree runner that does not know this field simply omits
+    /// it on write and (because `SessionCheckpoint` is NOT
+    /// `deny_unknown_fields`) ignores it on read — no runner rebuild is forced
+    /// for schema compatibility. A runner that pre-dates this field will,
+    /// however, DROP it when it rewrites a checkpoint it did not author, so the
+    /// canonical durable write must come from a runner that carries this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentBinding>,
+}
+
+/// The delegated environment context (Railway/container/remote node) a phase
+/// is bound to. Persisted into the phase [`SessionCheckpoint`] the instant
+/// `environment/prepare` returns a handle, so restart reconciliation can reap
+/// (or reattach to) the node by handle rather than leaking it and preparing a
+/// brand-new one on re-dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvironmentBinding {
+    /// Resolved environment plugin id (what `EnvironmentClient::resolve` binds).
+    /// Stored explicitly so a restart knows WHICH environment plugin to talk to
+    /// for teardown/exec — the handle alone does not carry it.
+    pub environment_id: String,
+    /// The full, serializable prepared-context handle (id + workspace_root +
+    /// opaque plugin metadata: container/remote/relay ids). Teardown and
+    /// on-node re-exec are handle-only, so this is sufficient to reap or
+    /// reattach after a restart.
+    pub handle: animus_environment_protocol::EnvironmentHandle,
+    /// RFC3339 timestamp of when the binding was persisted (prepare success).
+    pub bound_at: String,
+    /// Set true after a successful teardown so subsequent reconciliation sweeps
+    /// skip an already-reaped node (idempotent, no double-free).
+    #[serde(default)]
+    pub torn_down: bool,
 }
 
 pub fn phase_session_path(scoped_root: &Path, workflow_id: &str, phase_id: &str) -> PathBuf {
@@ -81,6 +119,7 @@ pub fn write_session_pending(
         completed_at: None,
         blocked_reason: None,
         request,
+        environment: None,
     };
     write_atomic(&path, &checkpoint)?;
     Ok(checkpoint)
@@ -110,6 +149,37 @@ pub fn update_provider_session_id(
     mutate(scoped_root, workflow_id, phase_id, |checkpoint| {
         if checkpoint.provider_session_id.as_deref() != Some(provider_session_id) {
             checkpoint.provider_session_id = Some(provider_session_id.to_string());
+        }
+    })
+}
+
+/// Persist the delegated environment binding for this phase, right after
+/// `environment/prepare` succeeds. Mirrors `update_provider_session_id`: the
+/// canonical caller is the out-of-tree workflow runner (which owns
+/// `scoped_root`/`workflow_id`/`phase_id` for a delegated coding phase and
+/// already writes the pending/running/provider-session-id fields). Once
+/// persisted, daemon restart reconciliation can reap the node by handle
+/// instead of leaking it.
+pub fn update_session_environment(
+    scoped_root: &Path,
+    workflow_id: &str,
+    phase_id: &str,
+    binding: EnvironmentBinding,
+) -> io::Result<()> {
+    mutate(scoped_root, workflow_id, phase_id, |checkpoint| {
+        checkpoint.environment = Some(binding);
+    })
+}
+
+/// Mark the delegated node for this phase as torn down after a successful
+/// `environment/teardown`. Leaves the binding in place (so the handle is still
+/// visible for auditing) but flips `torn_down` so subsequent reconciliation
+/// sweeps do not attempt a second teardown. A no-op if the checkpoint carries
+/// no environment binding.
+pub fn mark_environment_torn_down(scoped_root: &Path, workflow_id: &str, phase_id: &str) -> io::Result<()> {
+    mutate(scoped_root, workflow_id, phase_id, |checkpoint| {
+        if let Some(env) = checkpoint.environment.as_mut() {
+            env.torn_down = true;
         }
     })
 }
@@ -430,5 +500,92 @@ mod tests {
         // And no leftover .tmp siblings.
         let tmp_count = entries.iter().filter(|name| name.to_string_lossy().ends_with(".tmp")).count();
         assert_eq!(tmp_count, 0, "no .tmp siblings should remain after fsync_rename");
+    }
+
+    fn sample_binding() -> EnvironmentBinding {
+        EnvironmentBinding {
+            environment_id: "animus-environment-railway".to_string(),
+            handle: animus_environment_protocol::EnvironmentHandle {
+                id: "node-abc".to_string(),
+                workspace_root: "/work".to_string(),
+                metadata: serde_json::json!({ "railway_service_id": "svc-1", "relay": "wss://relay/x" }),
+            },
+            bound_at: Utc::now().to_rfc3339(),
+            torn_down: false,
+        }
+    }
+
+    // TASK-933: the EnvironmentBinding must survive a full serde round-trip
+    // through the on-disk checkpoint (the whole point is teardown-by-handle
+    // after a restart reads it back), including the opaque handle metadata.
+    #[test]
+    fn environment_binding_round_trips_through_the_checkpoint() {
+        let temp = tempdir().expect("tempdir");
+        let scoped_root = temp.path();
+        write_session_pending(scoped_root, "wf-env-1", "phase-a", "claude", "run-1", None).expect("pending");
+
+        // Freshly-written pending checkpoint has no binding.
+        let cp = read_checkpoint(scoped_root, "wf-env-1", "phase-a").expect("read").expect("present");
+        assert!(cp.environment.is_none(), "a local run carries no environment binding");
+
+        let binding = sample_binding();
+        update_session_environment(scoped_root, "wf-env-1", "phase-a", binding.clone()).expect("persist binding");
+
+        let cp = read_checkpoint(scoped_root, "wf-env-1", "phase-a").expect("read").expect("present");
+        assert_eq!(cp.environment.as_ref(), Some(&binding), "the binding round-trips byte-for-byte");
+        let env = cp.environment.expect("present");
+        assert_eq!(env.handle.id, "node-abc");
+        assert_eq!(
+            env.handle.metadata.pointer("/railway_service_id").and_then(Value::as_str),
+            Some("svc-1"),
+            "opaque handle metadata survives the round-trip"
+        );
+        assert!(!env.torn_down);
+    }
+
+    // TASK-811/933: mark_environment_torn_down flips the flag and is
+    // idempotent (a second call is a harmless no-op), and it never touches a
+    // checkpoint that has no binding.
+    #[test]
+    fn mark_environment_torn_down_is_idempotent_and_binding_gated() {
+        let temp = tempdir().expect("tempdir");
+        let scoped_root = temp.path();
+        write_session_pending(scoped_root, "wf-env-2", "phase-a", "claude", "run-2", None).expect("pending");
+
+        // No binding yet: mark is a silent no-op (does not error, does not
+        // fabricate a binding).
+        mark_environment_torn_down(scoped_root, "wf-env-2", "phase-a").expect("no-op ok");
+        let cp = read_checkpoint(scoped_root, "wf-env-2", "phase-a").expect("read").expect("present");
+        assert!(cp.environment.is_none(), "mark with no binding must not fabricate one");
+
+        update_session_environment(scoped_root, "wf-env-2", "phase-a", sample_binding()).expect("persist");
+        mark_environment_torn_down(scoped_root, "wf-env-2", "phase-a").expect("mark");
+        let cp = read_checkpoint(scoped_root, "wf-env-2", "phase-a").expect("read").expect("present");
+        assert!(cp.environment.as_ref().expect("binding").torn_down, "torn_down set after first mark");
+
+        // Idempotent: a second mark leaves it torn_down, no error, no change.
+        mark_environment_torn_down(scoped_root, "wf-env-2", "phase-a").expect("second mark");
+        let cp = read_checkpoint(scoped_root, "wf-env-2", "phase-a").expect("read").expect("present");
+        assert!(cp.environment.expect("binding").torn_down, "torn_down stays set on the second mark");
+    }
+
+    // Backward-compat: a checkpoint JSON written by an OLDER runner that does
+    // not know the `environment` field must still deserialize (serde ignores
+    // unknown fields; the struct is not deny_unknown_fields), with
+    // environment defaulting to None.
+    #[test]
+    fn legacy_checkpoint_without_environment_field_deserializes() {
+        let legacy = serde_json::json!({
+            "workflow_id": "wf-legacy",
+            "phase_id": "phase-a",
+            "provider": "claude",
+            "run_id": "run-legacy",
+            "status": "running",
+            "started_at": Utc::now().to_rfc3339(),
+        });
+        let cp: SessionCheckpoint =
+            serde_json::from_value(legacy).expect("legacy checkpoint without `environment` must deserialize");
+        assert!(cp.environment.is_none(), "missing environment field defaults to None");
+        assert_eq!(cp.status, SessionCheckpointStatus::Running);
     }
 }

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.7.0-rc.27"
+version = "0.7.0-rc.28"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
@@ -605,6 +605,75 @@ fn run_environment_pipeline(
         }
     };
 
+    run_exec_and_teardown(backend, &handle, command, stdin, timeout, backend_label, events);
+}
+
+/// TASK-933 resume entry: drive a delegated run's harness command against an
+/// ALREADY-PREPARED environment handle, skipping `prepare`. Same thread /
+/// forwarder shape as [`spawn_environment_run`], but the caller supplies the
+/// persisted [`EnvironmentHandle`] (from the phase checkpoint's
+/// `EnvironmentBinding`) instead of preparing a fresh node — so a restart
+/// reconnects to the SAME node (and, when `command` is a provider `--resume`
+/// launch, the same in-flight provider session) rather than materializing a
+/// new one and leaking the old.
+///
+/// This is the on-node resume primitive the out-of-tree workflow runner drives
+/// for a delegated coding phase (the daemon does not run coding phases; see the
+/// module scope note). It is intentionally decoupled from `prepare` so it can be
+/// re-entered idempotently against a live node; the AT-MOST-ONCE exec contract
+/// is respected because a `--resume` launch reattaches to the existing session
+/// rather than re-running side effects.
+#[allow(dead_code)] // resume entrypoint for the companion runner / future ad-hoc resume; validated by unit tests below.
+pub(super) fn spawn_environment_resume(
+    backend: Arc<dyn EnvironmentExecBackend>,
+    handle: EnvironmentHandle,
+    command: HarnessCommand,
+    stdin: Option<String>,
+    timeout: Option<Duration>,
+    backend_label: String,
+) -> SessionRun {
+    let (events_tx, events_rx) = mpsc::channel::<SessionEvent>(256);
+    let (pipeline_tx, mut pipeline_rx) = mpsc::unbounded_channel::<SessionEvent>();
+    tokio::spawn(async move {
+        while let Some(event) = pipeline_rx.recv().await {
+            if events_tx.send(event).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let selected_backend = backend_label.clone();
+    std::thread::spawn(move || {
+        let send = |event: SessionEvent| {
+            let _ = pipeline_tx.send(event);
+        };
+        send(SessionEvent::Started { backend: backend_label.clone(), session_id: None, pid: None });
+        // NO prepare — reuse the persisted handle for exec_stream + teardown.
+        run_exec_and_teardown(backend.as_ref(), &handle, command, stdin, timeout, &backend_label, &pipeline_tx);
+    });
+
+    SessionRun { session_id: None, events: events_rx, selected_backend, fallback_reason: None, pid: None }
+}
+
+/// The exec_stream → teardown → terminal-mapping tail shared by the fresh-run
+/// pipeline ([`run_environment_pipeline`], after `prepare`) and the resume
+/// pipeline ([`spawn_environment_resume`], which skips `prepare`). Emits the
+/// same event grammar in both cases: stdout `TextDelta`s, stderr recoverable
+/// `Error`s, then a terminal `Finished` (or unrecoverable `Error`). Teardown
+/// always runs (idempotent plugin-side); its failure is a recoverable frame.
+fn run_exec_and_teardown(
+    backend: &dyn EnvironmentExecBackend,
+    handle: &EnvironmentHandle,
+    command: HarnessCommand,
+    stdin: Option<String>,
+    timeout: Option<Duration>,
+    backend_label: &str,
+    events: &mpsc::UnboundedSender<SessionEvent>,
+) {
+    let send = |event: SessionEvent| {
+        let _ = events.send(event);
+    };
+
     let stream_events = events.clone();
     let on_output = move |stream: ExecStream, text: &str| {
         let event = match stream {
@@ -614,13 +683,13 @@ fn run_environment_pipeline(
         let _ = stream_events.send(event);
     };
 
-    let result = match backend.exec_stream(&handle, command.clone(), stdin.clone(), timeout, &on_output) {
+    let result = match backend.exec_stream(handle, command.clone(), stdin.clone(), timeout, &on_output) {
         // A plugin without exec_stream support answers METHOD_NOT_SUPPORTED
         // before the command ever starts, so retrying with the buffered exec
         // is safe (no double-execution risk). The aggregated output is then
         // emitted once, post-hoc — deltas were never streamed.
         Err(err) if is_method_not_supported(&err) => {
-            backend.exec(&handle, command, stdin, timeout).inspect(|response| {
+            backend.exec(handle, command, stdin, timeout).inspect(|response| {
                 if !response.stdout.is_empty() {
                     send(SessionEvent::FinalText { text: response.stdout.clone() });
                 }
@@ -634,7 +703,7 @@ fn run_environment_pipeline(
 
     // Teardown regardless of exec outcome; a teardown failure is surfaced as a
     // recoverable frame (the run's verdict is the exec result, not cleanup).
-    if let Err(err) = backend.teardown(&handle) {
+    if let Err(err) = backend.teardown(handle) {
         send(SessionEvent::Error {
             message: format!("environment teardown failed for {backend_label} (handle {}): {err:#}", handle.id),
             recoverable: true,
@@ -1350,6 +1419,48 @@ environment_routing:
             "a signal-killed command must not be reported as success: {events:?}"
         );
         assert!(backend.torn_down.load(Ordering::SeqCst));
+    }
+
+    // TASK-933: the resume entry re-enters at exec_stream against a
+    // PRE-EXISTING handle, skipping prepare, and still streams deltas + tears
+    // down. `prepare` must NEVER be called on the resume path (the node already
+    // exists; preparing a fresh one is the leak this fixes).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_reuses_the_handle_without_preparing_a_new_node() {
+        let backend = Arc::new(FakeBackend::new());
+        // Arm prepare to PANIC if the resume path ever calls it.
+        *backend.prepare_result.lock().unwrap() = Some(Err(anyhow!("prepare must not be called on resume")));
+        *backend.exec_stream_outcome.lock().unwrap() = Some(StreamOutcome::Deltas(
+            vec![(ExecStream::Stdout, "resumed-out".to_string())],
+            Ok(ok_response(0)),
+        ));
+
+        let run = spawn_environment_resume(
+            backend.clone(),
+            sample_handle(),
+            command_for_test(),
+            None,
+            None,
+            "environment:container".to_string(),
+        );
+        assert_eq!(run.selected_backend, "environment:container");
+        let events = drain(run).await;
+
+        assert_eq!(backend.exec_calls.load(Ordering::SeqCst), 0, "no buffered-exec fallback on a clean exec_stream");
+        assert!(
+            events.iter().any(|e| matches!(e, SessionEvent::TextDelta { text } if text == "resumed-out")),
+            "resume streams stdout deltas through the same channel: {events:?}"
+        );
+        assert!(
+            matches!(events.last(), Some(SessionEvent::Finished { exit_code: Some(0) })),
+            "resume terminates with the exec exit code: {events:?}"
+        );
+        assert!(backend.torn_down.load(Ordering::SeqCst), "resume tears the node down after exec");
+        // The prepare stub was never consumed -> prepare was never called.
+        assert!(
+            backend.prepare_result.lock().unwrap().is_some(),
+            "prepare must not be invoked on the resume path (the node already exists)"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
@@ -1430,10 +1430,8 @@ environment_routing:
         let backend = Arc::new(FakeBackend::new());
         // Arm prepare to PANIC if the resume path ever calls it.
         *backend.prepare_result.lock().unwrap() = Some(Err(anyhow!("prepare must not be called on resume")));
-        *backend.exec_stream_outcome.lock().unwrap() = Some(StreamOutcome::Deltas(
-            vec![(ExecStream::Stdout, "resumed-out".to_string())],
-            Ok(ok_response(0)),
-        ));
+        *backend.exec_stream_outcome.lock().unwrap() =
+            Some(StreamOutcome::Deltas(vec![(ExecStream::Stdout, "resumed-out".to_string())], Ok(ok_response(0))));
 
         let run = spawn_environment_resume(
             backend.clone(),

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -340,7 +340,10 @@ const PROBE_EXEC_TIMEOUT: Duration = Duration::from_secs(10);
 /// transport (`ConnectionLost` / `ProcessExited`) is an unambiguous death.
 fn probe_error_is_transient(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
-        matches!(cause.downcast_ref::<orchestrator_plugin_host::HostError>(), Some(orchestrator_plugin_host::HostError::Timeout(_)))
+        matches!(
+            cause.downcast_ref::<orchestrator_plugin_host::HostError>(),
+            Some(orchestrator_plugin_host::HostError::Timeout(_))
+        )
     })
 }
 
@@ -1740,8 +1743,7 @@ mod tests {
     // -----------------------------------------------------------------
 
     use animus_runtime_shared::phase_session::{
-        read_checkpoint, update_session_environment, write_session_pending, EnvironmentBinding,
-        SessionCheckpointStatus,
+        read_checkpoint, update_session_environment, write_session_pending, EnvironmentBinding, SessionCheckpointStatus,
     };
 
     fn sample_binding(node_id: &str) -> EnvironmentBinding {
@@ -1794,7 +1796,9 @@ mod tests {
             let n = calls.get();
             calls.set(n + 1);
             if n == 0 {
-                Err(anyhow::Error::from(orchestrator_plugin_host::HostError::Timeout(std::time::Duration::from_secs(10))))
+                Err(anyhow::Error::from(orchestrator_plugin_host::HostError::Timeout(std::time::Duration::from_secs(
+                    10,
+                ))))
             } else {
                 Ok(ok_probe_response())
             }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -1,14 +1,19 @@
 use super::*;
 use crate::services::runtime::execution_fact_projection::project_terminal_workflow_result;
 use crate::services::runtime::workflow_mutation_surface::cancel_orphaned_running_workflow;
+use animus_environment_protocol::{ExecResponse, HarnessCommand};
+use animus_runtime_shared::phase_session::{
+    mark_environment_torn_down, read_checkpoint, update_session_failed, EnvironmentBinding,
+};
 use anyhow::Result;
 use orchestrator_core::{
     active_workflow_runner_ids, dispatch_workflow_event, load_agent_runtime_config_or_default, services::ServiceHub,
-    workflow_runner_liveness, OrchestratorWorkflow, RunnerLiveness, WorkflowConfig, WorkflowEvent,
+    workflow_runner_liveness, EnvironmentClient, OrchestratorWorkflow, RunnerLiveness, WorkflowConfig, WorkflowEvent,
     WorkflowMachineState, WorkflowStatus,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
 /// Grace period after a workflow's `started_at` before the orphan
@@ -59,6 +64,9 @@ enum ReconcileDecision {
     ProtectedActiveSubject,
     /// Skipped because it is delegated to a live remote (environment) node.
     SkippedDelegated,
+    /// TASK-793/811: delegated to a remote node whose persisted handle probed
+    /// DEAD — terminalize the ghost (reap node + fail checkpoint + cancel).
+    TerminalizeDeadDelegate,
     /// Not yet actionable: still inside the `started_at` grace window.
     WithinGrace,
     /// Preserved (not cancelled) for journal resume — it has a phase boundary.
@@ -85,6 +93,7 @@ impl ReconcileDecision {
             ReconcileDecision::ProtectedLiveRunner => "protected-live-runner",
             ReconcileDecision::ProtectedActiveSubject => "protected-active-subject",
             ReconcileDecision::SkippedDelegated => "skipped-delegated",
+            ReconcileDecision::TerminalizeDeadDelegate => "terminalize-dead-delegate",
             ReconcileDecision::WithinGrace => "within-grace",
             ReconcileDecision::PreservedResumable => "preserved-resumable",
             ReconcileDecision::RedispatchCandidate => "redispatch-candidate",
@@ -102,6 +111,7 @@ impl ReconcileDecision {
             self,
             ReconcileDecision::CancelledOrphan
                 | ReconcileDecision::SkippedDelegated
+                | ReconcileDecision::TerminalizeDeadDelegate
                 | ReconcileDecision::RedispatchCandidate
         )
     }
@@ -248,6 +258,204 @@ pub(crate) fn journal_resume_enabled(project_root: &str) -> bool {
 /// fallback; only a run with no phase boundary at all is cancelled.
 fn is_resumable_orphan(workflow: &OrchestratorWorkflow) -> bool {
     workflow.current_phase.is_some() || workflow.phases.get(workflow.current_phase_index).is_some()
+}
+
+// ---------------------------------------------------------------------------
+// TASK-933 / TASK-793 / TASK-811: liveness-REFINED delegated reconciliation.
+//
+// rc.24 (`is_delegated_run`) skips a delegated run by ROUTING INTENT: if config
+// routes the workflow to a non-local environment, the sweep leaves it alone
+// because "the node owns its liveness". rc.24's own commit names the gap
+// (TASK-793): a delegated run whose node DIED between prepare and exec is then
+// preserved as a phantom `Running` lease forever, and its node leaks.
+//
+// This block REFINES that intent-based skip with the node's ACTUAL liveness,
+// read off the `EnvironmentBinding` the out-of-tree runner persists into the
+// phase session checkpoint the instant `environment/prepare` succeeds (the
+// daemon never runs a coding phase itself — see `environment_exec.rs`). The two
+// compose into ONE gate, not two parallel skips:
+//   * intent says "delegated"  -> rc.24's `is_delegated_run` selects the run;
+//   * a persisted binding lets us PROBE the node:
+//       - Alive / Unknown / no-binding -> keep rc.24's skip (preserve),
+//       - Dead (past grace)            -> terminalize the ghost + reap the node.
+//
+// Backward-compat: until the companion runner persists a binding,
+// `current_delegate_binding` returns `None`, `delegate_is_dead` is always
+// `false`, and the decision stays exactly rc.24's `SkippedDelegated`. There is
+// no behavior change for any run until the binding exists.
+// ---------------------------------------------------------------------------
+
+/// The workflow's current phase id (explicit `current_phase`, else the phase at
+/// `current_phase_index`).
+fn current_phase_id(workflow: &OrchestratorWorkflow) -> Option<String> {
+    workflow
+        .current_phase
+        .clone()
+        .or_else(|| workflow.phases.get(workflow.current_phase_index).map(|phase| phase.phase_id.clone()))
+}
+
+/// Load the delegated environment binding for a workflow's current phase, if
+/// its session checkpoint carries one that has NOT already been torn down.
+/// Returns `(phase_id, binding)`. `None` for a local run, a missing/unreadable
+/// checkpoint, or an already-reaped node — all "nothing to do".
+fn current_delegate_binding(
+    scoped_root: &Path,
+    workflow: &OrchestratorWorkflow,
+) -> Option<(String, EnvironmentBinding)> {
+    let phase_id = current_phase_id(workflow)?;
+    let checkpoint = read_checkpoint(scoped_root, &workflow.id, &phase_id).ok()??;
+    let binding = checkpoint.environment.filter(|binding| !binding.torn_down)?;
+    Some((phase_id, binding))
+}
+
+/// Liveness of a delegated node, as observed by a trivial exec probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DelegateLiveness {
+    /// The node answered a trivial exec — it is up and reusable.
+    Alive,
+    /// The node/plugin failed every probe with a definitive death signal.
+    Dead,
+    /// Could not verify (unresolvable plugin, or consistently-transient
+    /// failure). Fail safe — never destroy work we cannot confirm is lost.
+    Unknown,
+}
+
+/// Number of probe attempts before a delegated node is declared dead. A single
+/// success at ANY attempt => Alive; only ALL attempts failing terminalizes the
+/// node. This absorbs a transient relay/RPC blip (or a one-off timeout) against
+/// a genuinely-live node during restart reconciliation, which would otherwise
+/// false-kill an in-flight coding job — the exact work-loss this feature exists
+/// to prevent.
+const PROBE_ATTEMPTS: usize = 3;
+
+/// Delay between failed probe attempts.
+const PROBE_RETRY_DELAY: Duration = Duration::from_millis(750);
+
+/// Per-attempt exec-probe timeout.
+const PROBE_EXEC_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Whether a probe error looks like a TRANSIENT transport blip (node maybe
+/// alive but slow) rather than a definitive "node is gone" signal. Mirrors
+/// `EnvironmentClient::ping_is_dead`: a `Timeout` is busy/alive; a closed
+/// transport (`ConnectionLost` / `ProcessExited`) is an unambiguous death.
+fn probe_error_is_transient(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(cause.downcast_ref::<orchestrator_plugin_host::HostError>(), Some(orchestrator_plugin_host::HostError::Timeout(_)))
+    })
+}
+
+/// Probe a delegated node's liveness via a trivial, side-effect-free `exec` of
+/// `true`, RETRIED up to [`PROBE_ATTEMPTS`] times: the first success => Alive;
+/// an unresolvable plugin => Unknown; all attempts failing => Unknown when the
+/// last failure looked transient (preserve + re-probe next sweep), else Dead.
+fn probe_delegate(project_root: &str, binding: &EnvironmentBinding) -> DelegateLiveness {
+    let client = match EnvironmentClient::resolve(Path::new(project_root), &binding.environment_id) {
+        Ok(client) => client,
+        Err(_) => return DelegateLiveness::Unknown,
+    };
+    probe_liveness_with_retry(PROBE_ATTEMPTS, PROBE_RETRY_DELAY, || {
+        let probe =
+            HarnessCommand { program: "true".to_string(), args: Vec::new(), env: Default::default(), cwd: None };
+        client.exec(&binding.handle, probe, Default::default(), None, Some(PROBE_EXEC_TIMEOUT))
+    })
+}
+
+/// Retry loop for [`probe_delegate`], factored out with an injectable exec
+/// producer so the retry/backoff semantics are unit-testable without a live
+/// plugin. `Alive` on the first `Ok`; after all attempts fail, `Unknown` when
+/// the LAST failure looked transient, else `Dead`.
+fn probe_liveness_with_retry<F>(attempts: usize, retry_delay: Duration, mut exec_probe: F) -> DelegateLiveness
+where
+    F: FnMut() -> anyhow::Result<ExecResponse>,
+{
+    let mut last_error_transient = false;
+    for attempt in 0..attempts {
+        match exec_probe() {
+            Ok(_) => return DelegateLiveness::Alive,
+            Err(err) => {
+                last_error_transient = probe_error_is_transient(&err);
+                if attempt + 1 < attempts && !retry_delay.is_zero() {
+                    std::thread::sleep(retry_delay);
+                }
+            }
+        }
+    }
+    if last_error_transient {
+        DelegateLiveness::Unknown
+    } else {
+        DelegateLiveness::Dead
+    }
+}
+
+/// TASK-793: whether an intent-delegated run's persisted node has DEFINITIVELY
+/// died. `true` ONLY when a binding exists AND the probe returns `Dead`; a
+/// missing binding, an alive node, or an unverifiable one all return `false`
+/// (keep rc.24's skip). Callers must additionally require past-grace before
+/// terminalizing, so a just-started delegate is never reaped.
+fn delegate_is_dead(scoped_root: Option<&Path>, project_root: &str, workflow: &OrchestratorWorkflow) -> bool {
+    let Some(scoped_root) = scoped_root else { return false };
+    let Some((_, binding)) = current_delegate_binding(scoped_root, workflow) else { return false };
+    probe_delegate(project_root, &binding) == DelegateLiveness::Dead
+}
+
+/// Reap the delegated node bound to a workflow's current phase, by its
+/// persisted handle. Idempotent: teardown is dispose-by-id (a no-op if already
+/// gone), and `mark_environment_torn_down` is only written on success, so a
+/// failed reap is retried on the next sweep. Inert when there is no
+/// (un-torn-down) binding.
+fn teardown_delegated_node(project_root: &str, scoped_root: Option<&Path>, workflow: &OrchestratorWorkflow) {
+    let Some(scoped_root) = scoped_root else { return };
+    let Some((phase_id, binding)) = current_delegate_binding(scoped_root, workflow) else { return };
+    match EnvironmentClient::resolve(Path::new(project_root), &binding.environment_id) {
+        Ok(client) => match client.teardown(&binding.handle) {
+            Ok(()) => {
+                let _ = mark_environment_torn_down(scoped_root, &workflow.id, &phase_id);
+                info!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %workflow.id,
+                    node = %binding.handle.id,
+                    "reaped delegated node by persisted handle during orphan reconciliation"
+                );
+            }
+            Err(error) => warn!(
+                actor = protocol::ACTOR_DAEMON,
+                workflow_id = %workflow.id,
+                node = %binding.handle.id,
+                %error,
+                "env teardown of delegated node failed; will retry on the next sweep"
+            ),
+        },
+        Err(error) => warn!(
+            actor = protocol::ACTOR_DAEMON,
+            workflow_id = %workflow.id,
+            environment = %binding.environment_id,
+            %error,
+            "cannot resolve environment plugin to reap delegated node; will retry on the next sweep"
+        ),
+    }
+}
+
+/// TASK-811: drive a DEAD delegation ghost to a terminal state — reap the node
+/// by handle, fail the phase checkpoint so it never re-surfaces for auto-resume
+/// (`list_running_checkpoints` only yields `Running`), and cancel the workflow
+/// via the existing orphan-cancel path (so downstream terminal projections fire
+/// identically to a normal orphan cancel). Returns whether the workflow was
+/// cancelled.
+async fn terminalize_dead_delegation(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    scoped_root: &Path,
+    workflow: &OrchestratorWorkflow,
+) -> bool {
+    let phase_id = current_phase_id(workflow).unwrap_or_default();
+    teardown_delegated_node(project_root, Some(scoped_root), workflow);
+    let _ = update_session_failed(
+        scoped_root,
+        &workflow.id,
+        &phase_id,
+        "delegated environment node died before exec; terminalized by orphan reconciler (TASK-811)",
+    );
+    cancel_orphaned_running_workflow(hub, project_root, workflow).await
 }
 
 /// Normalize a subject id to its BARE form by stripping a leading `kind:`
@@ -469,6 +677,10 @@ pub async fn recover_orphaned_running_workflows(
     // Compare a node's BARE upstream-journaled subject against the delegating
     // runner's QUALIFIED active id (see `bare_subject_id`).
     let active_subject_bare: HashSet<&str> = active_subject_ids.iter().map(|s| bare_subject_id(s)).collect();
+    // TASK-933/793/811: the delegated-node binding lives in the scoped session
+    // checkpoints. `None` (no scope) => every delegate helper is inert and the
+    // sweep behaves exactly as rc.24.
+    let scoped_root = protocol::scoped_state_root(Path::new(project_root));
 
     let mut recovered = 0usize;
     let mut evaluated = 0usize;
@@ -506,7 +718,16 @@ pub async fn recover_orphaned_running_workflows(
         } else if in_active_subjects {
             ReconcileDecision::ProtectedActiveSubject
         } else if is_delegated {
-            ReconcileDecision::SkippedDelegated
+            // TASK-793: refine rc.24's intent-based skip with the node's ACTUAL
+            // liveness. Only a delegate PAST GRACE whose persisted node probes
+            // DEAD is terminalized; alive / unverifiable / no-binding (and any
+            // within-grace delegate) keep rc.24's skip. `delegate_is_dead` is
+            // inert (false) until the companion runner persists a binding.
+            if !within_grace && delegate_is_dead(scoped_root.as_deref(), project_root, &workflow) {
+                ReconcileDecision::TerminalizeDeadDelegate
+            } else {
+                ReconcileDecision::SkippedDelegated
+            }
         } else if within_grace {
             ReconcileDecision::WithinGrace
         } else if resume_orphans && resumable {
@@ -545,6 +766,28 @@ pub async fn recover_orphaned_running_workflows(
                     "skipping orphan sweep for delegated/environment-bound run"
                 );
             }
+            ReconcileDecision::TerminalizeDeadDelegate => {
+                // TASK-793/811: the delegate's node probed dead — reap it, fail
+                // the checkpoint, and cancel the workflow so it never re-surfaces
+                // as a phantom Running lease.
+                warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %workflow.id,
+                    workflow_ref = workflow.workflow_ref.as_deref().unwrap_or_default(),
+                    "delegated node probed dead; terminalizing ghost + reaping node (TASK-793/811)"
+                );
+                if let Some(scoped_root) = scoped_root.as_deref() {
+                    if terminalize_dead_delegation(hub.clone(), project_root, scoped_root, &workflow).await {
+                        recovered = recovered.saturating_add(1);
+                    } else {
+                        error!(
+                            actor = protocol::ACTOR_DAEMON,
+                            workflow_id = %workflow.id,
+                            "failed to cancel dead delegated workflow"
+                        );
+                    }
+                }
+            }
             ReconcileDecision::MergeConflict
             | ReconcileDecision::WaitingManual
             | ReconcileDecision::WithinGrace
@@ -577,6 +820,11 @@ pub async fn recover_orphaned_running_workflows(
                     task_id = %workflow.task_id,
                     "recovering orphaned running workflow"
                 );
+                // HALF A leak-killer: reap any persisted delegated node BEFORE
+                // cancel so an orphan (e.g. a dead delegate handled at startup,
+                // where intent-gating is off) does not leak its node. Inert for
+                // local runs and until the companion runner persists a binding.
+                teardown_delegated_node(project_root, scoped_root.as_deref(), &workflow);
                 let cancelled = cancel_orphaned_running_workflow(hub.clone(), project_root, &workflow).await;
                 if cancelled {
                     recovered = recovered.saturating_add(1);
@@ -828,13 +1076,17 @@ pub(crate) async fn resumable_orphans_for_redispatch(
                 selected += 1;
                 candidates.push(workflow);
             }
-            // All other outcomes exclude the run from re-dispatch (no-op).
+            // All other outcomes exclude the run from re-dispatch (no-op). A
+            // dead delegate is terminalized by the cancel leg (which sets it
+            // Cancelled, so it never reaches this Running-only leg); the variant
+            // is matched exhaustively but never arises here.
             ReconcileDecision::MergeConflict
             | ReconcileDecision::WaitingManual
             | ReconcileDecision::SkippedLiveOrphan
             | ReconcileDecision::SkippedBlockedResume
             | ReconcileDecision::WithinGrace
             | ReconcileDecision::NotResumable
+            | ReconcileDecision::TerminalizeDeadDelegate
             | ReconcileDecision::PreservedResumable
             | ReconcileDecision::CancelledOrphan => {}
         }
@@ -1481,6 +1733,216 @@ mod tests {
         assert_eq!(recovered, 0, "paused workflows must be exempt from orphan recovery");
         let reloaded = hub.workflows().get(&workflow.id).await.expect("workflow should reload");
         assert_eq!(reloaded.status, WorkflowStatus::Paused);
+    }
+
+    // -----------------------------------------------------------------
+    // TASK-933 / TASK-793 / TASK-811: liveness-refined delegated reconciliation
+    // -----------------------------------------------------------------
+
+    use animus_runtime_shared::phase_session::{
+        read_checkpoint, update_session_environment, write_session_pending, EnvironmentBinding,
+        SessionCheckpointStatus,
+    };
+
+    fn sample_binding(node_id: &str) -> EnvironmentBinding {
+        EnvironmentBinding {
+            environment_id: "animus-environment-railway".to_string(),
+            handle: animus_environment_protocol::EnvironmentHandle {
+                id: node_id.to_string(),
+                workspace_root: "/work".to_string(),
+                metadata: serde_json::json!({ "railway_service_id": "svc-1" }),
+            },
+            bound_at: chrono::Utc::now().to_rfc3339(),
+            torn_down: false,
+        }
+    }
+
+    /// Write a Running session checkpoint carrying `binding` for the workflow's
+    /// current phase; returns the scoped root + phase id.
+    async fn bind_delegate(
+        hub: &Arc<dyn ServiceHub>,
+        project_root: &str,
+        workflow_id: &str,
+        binding: EnvironmentBinding,
+    ) -> (std::path::PathBuf, String) {
+        let workflow = hub.workflows().get(workflow_id).await.expect("workflow loads");
+        let phase_id = super::current_phase_id(&workflow).expect("fixture workflow has a current phase");
+        let scoped_root =
+            protocol::scoped_state_root(std::path::Path::new(project_root)).expect("git-repo project has a scope");
+        write_session_pending(&scoped_root, workflow_id, &phase_id, "claude", "run-delegated", None)
+            .expect("write pending checkpoint");
+        update_session_environment(&scoped_root, workflow_id, &phase_id, binding).expect("persist binding");
+        (scoped_root, phase_id)
+    }
+
+    fn ok_probe_response() -> animus_environment_protocol::ExecResponse {
+        animus_environment_protocol::ExecResponse {
+            exit_code: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+        }
+    }
+
+    // Hardening: a live node that blips once (or twice) then answers is Alive —
+    // the retry absorbs a transient failure, never false-killing in-flight work.
+    #[test]
+    fn probe_retry_treats_a_transient_blip_then_success_as_alive() {
+        use std::cell::Cell;
+        let calls = Cell::new(0usize);
+        let liveness = super::probe_liveness_with_retry(3, std::time::Duration::ZERO, || {
+            let n = calls.get();
+            calls.set(n + 1);
+            if n == 0 {
+                Err(anyhow::Error::from(orchestrator_plugin_host::HostError::Timeout(std::time::Duration::from_secs(10))))
+            } else {
+                Ok(ok_probe_response())
+            }
+        });
+        assert_eq!(liveness, super::DelegateLiveness::Alive, "a live node that blips once must not be terminalized");
+        assert_eq!(calls.get(), 2, "probe retried once, then succeeded");
+    }
+
+    // A genuinely-gone node fails EVERY attempt with a definitive death signal
+    // (closed transport) => Dead.
+    #[test]
+    fn probe_retry_all_attempts_fail_definitively_is_dead() {
+        use std::cell::Cell;
+        let calls = Cell::new(0usize);
+        let liveness = super::probe_liveness_with_retry(3, std::time::Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            Err(anyhow::Error::from(orchestrator_plugin_host::HostError::ConnectionLost))
+        });
+        assert_eq!(liveness, super::DelegateLiveness::Dead, "a node whose transport is closed on all attempts is dead");
+        assert_eq!(calls.get(), 3, "all three attempts were exhausted before declaring Dead");
+    }
+
+    // A node that TIMES OUT on every attempt (busy/slow but maybe alive) leans
+    // to Unknown => preserve, never Dead.
+    #[test]
+    fn probe_retry_all_attempts_time_out_is_unknown_fail_safe() {
+        let liveness = super::probe_liveness_with_retry(3, std::time::Duration::ZERO, || {
+            Err(anyhow::Error::from(orchestrator_plugin_host::HostError::Timeout(std::time::Duration::from_secs(10))))
+        });
+        assert_eq!(
+            liveness,
+            super::DelegateLiveness::Unknown,
+            "a consistently-timing-out node fails safe to Unknown (preserve), never Dead"
+        );
+    }
+
+    // current_delegate_binding yields an UN-TORN-DOWN binding only.
+    #[tokio::test]
+    async fn current_delegate_binding_reads_untorn_binding_only() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
+
+        let scoped_root = protocol::scoped_state_root(std::path::Path::new(&project_root)).expect("scope");
+        assert!(super::current_delegate_binding(&scoped_root, &workflow).is_none(), "no checkpoint => no binding");
+
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-live")).await;
+        let (got_phase, got_binding) =
+            super::current_delegate_binding(&scoped_root, &workflow).expect("live binding present");
+        assert_eq!(got_phase, phase_id);
+        assert_eq!(got_binding.handle.id, "node-live");
+
+        animus_runtime_shared::phase_session::mark_environment_torn_down(&scoped_root, &workflow_id, &phase_id)
+            .expect("mark torn down");
+        assert!(
+            super::current_delegate_binding(&scoped_root, &workflow).is_none(),
+            "an already-reaped node is not returned again"
+        );
+    }
+
+    // TASK-793 refinement: an intent-delegated run (config routes it remote)
+    // whose node liveness cannot be verified (no plugin installed => probe
+    // Unknown) is STILL skipped/preserved — the liveness gate refines rc.24's
+    // skip without ever false-killing a delegate it cannot confirm is dead.
+    #[tokio::test]
+    async fn intent_delegated_run_with_unverifiable_node_is_still_preserved() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+
+        // Make the run intent-delegated (rc.24 gate) by binding its workflow to a
+        // remote environment in config.
+        let workflow_ref = hub
+            .workflows()
+            .get(&workflow_id)
+            .await
+            .expect("workflow loads")
+            .workflow_ref
+            .expect("fixture run carries a workflow_ref");
+        let _env_guard = rebind_config_base(&temp, |base| {
+            for workflow in &mut base.workflows {
+                if workflow.id == workflow_ref {
+                    workflow.environment = Some("railway".to_string());
+                }
+            }
+        });
+        // Persist a binding, but no environment plugin is installed => probe
+        // resolve fails => Unknown => NOT dead => stays SkippedDelegated.
+        bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-unverifiable")).await;
+
+        let recovered =
+            recover_orphaned_running_workflows(hub.clone(), &project_root, &HashSet::new(), false, true).await;
+        assert_eq!(recovered, 0, "an unverifiable delegate must be preserved, never terminalized");
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow reloads");
+        assert_eq!(reloaded.status, WorkflowStatus::Running, "unverifiable delegate stays Running");
+    }
+
+    // TASK-811: terminalize_dead_delegation drives the checkpoint Failed (so it
+    // never re-surfaces for auto-resume) and cancels the workflow.
+    #[tokio::test]
+    async fn terminalize_dead_delegation_fails_checkpoint_and_cancels_workflow() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-dead")).await;
+        let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
+
+        let cancelled = super::terminalize_dead_delegation(hub.clone(), &project_root, &scoped_root, &workflow).await;
+        assert!(cancelled, "terminalize cancels the workflow");
+
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert_eq!(
+            checkpoint.status,
+            SessionCheckpointStatus::Failed,
+            "dead delegation ghost's checkpoint is failed so it never re-surfaces for resume"
+        );
+        let reloaded = hub.workflows().get(&workflow_id).await.expect("workflow reloads");
+        assert_eq!(reloaded.status, WorkflowStatus::Cancelled, "the dead delegation ghost's workflow is terminalized");
+    }
+
+    // teardown_delegated_node is a safe no-op with no scope, no checkpoint, or an
+    // already-torn-down binding (idempotent; never errors, never double-reaps).
+    #[tokio::test]
+    async fn teardown_delegated_node_is_inert_without_a_live_binding() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
+
+        super::teardown_delegated_node(&project_root, None, &workflow);
+        let scoped_root = protocol::scoped_state_root(std::path::Path::new(&project_root)).expect("scope");
+        super::teardown_delegated_node(&project_root, Some(&scoped_root), &workflow);
+
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-gone")).await;
+        animus_runtime_shared::phase_session::mark_environment_torn_down(&scoped_root, &workflow_id, &phase_id)
+            .expect("mark torn down");
+        super::teardown_delegated_node(&project_root, Some(&scoped_root), &workflow);
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(
+            checkpoint.environment.expect("binding present").torn_down,
+            "an already-reaped binding stays torn_down (no double-free)"
+        );
     }
 }
 

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -460,6 +460,25 @@ where
         Err(_) => return report,
     };
     for (_path, checkpoint) in running {
+        // TASK-933: a DELEGATED coding phase's provider session lives INSIDE the
+        // remote node prepared by an `environment` plugin, NOT in a local
+        // provider plugin. The daemon must not try to resume it against a local
+        // plugin — that plugin never issued the session id and would reject it,
+        // mis-blocking the checkpoint with a misleading reinstall hint. Leave it
+        // Running so the companion runner re-dispatch reuses the node (skip
+        // prepare + `--resume` on the live handle); a dead node was already
+        // terminalized by `recover_orphaned_running_workflows`. This branch is
+        // inert until the companion runner persists `environment` (the field is
+        // `None` for every local run and for every runner without the change).
+        if checkpoint.environment.is_some() {
+            tracing::info!(
+                actor = protocol::ACTOR_DAEMON,
+                workflow_id = %checkpoint.workflow_id,
+                phase_id = %checkpoint.phase_id,
+                "delegated phase: skipping local provider resume; preserved for runner re-dispatch to reuse the node (TASK-933)"
+            );
+            continue;
+        }
         // Guard rail: provider plugins can only resume an external session
         // they themselves issued. If no provider_session_id was captured
         // before the daemon crashed, dispatching ANY id (the run_id, an


### PR DESCRIPTION
Re-based #345 onto the correct prod line. **Base: `fix/v0.7/orphan-sweep-skip-delegated` (orchestrator-cli rc.27).** The old #345 was cut from `release/0.7` (rc.14, 13 rc's behind prod) and would have regressed prod. Bumps rc.27 → **rc.28**.

## How this reconciles with rc.24's `skip_live_delegated` (d507466d / TASK-750)

rc.24 stops the orphan sweep from reaping in-flight delegated runs by adding a `skip_live_delegated` flag: a run whose config routing resolves to a non-local environment (`is_delegated_run` = `resolve_environment` + `!is_local_environment`) is skipped by **routing INTENT** ("the node owns its liveness"). rc.24's own commit names the gap it left for me:

> *Known limitation (TASK-793): the skip is by routing INTENT, not live-vs-dead delegate liveness.*

**The exact relationship:** rc.24's intent skip and my TASK-793 gate are **composed into ONE gate, not two parallel skips.**
- rc.24's `is_delegated_run` still **selects** which runs are delegated (unchanged).
- Where rc.24 unconditionally emitted `SkippedDelegated`, I now refine with the node's **actual liveness**, read off the `EnvironmentBinding` the companion runner persists into the phase checkpoint:
  - **no binding / Alive / Unknown / within-grace** → keep rc.24's `SkippedDelegated` (preserve);
  - **past-grace + Dead** → new `TerminalizeDeadDelegate` → `terminalize_dead_delegation` (reap node by handle + fail checkpoint + cancel workflow).

So a delegated run whose node died between prepare and exec — which rc.24 would preserve as a phantom `Running` lease forever, leaking the node — is now terminalized and reaped. This is exactly the refinement rc.24's observability (`reconcile-decision` lines) was added to enable. There is no second skip mechanism; `is_delegated` is the single delegation classifier and the liveness probe only decides skip-vs-terminalize within it.

**Conflict resolution:** the only conflicting file was `daemon_reconciliation.rs`. I took rc.27's version wholesale and hand-integrated my logic into rc.24's `ReconcileDecision` cascade (added one variant `TerminalizeDeadDelegate` + its label/`always_emit`/exhaustive-match arms), so rc.24's observability, precedence, `skip_live_delegated` semantics, config-outage suppression, and all its tests are preserved intact. My other files (`phase_session.rs`, `environment_exec.rs`, `daemon_run.rs`, runtime-shared `Cargo.toml`) were untouched by rc.14→rc.27 and applied cleanly.

## Was any of my logic already covered by rc.15–rc.27?

- **rc.24 (d507466d)** already added the delegated-skip + `reconcile-decision`/`reconcile-sweep` observability. I did **not** re-introduce or duplicate it — I refined its `SkippedDelegated` outcome. My earlier standalone `classify_delegate`/`DelegateDecision` from #345 were **dropped** in favor of composing with rc.24's `is_delegated`.
- **rc.24/rc.25 (62ddd0d8, e88bc0d7)** added the cross-phase environment broker (`reap_prior_daemon_records` at boot, workflow-level env sharing). My HALF A `teardown_delegated_node` on the cancel path is complementary defense-in-depth (idempotent, by-persisted-handle) and does not overlap the broker's boot reap.
- **rc.27 (31fd05c1)** bare-vs-qualified subject-id normalization — untouched, still in effect.
- Nothing in rc.15–rc.27 provides the persisted `EnvironmentBinding`, the node-liveness probe, or the terminalize-dead path, so no other part of my change was redundant.

## What changed (per task)

- **HALF A**: `SessionCheckpoint.environment: Option<EnvironmentBinding>` + `update_session_environment`/`mark_environment_torn_down` (animus-runtime-shared, dep on animus-environment-protocol); `teardown_delegated_node` reaps by handle before the CancelledOrphan path.
- **TASK-793**: `probe_delegate` (3× retry: transient blip → Alive, all-timeout → Unknown fail-safe, definitive closed-transport → Dead) gates rc.24's skip; `delegate_is_dead` folds it into the `is_delegated` cascade arm.
- **TASK-811**: `TerminalizeDeadDelegate` decision → `terminalize_dead_delegation` (reap + fail checkpoint + cancel).
- **HALF B (933)**: `spawn_environment_resume` primitive (skip-prepare exec_stream on a live handle) for the companion runner; `auto_resume_running_checkpoints` skips delegated checkpoints (their provider session lives on the node, not a local plugin). Redispatch leg unchanged (a dead delegate is terminalized by the cancel leg → Cancelled → excluded).

## Backward-compat / inertness

`SessionCheckpoint.environment` is `#[serde(default, skip_serializing_if="Option::is_none")]`; the struct is not `deny_unknown_fields`. Until the companion runner persists a binding, `current_delegate_binding` returns `None`, `delegate_is_dead` is always `false`, and every run's decision is exactly rc.24's. No behavior change for local runs or today's runner; no runner rebuild forced for schema compat.

## Companion runner PR: still REQUIRED

The daemon reconciles from `SessionCheckpoint.environment`, which only a runner calling `update_session_environment` on `environment/prepare` success writes. Until then all four halves are inert. Serde compat lets the two land independently.

## Build / test / clippy (re-verified on the rc.27 line)

```
cargo build  -p animus-runtime-shared -p orchestrator-cli   # Finished, 0 errors
cargo test   -p orchestrator-cli --bin animus               # ok. 1352 passed; 0 failed; 0 ignored
cargo test   -p animus-runtime-shared --lib phase_session   # ok. 5 passed
cargo clippy -p animus-runtime-shared -p orchestrator-cli   # 0 warnings
```

New tests compose with rc.24's existing delegated tests (`environment_bound_run_is_not_cancelled_by_orphan_sweep`, `routing_default_delegated_run_is_not_cancelled`, `startup_still_cancels_reaped_delegated_run`, `orphan_sweep_suppressed_when_config_source_unavailable`), all still green. Added: probe 3×-retry (blip→Alive / all-fail→Dead / all-timeout→Unknown), `current_delegate_binding` untorn-only, `intent_delegated_run_with_unverifiable_node_is_still_preserved` (the composition proof: intent-delegated + binding + unresolvable plugin → preserved, never false-killed), `terminalize_dead_delegation` fails checkpoint + cancels, `teardown_delegated_node` inert, `spawn_environment_resume` skips prepare, `EnvironmentBinding` serde round-trip + legacy-field back-compat.

Supersedes #345 (which targeted the stale rc.14 base).
