### PR TITLE
ci: reject stale release candidate lineage (TASK-956)

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -33,14 +33,26 @@ jobs:
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Auto-tagging: ${VERSION}"
 
-      - name: Check tag doesn't already exist
+      - name: Check whether tag already exists
+        id: tag
+        shell: bash
         run: |
-          if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          if git rev-parse --verify --quiet "refs/tags/${{ steps.version.outputs.version }}" >/dev/null; then
             echo "Tag ${{ steps.version.outputs.version }} already exists, skipping"
-            exit 0
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
+      # This workflow is loaded from the default branch for pull_request events,
+      # so a stale release branch cannot bypass the guard by lacking the script.
+      - name: Validate release candidate lineage before tagging
+        if: steps.tag.outputs.exists != 'true'
+        shell: bash
+        run: scripts/check-release-lineage.sh "${{ steps.version.outputs.version }}" HEAD
+
       - name: Create and push tag
+        if: steps.tag.outputs.exists != 'true'
         run: |
           git config user.name "AO Release Bot"
           git config user.email "noreply@launchapp.dev"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,24 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  release-lineage:
+    name: Verify release tag lineage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout complete release history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce release candidate ancestry
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: scripts/check-release-lineage.sh
+
   build:
     name: Build (${{ matrix.target }})
