### PR TITLE
Support agent-bound chat creation

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/chat_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/chat_types.rs
@@ -88,6 +88,11 @@ pub(crate) struct ChatNewArgs {
     /// Optional human-facing title.
     #[arg(long)]
     pub(crate) title: Option<String>,
+    /// Canonical agent profile to bind to this conversation at creation.
+    /// The profile is resolved in the transport actor's project scope before
+    /// any conversation is written.
+    #[arg(long, value_name = "AGENT_ID")]
+    pub(crate) agent: Option<String>,
     /// Legacy user assertion. When present, must equal the transport actor's
     /// `user_id`; it never establishes caller authority.
     #[arg(long, value_name = "USER_ID")]

--- a/crates/orchestrator-cli/src/cli_types/mod.rs
+++ b/crates/orchestrator-cli/src/cli_types/mod.rs
@@ -1407,6 +1407,26 @@ mod tests {
     }
 
     #[test]
+    fn chat_new_accepts_canonical_agent_binding() {
+        let cli = Cli::try_parse_from([
+            "animus",
+            "chat",
+            "new",
+            "--agent",
+            "researcher",
+            "--actor-json",
+            r#"{"user_id":"alice","tenant_id":"tenant-a","claims":[]}"#,
+        ])
+        .expect("chat new should accept an agent binding");
+        match cli.command {
+            Command::Chat { command: ChatCommand::New(args) } => {
+                assert_eq!(args.agent.as_deref(), Some("researcher"));
+            }
+            other => panic!("expected chat new, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn output_read_is_primary_and_run_alias_is_retired() {
         let cli =
             Cli::try_parse_from(["animus", "output", "read", "--run-id", "RUN-1"]).expect("output read should parse");

--- a/crates/orchestrator-cli/src/services/runtime/runtime_chat/mod.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_chat/mod.rs
@@ -70,7 +70,8 @@ fn handle_chat_capabilities(project_root: &str, json: bool) -> Result<()> {
                 "commands": ["new", "list", "get", "rename", "delete", "export", "search", "send"],
                 "features": [
                     "chat_new_actor", "chat_list_actor", "chat_get_actor", "chat_rename_actor",
-                    "chat_delete_actor", "chat_export_actor", "chat_search_actor", "chat_send_actor"
+                    "chat_delete_actor", "chat_export_actor", "chat_search_actor", "chat_send_actor",
+                    "chat_new_agent_binding"
                 ],
                 "local_store": {
                     "unscoped_system_mode": true,
@@ -558,12 +559,20 @@ fn visibility_from_arg(arg: ChatVisibilityArg) -> Visibility {
 }
 
 fn handle_chat_new(args: ChatNewArgs, project_root: &str, json: bool) -> Result<()> {
-    // Build the client with the acting user so a plugin backend authorizes the
-    // follow-up title `save_meta` as the same owner the create stamped, not as
-    // an unscoped/admin mutation.
+    // Resolve the canonical profile before constructing the store or writing a
+    // conversation. This keeps an unknown, hidden, or cross-scope agent from
+    // leaving an unbound row behind.
     let (actor, user) = chat_actor(args.actor_json.as_deref(), args.as_user.as_deref())?;
+    let agent_id = resolve_chat_agent(Path::new(project_root), actor.as_ref(), None, args.agent.as_deref())?
+        .map(|(canonical, _)| canonical);
+
+    // Build the client with the acting user so a plugin backend authorizes the
+    // create and any follow-up title save as the same owner. The canonical
+    // agent id rides the create RPC, so plugin-backed storage never exposes a
+    // partially-created unbound conversation.
     let store = ConversationStoreClient::for_project_as_actor(Path::new(project_root), actor, args.as_user.as_deref())?;
-    let mut meta = store.create_with_ownership(args.id, user, visibility_from_arg(args.visibility))?;
+    let mut meta =
+        store.create_with_ownership_and_agent(args.id, user, visibility_from_arg(args.visibility), agent_id)?;
     if let Some(title) = normalize_title_update(args.title.as_deref()) {
         meta.title = title;
         save_meta_update(&store, &mut meta)?;
@@ -571,6 +580,8 @@ fn handle_chat_new(args: ChatNewArgs, project_root: &str, json: bool) -> Result<
     print_value(
         serde_json::json!({
             "conversation_id": meta.id,
+            "agent_id": meta.agent_id,
+            "revision": meta.revision,
             "title": meta.title,
             "owner": meta.owner,
             "visibility": meta.visibility,

--- a/crates/orchestrator-cli/tests/cli_json_contract.rs
+++ b/crates/orchestrator-cli/tests/cli_json_contract.rs
@@ -79,7 +79,12 @@ fn chat_capabilities_exposes_durable_application_contract() -> Result<()> {
         payload.pointer("/data/conversation_store/tenant_scope_field").and_then(Value::as_str),
         Some("tenant_id")
     );
-    assert_eq!(payload.pointer("/data/conversation_store/features").and_then(Value::as_array).map(Vec::len), Some(8));
+    let store_features = payload
+        .pointer("/data/conversation_store/features")
+        .and_then(Value::as_array)
+        .expect("capability probe should list conversation-store features");
+    assert_eq!(store_features.len(), 9);
+    assert!(store_features.iter().any(|feature| feature == "chat_new_agent_binding"));
     assert_eq!(payload.pointer("/data/send/partial_success/supported").and_then(Value::as_bool), Some(true));
     let events = payload
         .pointer("/data/send/partial_success/jsonl_events")

--- a/docs/reference/chat.md
+++ b/docs/reference/chat.md
@@ -43,6 +43,7 @@ If a resume turn (case 1) comes back with an error indicating the native session
 ```bash
 # Start an empty conversation (prints the conversation id)
 animus chat new [--id <id>] [--title <title>] \
+  [--agent <agent-id>] \
   [--actor-json <json>] [--as-user <user-id>] [--visibility private|shared]
 
 # Send a turn (creates a conversation if --conversation is omitted)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -804,6 +804,12 @@ resume and replay-fallback attempts. Renamed/deleted/hidden profiles and
 conflicting `--agent` flags error before provider execution. Legacy metadata
 without `agent_id` remains neutral and is never inferred.
 
+`animus chat new --agent <AGENT_ID>` resolves the exact canonical profile in
+the current project and actor scope before writing, then includes `agent_id` in
+the conversation-store create operation. This is the empty-conversation path
+for application layers that need to open a composer before the first message;
+unknown, hidden, renamed, deleted, or cross-scope profiles fail before create.
+
 ### `animus agent interactions`
 
 The inbox for human-in-the-loop round-trips. Agents running with the injected


### PR DESCRIPTION
## What changed

- add an explicit `chat new --agent <AGENT_ID>` application contract
- resolve and persist the canonical agent profile at conversation creation time
- advertise the `chat_new_agent_binding` runtime capability
- update CLI reference documentation and machine-contract tests

## Why

Arena needs to create a conversation for an authorized projected agent without accepting client-controlled runtime configuration. Binding the agent atomically during creation removes the unsafe create-then-bind gap.

## Validation

- `cargo animus-fmt`
- `cargo test -p orchestrator-cli` (full suite, including integration tests)