+    needs: release-lineage
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/scripts/check-release-lineage.sh
+++ b/scripts/check-release-lineage.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_tag="${1:-${GITHUB_REF_NAME:-}}"
+current_commit="${2:-${GITHUB_SHA:-}}"
+
+if [[ -z "${current_tag}" || -z "${current_commit}" ]]; then
+  echo "usage: $0 <release-tag> <commit>" >&2
+  echo "example: $0 v0.7.0-rc.33 HEAD" >&2
+  exit 2
+fi
+
+if [[ ! "${current_tag}" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+  echo "${current_tag} is not a release-candidate tag; no RC lineage check is required."
+  exit 0
+fi
+
+release_prefix="${BASH_REMATCH[1]}"
+current_rc=$((10#${BASH_REMATCH[2]}))
+previous_tag=""
+previous_rc=-1
+
+if ! git rev-parse --verify --quiet "${current_commit}^{commit}" >/dev/null; then
+  echo "${current_commit} does not resolve to a commit." >&2
+  exit 2
+fi
+
+# Keep direct and CI invocations safe when the checkout is shallow or its local
+# tag set is stale; ancestry checks need both RC tags and the commits between them.
+if git remote get-url origin >/dev/null 2>&1; then
+  if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+    git fetch --quiet --unshallow --tags origin
+  else
+    git fetch --quiet --force origin \
+      "+refs/tags/${release_prefix}-rc.*:refs/tags/${release_prefix}-rc.*"
+  fi
+fi
+
+while IFS= read -r tag; do
+  if [[ "${tag}" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]] \
+    && [[ "${BASH_REMATCH[1]}" == "${release_prefix}" ]]; then
+    candidate_rc=$((10#${BASH_REMATCH[2]}))
+    if (( candidate_rc < current_rc && candidate_rc > previous_rc )); then
+      previous_tag="${tag}"
+      previous_rc=${candidate_rc}
+    fi
+  fi
+done < <(git tag --list "${release_prefix}-rc.*")
+
+if [[ -z "${previous_tag}" ]]; then
+  echo "No earlier ${release_prefix} release candidate exists; lineage starts at ${current_tag}."
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "${previous_tag}^{commit}" "${current_commit}^{commit}"; then
+  echo "::error::${current_tag} (${current_commit}) is not descended from ${previous_tag}."
+  echo "Create the release candidate from the commit carrying ${previous_tag}, then tag it again."
+  exit 1
+fi
+
+echo "Release lineage verified: ${previous_tag} is an ancestor of ${current_tag}."

--- a/scripts/test-check-release-lineage.sh
+++ b/scripts/test-check-release-lineage.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+checker="${repo_root}/scripts/check-release-lineage.sh"
+test_repo="$(mktemp -d)"
+trap 'rm -rf "${test_repo}"' EXIT
+
+git -C "${test_repo}" init --quiet
+git -C "${test_repo}" config user.name "Release Lineage Test"
+git -C "${test_repo}" config user.email "release-lineage-test@example.invalid"
+
+commit_file() {
+  local contents="$1"
+  printf '%s\n' "${contents}" >"${test_repo}/release.txt"
+  git -C "${test_repo}" add release.txt
+  git -C "${test_repo}" commit --quiet -m "${contents}"
+  git -C "${test_repo}" rev-parse HEAD
+}
+
+base_commit="$(commit_file base)"
+git -C "${test_repo}" tag v0.7.0-rc.9 "${base_commit}"
+
+next_commit="$(commit_file next)"
+git -C "${test_repo}" tag v0.7.0-rc.10 "${next_commit}"
+
+# Numeric ordering must select rc.10 rather than lexically sorting rc.9 later.
+latest_commit="$(commit_file latest)"
+lineage_output="$(
+  cd "${test_repo}"
+  "${checker}" v0.7.0-rc.11 "${latest_commit}"
+)"
+grep -Fq "v0.7.0-rc.10 is an ancestor" <<<"${lineage_output}"
+
+# Model the default-branch auto-tag preflight: a proposal based on the old
+# rc.9 line must be rejected before the tag is created or pushed.
+git -C "${test_repo}" switch --quiet --detach "${base_commit}"
+diverged_commit="$(commit_file diverged)"
+if lineage_output="$(
+  cd "${test_repo}"
+  "${checker}" v0.7.0-rc.11 "${diverged_commit}" 2>&1
+)"; then
+  echo "expected a release candidate from a stale branch to be rejected" >&2
+  exit 1
+fi
+grep -Fq "is not descended from v0.7.0-rc.10" <<<"${lineage_output}"
+
+# A proposal descended from the latest RC must pass the same preflight.
+git -C "${test_repo}" switch --quiet --detach "${next_commit}"
+descended_commit="$(commit_file descended)"
+descended_output="$(
+  cd "${test_repo}"
+  "${checker}" v0.7.0-rc.11 "${descended_commit}"
+)"
+grep -Fq "v0.7.0-rc.10 is an ancestor" <<<"${descended_output}"
+
+stable_output="$(
+  cd "${test_repo}"
+  "${checker}" v0.7.0 "${diverged_commit}"
+)"
+grep -Fq "no RC lineage check is required" <<<"${stable_output}"
+
+if invalid_output="$(
+  cd "${test_repo}"
+  "${checker}" v0.7.0-rc.11 does-not-exist 2>&1
+)"; then
+  echo "expected an invalid release commit to be rejected" >&2
+  exit 1
+fi
+grep -Fq "does-not-exist does not resolve to a commit" <<<"${invalid_output}"
+
+echo "release lineage checks passed"


### PR DESCRIPTION
## Summary

- reject a release-candidate tag unless its commit descends from the highest prior RC for that version line
- run the guard in the default-branch-owned auto-tag workflow before tag creation, so a stale branch cannot bypass it by omitting the guard
- gate release builds on the same lineage validation and make existing-tag handling truly skip tag creation
- add deterministic coverage for numeric RC ordering, stale-branch rejection, valid ancestry, stable tags, and invalid commits

Closes TASK-956.

## Validation

- `scripts/test-check-release-lineage.sh`
- `git diff --check`
- `actionlint` and `shellcheck` when available

## Production canary evidence

The runtime-v11 coding canary implemented and reviewed this change successfully. Its node GitHub App lacked permission to update workflow files, so v0.4.55 correctly refused completion, retained the Railway node, and preserved the work instead of tearing it down. This operator branch publishes the same final tree with a credential authorized for workflow files.
