### PR TITLE
fix: resume delegated workflows on retained nodes

### DIFF
--- a/crates/animus-runtime-shared/src/phase_session.rs
+++ b/crates/animus-runtime-shared/src/phase_session.rs
@@ -569,6 +569,30 @@ mod tests {
         assert!(cp.environment.expect("binding").torn_down, "torn_down stays set on the second mark");
     }
 
+    // TASK-811: terminalizing a dead delegation must not discard the durable
+    // handle or its cleanup state. Reconciliation can fail the checkpoint
+    // after teardown, and operators still need the retained binding for audit
+    // while later scans must see that the node has already been reaped.
+    #[test]
+    fn failing_checkpoint_preserves_torn_down_environment_binding() {
+        let temp = tempdir().expect("tempdir");
+        let scoped_root = temp.path();
+        write_session_pending(scoped_root, "wf-env-3", "phase-a", "claude", "run-3", None).expect("pending");
+
+        let binding = sample_binding();
+        update_session_environment(scoped_root, "wf-env-3", "phase-a", binding.clone()).expect("persist binding");
+        mark_environment_torn_down(scoped_root, "wf-env-3", "phase-a").expect("mark torn down");
+        update_session_failed(scoped_root, "wf-env-3", "phase-a", "delegated node died").expect("fail checkpoint");
+
+        let cp = read_checkpoint(scoped_root, "wf-env-3", "phase-a").expect("read").expect("present");
+        assert_eq!(cp.status, SessionCheckpointStatus::Failed);
+        assert_eq!(cp.blocked_reason.as_deref(), Some("delegated node died"));
+        let environment = cp.environment.expect("terminal checkpoint retains environment binding");
+        assert_eq!(environment.handle, binding.handle);
+        assert_eq!(environment.environment_id, binding.environment_id);
+        assert!(environment.torn_down, "terminal mutation retains the completed cleanup marker");
+    }
+
     // Backward-compat: a checkpoint JSON written by an OLDER runner that does
     // not know the `environment` field must still deserialize (serde ignores
     // unknown fields; the struct is not deny_unknown_fields), with

--- a/crates/animus-runtime-shared/src/phase_session.rs
+++ b/crates/animus-runtime-shared/src/phase_session.rs
@@ -593,6 +593,31 @@ mod tests {
         assert!(environment.torn_down, "terminal mutation retains the completed cleanup marker");
     }
 
+    // TASK-933: after reconciliation reaps an unusable node, a phase-boundary
+    // redispatch may prepare a replacement for the same checkpoint. Persisting
+    // that replacement must overwrite the old handle AND clear its completed
+    // teardown marker, otherwise the replacement is invisible to subsequent
+    // restart recovery and can leak.
+    #[test]
+    fn replacement_environment_binding_supersedes_torn_down_node() {
+        let temp = tempdir().expect("tempdir");
+        let scoped_root = temp.path();
+        write_session_pending(scoped_root, "wf-env-4", "phase-a", "claude", "run-4", None).expect("pending");
+
+        update_session_environment(scoped_root, "wf-env-4", "phase-a", sample_binding()).expect("persist first");
+        mark_environment_torn_down(scoped_root, "wf-env-4", "phase-a").expect("mark first torn down");
+
+        let mut replacement = sample_binding();
+        replacement.handle.id = "node-2".to_string();
+        replacement.bound_at = "2025-01-02T00:00:00Z".to_string();
+        update_session_environment(scoped_root, "wf-env-4", "phase-a", replacement.clone())
+            .expect("persist replacement");
+
+        let cp = read_checkpoint(scoped_root, "wf-env-4", "phase-a").expect("read").expect("present");
+        assert_eq!(cp.environment.as_ref(), Some(&replacement));
+        assert!(!cp.environment.expect("replacement binding").torn_down);
+    }
+
     // Backward-compat: a checkpoint JSON written by an OLDER runner that does
     // not know the `environment` field must still deserialize (serde ignores
     // unknown fields; the struct is not deny_unknown_fields), with

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/control_routing.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/control_routing.rs
@@ -299,6 +299,8 @@ impl WorkflowRouting for WorkflowRoutingImpl {
     async fn workflow_cancel(&self, request: WireCancelRequest) -> Result<Unit, ControlError> {
         let hub = self.hub()?;
         let root = self.project_root_str();
+        let workflow = hub.workflows().get(&request.id).await.map_err(internal)?;
+        crate::services::runtime::teardown_retained_environment_for_cancel(&root, &workflow).map_err(internal)?;
         let task_store = orchestrator_daemon_runtime::resolve_task_projection_store(&root, hub.clone()).await;
         let _ =
             dispatch_workflow_event(hub, task_store.as_ref(), &root, WorkflowEvent::Cancel { workflow_id: request.id })

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -828,6 +828,7 @@ pub(crate) async fn handle_workflow(
                     return print_value(workflow, json);
                 }
             }
+            crate::services::runtime::teardown_retained_environment_for_cancel(project_root, &workflow)?;
             let task_store =
                 orchestrator_daemon_runtime::resolve_task_projection_store(project_root, hub.clone()).await;
             let outcome = dispatch_workflow_event(

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent.rs
@@ -5,7 +5,7 @@ use orchestrator_core::services::ServiceHub;
 
 use crate::AgentCommand;
 
-mod environment_exec;
+pub(crate) mod environment_exec;
 pub(crate) mod interactions;
 mod profiles;
 pub(crate) mod provider_client;

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
@@ -691,7 +691,17 @@ fn run_environment_pipeline(
             }
         }
     };
-    run_exec_and_teardown(backend, &handle, command, stdin, timeout, backend_label, events, Some(&record_teardown));
+    run_exec_and_teardown(
+        backend,
+        &handle,
+        command,
+        stdin,
+        timeout,
+        backend_label,
+        events,
+        true,
+        Some(&record_teardown),
+    );
 }
 
 /// TASK-933 resume entry: drive a delegated run's harness command against an
@@ -718,7 +728,7 @@ pub(super) fn spawn_environment_resume(
     timeout: Option<Duration>,
     backend_label: String,
 ) -> SessionRun {
-    spawn_environment_resume_tracked(backend, handle, command, stdin, timeout, backend_label).0
+    spawn_environment_resume_tracked(backend, handle, command, stdin, timeout, backend_label, true).0
 }
 
 fn spawn_environment_resume_tracked(
@@ -728,6 +738,7 @@ fn spawn_environment_resume_tracked(
     stdin: Option<String>,
     timeout: Option<Duration>,
     backend_label: String,
+    teardown_after_exec: bool,
 ) -> (SessionRun, tokio::sync::oneshot::Receiver<bool>) {
     let (events_tx, events_rx) = mpsc::channel::<SessionEvent>(256);
     let (pipeline_tx, mut pipeline_rx) = mpsc::unbounded_channel::<SessionEvent>();
@@ -746,7 +757,10 @@ fn spawn_environment_resume_tracked(
             let _ = pipeline_tx.send(event);
         };
         send(SessionEvent::Started { backend: backend_label.clone(), session_id: None, pid: None });
-        // NO prepare — reuse the persisted handle for exec_stream + teardown.
+        // NO prepare — reuse the persisted handle. A broker-owned restart
+        // lease remains alive for later workflow phases and is torn down only
+        // at terminal workflow completion; legacy standalone callers retain
+        // the previous exec-then-teardown behavior.
         let torn_down = run_exec_and_teardown(
             backend.as_ref(),
             &handle,
@@ -755,6 +769,7 @@ fn spawn_environment_resume_tracked(
             timeout,
             &backend_label,
             &pipeline_tx,
+            teardown_after_exec,
             None,
         );
         let _ = teardown_tx.send(torn_down);
@@ -779,6 +794,7 @@ pub(crate) enum EnvironmentCheckpointResume {
 pub(crate) async fn resume_environment_checkpoint(
     project_root: &Path,
     checkpoint: &animus_runtime_shared::phase_session::SessionCheckpoint,
+    retain_for_later_phases: bool,
 ) -> EnvironmentCheckpointResume {
     use orchestrator_plugin_host::session::ResumeAgentOutcome;
 
@@ -846,6 +862,7 @@ pub(crate) async fn resume_environment_checkpoint(
         None,
         Some(Duration::from_secs(DEFAULT_ENVIRONMENT_RUN_TIMEOUT_SECS)),
         backend_label,
+        !retain_for_later_phases,
     );
 
     let mut outcome = None;
@@ -892,6 +909,7 @@ fn run_exec_and_teardown(
     timeout: Option<Duration>,
     backend_label: &str,
     events: &mpsc::UnboundedSender<SessionEvent>,
+    teardown_after_exec: bool,
     on_teardown_success: Option<&dyn Fn()>,
 ) -> bool {
     let send = |event: SessionEvent| {
@@ -925,21 +943,26 @@ fn run_exec_and_teardown(
         result => result,
     };
 
-    // Teardown regardless of exec outcome; a teardown failure is surfaced as a
-    // recoverable frame (the run's verdict is the exec result, not cleanup).
-    let torn_down = match backend.teardown(handle) {
-        Ok(()) => {
-            if let Some(on_teardown_success) = on_teardown_success {
-                on_teardown_success();
+    // Standalone leases teardown regardless of exec outcome. Broker-owned
+    // restart leases deliberately stay ready across phase boundaries; their
+    // terminal workflow transition calls EnvironmentBroker::teardown once.
+    let torn_down = if !teardown_after_exec {
+        true
+    } else {
+        match backend.teardown(handle) {
+            Ok(()) => {
+                if let Some(on_teardown_success) = on_teardown_success {
+                    on_teardown_success();
+                }
+                true
             }
-            true
-        }
-        Err(err) => {
-            send(SessionEvent::Error {
-                message: format!("environment teardown failed for {backend_label} (handle {}): {err:#}", handle.id),
-                recoverable: true,
-            });
-            false
+            Err(err) => {
+                send(SessionEvent::Error {
+                    message: format!("environment teardown failed for {backend_label} (handle {}): {err:#}", handle.id),
+                    recoverable: true,
+                });
+                false
+            }
         }
     };
 
@@ -1745,6 +1768,28 @@ environment_routing:
             backend.prepare_result.lock().unwrap().is_some(),
             "prepare must not be invoked on the resume path (the node already exists)"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn broker_owned_resume_keeps_node_for_later_phases() {
+        let backend = Arc::new(FakeBackend::new());
+        *backend.prepare_result.lock().unwrap() = Some(Err(anyhow!("prepare must not be called on resume")));
+        *backend.exec_stream_outcome.lock().unwrap() = Some(StreamOutcome::Deltas(Vec::new(), Ok(ok_response(0))));
+
+        let (run, retained_rx) = spawn_environment_resume_tracked(
+            backend.clone(),
+            sample_handle(),
+            command_for_test(),
+            None,
+            None,
+            "environment:container".to_string(),
+            false,
+        );
+        let events = drain(run).await;
+        assert!(matches!(events.last(), Some(SessionEvent::Finished { exit_code: Some(0) })));
+        assert!(retained_rx.await.expect("retention result"));
+        assert!(!backend.torn_down.load(Ordering::SeqCst), "broker-owned resume retains the node");
+        assert!(backend.prepare_result.lock().unwrap().is_some(), "resume does not prepare a replacement node");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
@@ -691,16 +691,7 @@ fn run_environment_pipeline(
             }
         }
     };
-    run_exec_and_teardown(
-        backend,
-        &handle,
-        command,
-        stdin,
-        timeout,
-        backend_label,
-        events,
-        Some(&record_teardown),
-    );
+    run_exec_and_teardown(backend, &handle, command, stdin, timeout, backend_label, events, Some(&record_teardown));
 }
 
 /// TASK-933 resume entry: drive a delegated run's harness command against an
@@ -1550,8 +1541,7 @@ environment_routing:
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn successful_normal_teardown_marks_the_persisted_binding_torn_down() {
         let backend = Arc::new(FakeBackend::new());
-        *backend.exec_stream_outcome.lock().unwrap() =
-            Some(StreamOutcome::Deltas(Vec::new(), Ok(ok_response(0))));
+        *backend.exec_stream_outcome.lock().unwrap() = Some(StreamOutcome::Deltas(Vec::new(), Ok(ok_response(0))));
         let temp = tempfile::tempdir().expect("tempdir");
         let scoped_root = temp.path().to_path_buf();
         animus_runtime_shared::phase_session::write_session_pending(
@@ -1580,13 +1570,10 @@ environment_routing:
         );
         let _events = drain(run).await;
 
-        let checkpoint = animus_runtime_shared::phase_session::read_checkpoint(
-            &scoped_root,
-            "wf-normal-cleanup",
-            "phase-code",
-        )
-        .expect("read checkpoint")
-        .expect("checkpoint exists");
+        let checkpoint =
+            animus_runtime_shared::phase_session::read_checkpoint(&scoped_root, "wf-normal-cleanup", "phase-code")
+                .expect("read checkpoint")
+                .expect("checkpoint exists");
         assert!(
             checkpoint.environment.expect("binding persisted").torn_down,
             "successful normal teardown must retire the durable binding"

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/environment_exec.rs
@@ -50,7 +50,7 @@
 //! [`EnvironmentClient`] contract this module exercises kernel-side.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -64,6 +64,8 @@ use orchestrator_core::EnvironmentClient;
 use orchestrator_plugin_host::HostError;
 use serde_json::Value;
 use tokio::sync::mpsc;
+
+use animus_runtime_shared::phase_session::EnvironmentBinding;
 
 /// Environment ids that mean "run on the host": the resolver treats them as
 /// no-routing so the existing local spawn path stays byte-for-byte unchanged.
@@ -139,10 +141,17 @@ fn routing_spec_overrides(
 /// [`SessionRun`] — the same handle shape `start_session` produces, so the
 /// caller's event loop (persistence, rendering, exit-code handling) is
 /// unchanged.
+pub(super) struct EnvironmentCheckpointTarget {
+    pub scoped_root: PathBuf,
+    pub workflow_id: String,
+    pub phase_id: String,
+}
+
 pub(super) fn start_environment_session(
     project_root: &Path,
     environment: &ResolvedEnvironment,
     request: &SessionRequest,
+    checkpoint_target: Option<EnvironmentCheckpointTarget>,
 ) -> Result<SessionRun> {
     let environment_id = environment.id.as_str();
     let client = EnvironmentClient::resolve(project_root, environment_id).map_err(|err| {
@@ -161,7 +170,17 @@ pub(super) fn start_environment_session(
     // hung provider command inside the environment would drain forever.
     let timeout = Some(Duration::from_secs(request.timeout_secs.unwrap_or(DEFAULT_ENVIRONMENT_RUN_TIMEOUT_SECS)));
     let backend_label = format!("environment:{}", client.plugin_name());
-    Ok(spawn_environment_run(Arc::new(client), spec, command, stdin, timeout, backend_label))
+    let resolved_environment_id = client.plugin_name().to_string();
+    Ok(spawn_environment_run(
+        Arc::new(client),
+        spec,
+        command,
+        stdin,
+        timeout,
+        backend_label,
+        resolved_environment_id,
+        checkpoint_target,
+    ))
 }
 
 /// Merge a routing rule's opaque `spec` overrides into the compiled
@@ -551,6 +570,8 @@ pub(super) fn spawn_environment_run(
     stdin: Option<String>,
     timeout: Option<Duration>,
     backend_label: String,
+    environment_id: String,
+    checkpoint_target: Option<EnvironmentCheckpointTarget>,
 ) -> SessionRun {
     let (events_tx, events_rx) = mpsc::channel::<SessionEvent>(256);
     // The pipeline thread sends through an unbounded channel: the exec_stream
@@ -568,7 +589,17 @@ pub(super) fn spawn_environment_run(
 
     let selected_backend = backend_label.clone();
     std::thread::spawn(move || {
-        run_environment_pipeline(backend.as_ref(), spec, command, stdin, timeout, &backend_label, &pipeline_tx);
+        run_environment_pipeline(
+            backend.as_ref(),
+            spec,
+            command,
+            stdin,
+            timeout,
+            &backend_label,
+            &environment_id,
+            checkpoint_target,
+            &pipeline_tx,
+        );
     });
 
     SessionRun { session_id: None, events: events_rx, selected_backend, fallback_reason: None, pid: None }
@@ -587,6 +618,8 @@ fn run_environment_pipeline(
     stdin: Option<String>,
     timeout: Option<Duration>,
     backend_label: &str,
+    environment_id: &str,
+    checkpoint_target: Option<EnvironmentCheckpointTarget>,
     events: &mpsc::UnboundedSender<SessionEvent>,
 ) {
     let send = |event: SessionEvent| {
@@ -595,7 +628,40 @@ fn run_environment_pipeline(
     send(SessionEvent::Started { backend: backend_label.to_string(), session_id: None, pid: None });
 
     let handle = match backend.prepare(spec) {
-        Ok(handle) => handle,
+        Ok(handle) => {
+            let binding = EnvironmentBinding {
+                environment_id: environment_id.to_string(),
+                handle: handle.clone(),
+                bound_at: chrono::Utc::now().to_rfc3339(),
+                torn_down: false,
+            };
+            // Do not return the prepared handle to the execution pipeline until
+            // its owner is durable. An async notification leaves a
+            // prepare-to-persistence crash window and can execute work whose
+            // node a restarted daemon cannot identify.
+            if let Some(target) = checkpoint_target.as_ref() {
+                if let Err(error) = animus_runtime_shared::phase_session::update_session_environment(
+                    &target.scoped_root,
+                    &target.workflow_id,
+                    &target.phase_id,
+                    binding,
+                ) {
+                    let teardown_error = backend.teardown(&handle).err();
+                    send(SessionEvent::Error {
+                        message: format!(
+                            "environment binding persistence failed for {backend_label}: {error}; \
+                             prepared node cleanup: {}",
+                            teardown_error
+                                .map(|error| format!("failed: {error:#}"))
+                                .unwrap_or_else(|| "succeeded".to_string())
+                        ),
+                        recoverable: false,
+                    });
+                    return;
+                }
+            }
+            handle
+        }
         Err(err) => {
             send(SessionEvent::Error {
                 message: format!("environment prepare failed for {backend_label}: {err:#}"),
@@ -605,7 +671,36 @@ fn run_environment_pipeline(
         }
     };
 
-    run_exec_and_teardown(backend, &handle, command, stdin, timeout, backend_label, events);
+    let record_teardown = || {
+        if let Some(target) = checkpoint_target.as_ref() {
+            if let Err(error) = animus_runtime_shared::phase_session::mark_environment_torn_down(
+                &target.scoped_root,
+                &target.workflow_id,
+                &target.phase_id,
+            ) {
+                // The node is already gone. Leave the durable binding untorn so
+                // reconciliation retries the idempotent teardown and can repair
+                // the checkpoint instead of treating stale state as a live node.
+                send(SessionEvent::Error {
+                    message: format!(
+                        "environment teardown succeeded for {backend_label}, but its checkpoint \
+                         could not be marked torn down: {error}"
+                    ),
+                    recoverable: true,
+                });
+            }
+        }
+    };
+    run_exec_and_teardown(
+        backend,
+        &handle,
+        command,
+        stdin,
+        timeout,
+        backend_label,
+        events,
+        Some(&record_teardown),
+    );
 }
 
 /// TASK-933 resume entry: drive a delegated run's harness command against an
@@ -632,8 +727,20 @@ pub(super) fn spawn_environment_resume(
     timeout: Option<Duration>,
     backend_label: String,
 ) -> SessionRun {
+    spawn_environment_resume_tracked(backend, handle, command, stdin, timeout, backend_label).0
+}
+
+fn spawn_environment_resume_tracked(
+    backend: Arc<dyn EnvironmentExecBackend>,
+    handle: EnvironmentHandle,
+    command: HarnessCommand,
+    stdin: Option<String>,
+    timeout: Option<Duration>,
+    backend_label: String,
+) -> (SessionRun, tokio::sync::oneshot::Receiver<bool>) {
     let (events_tx, events_rx) = mpsc::channel::<SessionEvent>(256);
     let (pipeline_tx, mut pipeline_rx) = mpsc::unbounded_channel::<SessionEvent>();
+    let (teardown_tx, teardown_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         while let Some(event) = pipeline_rx.recv().await {
             if events_tx.send(event).await.is_err() {
@@ -649,10 +756,135 @@ pub(super) fn spawn_environment_resume(
         };
         send(SessionEvent::Started { backend: backend_label.clone(), session_id: None, pid: None });
         // NO prepare — reuse the persisted handle for exec_stream + teardown.
-        run_exec_and_teardown(backend.as_ref(), &handle, command, stdin, timeout, &backend_label, &pipeline_tx);
+        let torn_down = run_exec_and_teardown(
+            backend.as_ref(),
+            &handle,
+            command,
+            stdin,
+            timeout,
+            &backend_label,
+            &pipeline_tx,
+            None,
+        );
+        let _ = teardown_tx.send(torn_down);
     });
 
-    SessionRun { session_id: None, events: events_rx, selected_backend, fallback_reason: None, pid: None }
+    (
+        SessionRun { session_id: None, events: events_rx, selected_backend, fallback_reason: None, pid: None },
+        teardown_rx,
+    )
+}
+
+pub(crate) enum EnvironmentCheckpointResume {
+    Outcome(orchestrator_plugin_host::session::ResumeAgentOutcome),
+    CleanupPending { reason: String },
+}
+
+/// Production restart entry for a delegated phase. Rebuild only the
+/// provider's *resume* invocation, then execute it on the already-prepared
+/// node recorded in the checkpoint. This is deliberately separate from
+/// `start_environment_session`: calling that function would prepare a second
+/// node before the old one could be reclaimed.
+pub(crate) async fn resume_environment_checkpoint(
+    project_root: &Path,
+    checkpoint: &animus_runtime_shared::phase_session::SessionCheckpoint,
+) -> EnvironmentCheckpointResume {
+    use orchestrator_plugin_host::session::ResumeAgentOutcome;
+
+    let Some(binding) = checkpoint.environment.as_ref().filter(|binding| !binding.torn_down) else {
+        return EnvironmentCheckpointResume::Outcome(ResumeAgentOutcome::Failed {
+            reason: "delegated environment binding is missing or torn down".into(),
+        });
+    };
+
+    let request = checkpoint.request.as_ref().unwrap_or(&Value::Null);
+    let request_field = |name: &str| {
+        request
+            .pointer(&format!("/context/{name}"))
+            .or_else(|| request.get(name))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    };
+    let prompt = request_field("prompt");
+    let provider = checkpoint.provider.trim().to_ascii_lowercase();
+    let session_id = checkpoint.provider_session_id.as_deref().map(str::trim).filter(|sid| !sid.is_empty());
+    // Build both fresh and resumed invocations through the same canonical
+    // runtime contract as normal runner launches. Hand-building these argv
+    // vectors is unsafe: provider syntax and required non-interactive flags
+    // differ (notably Codex uses its configured resume policy), which can
+    // accidentally start a second session or execute the prompt twice.
+    let model = request_field("model").unwrap_or_default();
+    let prompt = prompt.unwrap_or_default();
+    let resume_plan = session_id.map(|session_id| orchestrator_core::runtime_contract::CliSessionResumePlan {
+        mode: orchestrator_core::runtime_contract::CliSessionResumeMode::NativeId,
+        session_key: format!("wf:{}:{}", checkpoint.workflow_id, checkpoint.phase_id),
+        session_id: Some(session_id.to_string()),
+        summary_seed: None,
+        reused: true,
+        phase_thread_isolated: true,
+    });
+    let Some((program, args)) = orchestrator_core::runtime_contract::build_cli_launch_contract(
+        &provider,
+        model,
+        prompt,
+        resume_plan.as_ref(),
+        None,
+    )
+    .as_ref()
+    .and_then(launch_program_args) else {
+        return EnvironmentCheckpointResume::Outcome(ResumeAgentOutcome::Failed {
+            reason: format!("cannot build environment resume command for provider '{}'", checkpoint.provider),
+        });
+    };
+    let args = plain_text_launch_args(&provider, args);
+
+    let client = match EnvironmentClient::resolve(project_root, &binding.environment_id) {
+        Ok(client) => client,
+        Err(err) => {
+            return EnvironmentCheckpointResume::Outcome(ResumeAgentOutcome::Failed {
+                reason: format!("cannot resolve environment plugin '{}': {err:#}", binding.environment_id),
+            });
+        }
+    };
+    let backend_label = format!("environment:{}", client.plugin_name());
+    let (mut run, teardown_rx) = spawn_environment_resume_tracked(
+        Arc::new(client),
+        binding.handle.clone(),
+        HarnessCommand { program, args, env: BTreeMap::new(), cwd: None },
+        None,
+        Some(Duration::from_secs(DEFAULT_ENVIRONMENT_RUN_TIMEOUT_SECS)),
+        backend_label,
+    );
+
+    let mut outcome = None;
+    while let Some(event) = run.events.recv().await {
+        match event {
+            SessionEvent::Finished { exit_code } if exit_code.unwrap_or_default() == 0 => {
+                outcome = Some(ResumeAgentOutcome::Resumed { session_id: session_id.map(str::to_string) });
+            }
+            SessionEvent::Finished { exit_code } => {
+                outcome = Some(ResumeAgentOutcome::Failed {
+                    reason: format!("delegated resume exited with code {exit_code:?}"),
+                });
+            }
+            SessionEvent::Error { message, recoverable: false } => {
+                outcome = Some(ResumeAgentOutcome::Failed { reason: message });
+            }
+            _ => {}
+        }
+    }
+    if !teardown_rx.await.unwrap_or(false) {
+        return EnvironmentCheckpointResume::CleanupPending {
+            reason: format!(
+                "delegated command completed but teardown of environment handle '{}' failed",
+                binding.handle.id
+            ),
+        };
+    }
+    EnvironmentCheckpointResume::Outcome(outcome.unwrap_or_else(|| ResumeAgentOutcome::Failed {
+        reason: "delegated resume stream ended before completion".into(),
+    }))
 }
 
 /// The exec_stream → teardown → terminal-mapping tail shared by the fresh-run
@@ -669,7 +901,8 @@ fn run_exec_and_teardown(
     timeout: Option<Duration>,
     backend_label: &str,
     events: &mpsc::UnboundedSender<SessionEvent>,
-) {
+    on_teardown_success: Option<&dyn Fn()>,
+) -> bool {
     let send = |event: SessionEvent| {
         let _ = events.send(event);
     };
@@ -703,12 +936,21 @@ fn run_exec_and_teardown(
 
     // Teardown regardless of exec outcome; a teardown failure is surfaced as a
     // recoverable frame (the run's verdict is the exec result, not cleanup).
-    if let Err(err) = backend.teardown(handle) {
-        send(SessionEvent::Error {
-            message: format!("environment teardown failed for {backend_label} (handle {}): {err:#}", handle.id),
-            recoverable: true,
-        });
-    }
+    let torn_down = match backend.teardown(handle) {
+        Ok(()) => {
+            if let Some(on_teardown_success) = on_teardown_success {
+                on_teardown_success();
+            }
+            true
+        }
+        Err(err) => {
+            send(SessionEvent::Error {
+                message: format!("environment teardown failed for {backend_label} (handle {}): {err:#}", handle.id),
+                recoverable: true,
+            });
+            false
+        }
+    };
 
     match result {
         Ok(response) if response.timed_out => send(SessionEvent::Error {
@@ -733,6 +975,7 @@ fn run_exec_and_teardown(
             recoverable: false,
         }),
     }
+    torn_down
 }
 
 /// Whether an exec error is the plugin's structured METHOD_NOT_SUPPORTED
@@ -1275,6 +1518,8 @@ environment_routing:
             None,
             None,
             "environment:container".to_string(),
+            "container".to_string(),
+            None,
         );
         assert_eq!(run.selected_backend, "environment:container");
         let events = drain(run).await;
@@ -1303,6 +1548,52 @@ environment_routing:
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn successful_normal_teardown_marks_the_persisted_binding_torn_down() {
+        let backend = Arc::new(FakeBackend::new());
+        *backend.exec_stream_outcome.lock().unwrap() =
+            Some(StreamOutcome::Deltas(Vec::new(), Ok(ok_response(0))));
+        let temp = tempfile::tempdir().expect("tempdir");
+        let scoped_root = temp.path().to_path_buf();
+        animus_runtime_shared::phase_session::write_session_pending(
+            &scoped_root,
+            "wf-normal-cleanup",
+            "phase-code",
+            "claude",
+            "run-normal-cleanup",
+            None,
+        )
+        .expect("pending checkpoint");
+
+        let run = spawn_environment_run(
+            backend,
+            spec_for_test(),
+            command_for_test(),
+            None,
+            None,
+            "environment:container".to_string(),
+            "container".to_string(),
+            Some(EnvironmentCheckpointTarget {
+                scoped_root: scoped_root.clone(),
+                workflow_id: "wf-normal-cleanup".to_string(),
+                phase_id: "phase-code".to_string(),
+            }),
+        );
+        let _events = drain(run).await;
+
+        let checkpoint = animus_runtime_shared::phase_session::read_checkpoint(
+            &scoped_root,
+            "wf-normal-cleanup",
+            "phase-code",
+        )
+        .expect("read checkpoint")
+        .expect("checkpoint exists");
+        assert!(
+            checkpoint.environment.expect("binding persisted").torn_down,
+            "successful normal teardown must retire the durable binding"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn prepare_failure_fails_the_run_without_executing_locally() {
         let backend = Arc::new(FakeBackend::new());
         *backend.prepare_result.lock().unwrap() = Some(Err(anyhow!("no docker daemon")));
@@ -1314,6 +1605,8 @@ environment_routing:
             None,
             None,
             "environment:container".to_string(),
+            "container".to_string(),
+            None,
         );
         let events = drain(run).await;
         assert!(
@@ -1339,6 +1632,8 @@ environment_routing:
             None,
             None,
             "environment:container".to_string(),
+            "container".to_string(),
+            None,
         );
         let events = drain(run).await;
         assert!(
@@ -1375,6 +1670,8 @@ environment_routing:
             None,
             None,
             "environment:container".to_string(),
+            "container".to_string(),
+            None,
         );
         let events = drain(run).await;
         assert_eq!(backend.exec_calls.load(Ordering::SeqCst), 1, "buffered exec retried exactly once");
@@ -1409,6 +1706,8 @@ environment_routing:
             None,
             None,
             "environment:container".to_string(),
+            "container".to_string(),
+            None,
         );
         let events = drain(run).await;
         assert!(
@@ -1476,6 +1775,8 @@ environment_routing:
             None,
             Some(Duration::from_secs(5)),
             "environment:container".to_string(),
+            "container".to_string(),
+            None,
         );
         let events = drain(run).await;
         assert!(

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/run.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::{persist_agent_event, persist_json_output, print_agent_event, print_value, run_dir, AgentRunArgs};
 
 use super::provider_client::{session_request_from_args, start_session, to_agent_event};
+use animus_runtime_shared::phase_session::list_running_checkpoints;
 
 pub(super) async fn handle_agent_run(
     args: AgentRunArgs,
@@ -26,7 +27,13 @@ pub(super) async fn handle_agent_run(
     // The default resolution is `None`, taking the unchanged local path.
     let run = match super::environment_exec::resolve_exec_environment(project_root_path, &request.tool) {
         Some(environment) => {
-            super::environment_exec::start_environment_session(project_root_path, &environment, &request)?
+            let checkpoint_target = environment_checkpoint_target(project_root_path, &run_id)?;
+            super::environment_exec::start_environment_session(
+                project_root_path,
+                &environment,
+                &request,
+                checkpoint_target,
+            )?
         }
         None => start_session(project_root_path, request).await?,
     };
@@ -75,6 +82,31 @@ pub(super) async fn handle_agent_run(
         if args.save_jsonl { Some(run_dir(project_root, &run_id, args.jsonl_dir.as_deref())) } else { None };
 
     stream_events(run, run_id, &args, run_dir_path, json).await
+}
+
+fn environment_checkpoint_target(
+    project_root: &Path,
+    run_id: &RunId,
+) -> Result<Option<super::environment_exec::EnvironmentCheckpointTarget>> {
+    let Some(scoped_root) = protocol::repository_scope::scoped_state_root(project_root) else {
+        return Ok(None);
+    };
+    let checkpoint = list_running_checkpoints(&scoped_root)?
+        .into_iter()
+        .map(|(_, checkpoint)| checkpoint)
+        .find(|checkpoint| checkpoint.run_id == run_id.0);
+    let Some(checkpoint) = checkpoint else {
+        // Ad-hoc agent runs have no phase checkpoint. Their normal pipeline
+        // still tears down; workflow-linked runs must always have been
+        // checkpointed before their agent child is launched.
+        tracing::debug!(run_id = %run_id.0, "prepared environment belongs to an ad-hoc run; no phase checkpoint to bind");
+        return Ok(None);
+    };
+    Ok(Some(super::environment_exec::EnvironmentCheckpointTarget {
+        scoped_root,
+        workflow_id: checkpoint.workflow_id,
+        phase_id: checkpoint.phase_id,
+    }))
 }
 
 async fn stream_events(

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
@@ -37,6 +37,7 @@ pub(crate) mod daemon_scheduler;
 mod notifier_dispatcher;
 
 pub(crate) use control_routing::build_daemon_ops_routing;
+pub(crate) use daemon_reconciliation::teardown_retained_environment_for_cancel;
 
 use daemon_events::handle_daemon_events_impl;
 use daemon_run::handle_daemon_run;

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -308,11 +308,12 @@ fn current_delegate_binding(
     Some((phase_id, binding))
 }
 
-/// Release the exact delegated node retained by a workflow before an external
-/// cancellation is committed. The teardown happens first and the durable
-/// binding is marked only after it succeeds, so a failed cleanup leaves the
-/// workflow and checkpoint retryable. Repeated calls are idempotent because a
-/// marked binding is no longer returned by `current_delegate_binding`.
+/// Release every distinct delegated node retained by a workflow before an
+/// external cancellation is committed. Bindings are scanned across all phase
+/// checkpoints because the current phase may be manual/local while an earlier
+/// delegated phase still owns the workflow-scoped lease. Teardown happens
+/// first and every checkpoint referring to that handle is marked only after it
+/// succeeds, so failed cleanup remains retryable.
 pub(crate) fn teardown_retained_environment_for_cancel(
     project_root: &str,
     workflow: &OrchestratorWorkflow,
@@ -343,25 +344,57 @@ fn teardown_retained_environment_with<F>(
     teardown: F,
 ) -> anyhow::Result<()>
 where
-    F: FnOnce(&EnvironmentBinding) -> anyhow::Result<()>,
+    F: FnMut(&EnvironmentBinding) -> anyhow::Result<()>,
 {
-    let Some((phase_id, binding)) = current_delegate_binding(scoped_root, workflow) else {
-        return Ok(());
-    };
-    teardown(&binding)?;
-    mark_environment_torn_down(scoped_root, &workflow.id, &phase_id).with_context(|| {
-        format!(
-            "node {} was torn down but its retained binding could not be marked for workflow {}/{}",
-            binding.handle.id, workflow.id, phase_id
-        )
-    })?;
-    info!(
-        actor = protocol::ACTOR_DAEMON,
-        workflow_id = %workflow.id,
-        node = %binding.handle.id,
-        "released retained delegated node before external workflow cancellation"
-    );
+    let mut teardown = teardown;
+    for (binding, phase_ids) in retained_delegate_bindings(scoped_root, workflow) {
+        teardown(&binding)?;
+        for phase_id in &phase_ids {
+            mark_environment_torn_down(scoped_root, &workflow.id, phase_id).with_context(|| {
+                format!(
+                    "node {} was torn down but its retained binding could not be marked for workflow {}/{}",
+                    binding.handle.id, workflow.id, phase_id
+                )
+            })?;
+        }
+        info!(
+            actor = protocol::ACTOR_DAEMON,
+            workflow_id = %workflow.id,
+            node = %binding.handle.id,
+            phases = ?phase_ids,
+            "released retained delegated node before external workflow cancellation"
+        );
+    }
     Ok(())
+}
+
+/// Group every untorn-down phase binding by exact environment handle. A
+/// healthy brokered workflow normally has one group (the same handle repeated
+/// by later phases); grouping also prevents duplicate teardown if several
+/// checkpoints reference it and safely exposes any historical extra lease.
+fn retained_delegate_bindings(
+    scoped_root: &Path,
+    workflow: &OrchestratorWorkflow,
+) -> Vec<(EnvironmentBinding, Vec<String>)> {
+    let mut groups: Vec<(EnvironmentBinding, Vec<String>)> = Vec::new();
+    for phase in &workflow.phases {
+        let Some(binding) = read_checkpoint(scoped_root, &workflow.id, &phase.phase_id)
+            .ok()
+            .flatten()
+            .and_then(|checkpoint| checkpoint.environment)
+            .filter(|binding| !binding.torn_down)
+        else {
+            continue;
+        };
+        if let Some((_, phase_ids)) = groups.iter_mut().find(|(candidate, _)| {
+            candidate.environment_id == binding.environment_id && candidate.handle == binding.handle
+        }) {
+            phase_ids.push(phase.phase_id.clone());
+        } else {
+            groups.push((binding, vec![phase.phase_id.clone()]));
+        }
+    }
+    groups
 }
 
 /// Liveness of a delegated node, as observed by a trivial exec probe.
@@ -2088,6 +2121,48 @@ mod tests {
         let checkpoint =
             read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
         assert!(checkpoint.environment.expect("binding").torn_down, "successful cleanup releases the hold");
+    }
+
+    #[tokio::test]
+    async fn external_cancel_finds_retained_binding_from_earlier_phase() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
+        let (scoped_root, retained_phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-from-earlier-phase")).await;
+
+        // Model cancellation after the workflow has advanced to a later
+        // manual/local phase whose checkpoint has no environment binding.
+        let (later_index, later_phase) = workflow
+            .phases
+            .iter()
+            .enumerate()
+            .find(|(_, phase)| phase.phase_id != retained_phase_id)
+            .expect("fixture has a later phase");
+        let mut later_workflow = workflow.clone();
+        later_workflow.current_phase_index = later_index;
+        later_workflow.current_phase = Some(later_phase.phase_id.clone());
+
+        let teardown_calls = AtomicUsize::new(0);
+        super::teardown_retained_environment_with(&scoped_root, &later_workflow, |binding| {
+            assert_eq!(binding.handle.id, "node-from-earlier-phase");
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("earlier retained binding is released");
+        super::teardown_retained_environment_with(&scoped_root, &later_workflow, |_| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("repeated cleanup is inert");
+
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1, "earlier retained handle tears down exactly once");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &retained_phase_id).expect("read").expect("checkpoint present");
+        assert!(checkpoint.environment.expect("binding").torn_down, "earlier binding is marked torn down");
     }
 
     #[tokio::test]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -310,7 +310,7 @@ fn current_delegate_binding(
 
 /// Liveness of a delegated node, as observed by a trivial exec probe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DelegateLiveness {
+pub(crate) enum DelegateLiveness {
     /// The node answered a trivial exec — it is up and reusable.
     Alive,
     /// The node/plugin failed every probe with a definitive death signal.
@@ -351,7 +351,7 @@ fn probe_error_is_transient(err: &anyhow::Error) -> bool {
 /// `true`, RETRIED up to [`PROBE_ATTEMPTS`] times: the first success => Alive;
 /// an unresolvable plugin => Unknown; all attempts failing => Unknown when the
 /// last failure looked transient (preserve + re-probe next sweep), else Dead.
-fn probe_delegate(project_root: &str, binding: &EnvironmentBinding) -> DelegateLiveness {
+pub(crate) fn probe_delegate(project_root: &str, binding: &EnvironmentBinding) -> DelegateLiveness {
     let client = match EnvironmentClient::resolve(Path::new(project_root), &binding.environment_id) {
         Ok(client) => client,
         Err(_) => return DelegateLiveness::Unknown,
@@ -406,35 +406,50 @@ fn delegate_is_dead(scoped_root: Option<&Path>, project_root: &str, workflow: &O
 /// gone), and `mark_environment_torn_down` is only written on success, so a
 /// failed reap is retried on the next sweep. Inert when there is no
 /// (un-torn-down) binding.
-fn teardown_delegated_node(project_root: &str, scoped_root: Option<&Path>, workflow: &OrchestratorWorkflow) {
-    let Some(scoped_root) = scoped_root else { return };
-    let Some((phase_id, binding)) = current_delegate_binding(scoped_root, workflow) else { return };
+fn teardown_delegated_node(project_root: &str, scoped_root: Option<&Path>, workflow: &OrchestratorWorkflow) -> bool {
+    let Some(scoped_root) = scoped_root else { return true };
+    let Some((phase_id, binding)) = current_delegate_binding(scoped_root, workflow) else { return true };
     match EnvironmentClient::resolve(Path::new(project_root), &binding.environment_id) {
         Ok(client) => match client.teardown(&binding.handle) {
             Ok(()) => {
-                let _ = mark_environment_torn_down(scoped_root, &workflow.id, &phase_id);
+                if let Err(error) = mark_environment_torn_down(scoped_root, &workflow.id, &phase_id) {
+                    warn!(
+                        actor = protocol::ACTOR_DAEMON,
+                        workflow_id = %workflow.id,
+                        %error,
+                        "node was reaped but its checkpoint could not be updated; idempotent teardown will retry"
+                    );
+                    return false;
+                }
                 info!(
                     actor = protocol::ACTOR_DAEMON,
                     workflow_id = %workflow.id,
                     node = %binding.handle.id,
                     "reaped delegated node by persisted handle during orphan reconciliation"
                 );
+                true
             }
-            Err(error) => warn!(
+            Err(error) => {
+                warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %workflow.id,
+                    node = %binding.handle.id,
+                    %error,
+                    "env teardown of delegated node failed; will retry on the next sweep"
+                );
+                false
+            }
+        },
+        Err(error) => {
+            warn!(
                 actor = protocol::ACTOR_DAEMON,
                 workflow_id = %workflow.id,
-                node = %binding.handle.id,
+                environment = %binding.environment_id,
                 %error,
-                "env teardown of delegated node failed; will retry on the next sweep"
-            ),
-        },
-        Err(error) => warn!(
-            actor = protocol::ACTOR_DAEMON,
-            workflow_id = %workflow.id,
-            environment = %binding.environment_id,
-            %error,
-            "cannot resolve environment plugin to reap delegated node; will retry on the next sweep"
-        ),
+                "cannot resolve environment plugin to reap delegated node; will retry on the next sweep"
+            );
+            false
+        }
     }
 }
 
@@ -451,7 +466,12 @@ async fn terminalize_dead_delegation(
     workflow: &OrchestratorWorkflow,
 ) -> bool {
     let phase_id = current_phase_id(workflow).unwrap_or_default();
-    teardown_delegated_node(project_root, Some(scoped_root), workflow);
+    if !teardown_delegated_node(project_root, Some(scoped_root), workflow) {
+        // Keep both checkpoint and workflow Running. A terminal checkpoint is
+        // omitted from future sweeps, so terminalizing here would permanently
+        // suppress the promised cleanup retry and leak the node.
+        return false;
+    }
     let _ = update_session_failed(
         scoped_root,
         &workflow.id,
@@ -711,6 +731,13 @@ pub async fn recover_orphaned_running_workflows(
         let age_secs = (now - workflow.started_at).num_seconds();
         let within_grace = age_secs < ORPHAN_RECONCILIATION_GRACE_SECS;
         let resumable = is_resumable_orphan(&workflow);
+        // A persisted binding is stronger evidence than current routing
+        // intent. In particular startup deliberately does not load routing,
+        // and configuration may have changed since this run was dispatched.
+        // Always liveness-gate such a delegate before the generic
+        // journal-resume preserve branch, otherwise a dead node is preserved
+        // forever across every daemon restart.
+        let dead_delegate = !within_grace && delegate_is_dead(scoped_root.as_deref(), project_root, &workflow);
 
         let decision = if workflow.machine_state == WorkflowMachineState::MergeConflict {
             ReconcileDecision::MergeConflict
@@ -718,19 +745,16 @@ pub async fn recover_orphaned_running_workflows(
             ReconcileDecision::WaitingManual
         } else if in_runner_registry {
             ReconcileDecision::ProtectedLiveRunner
+        } else if dead_delegate {
+            ReconcileDecision::TerminalizeDeadDelegate
         } else if in_active_subjects {
             ReconcileDecision::ProtectedActiveSubject
         } else if is_delegated {
-            // TASK-793: refine rc.24's intent-based skip with the node's ACTUAL
-            // liveness. Only a delegate PAST GRACE whose persisted node probes
-            // DEAD is terminalized; alive / unverifiable / no-binding (and any
-            // within-grace delegate) keep rc.24's skip. `delegate_is_dead` is
-            // inert (false) until the companion runner persists a binding.
-            if !within_grace && delegate_is_dead(scoped_root.as_deref(), project_root, &workflow) {
-                ReconcileDecision::TerminalizeDeadDelegate
-            } else {
-                ReconcileDecision::SkippedDelegated
-            }
+            // Alive / unverifiable / no-binding (and any within-grace
+            // delegate) keep rc.24's fail-safe skip. Definitively dead
+            // persisted bindings were handled above, including at startup
+            // where routing is intentionally unavailable.
+            ReconcileDecision::SkippedDelegated
         } else if within_grace {
             ReconcileDecision::WithinGrace
         } else if resume_orphans && resumable {
@@ -827,7 +851,19 @@ pub async fn recover_orphaned_running_workflows(
                 // cancel so an orphan (e.g. a dead delegate handled at startup,
                 // where intent-gating is off) does not leak its node. Inert for
                 // local runs and until the companion runner persists a binding.
-                teardown_delegated_node(project_root, scoped_root.as_deref(), &workflow);
+                if !teardown_delegated_node(project_root, scoped_root.as_deref(), &workflow) {
+                    // Cancellation makes the workflow/checkpoint terminal and
+                    // removes it from subsequent orphan sweeps. Keep it Running
+                    // when cleanup fails so the persisted binding remains a
+                    // retryable cleanup obligation instead of becoming a
+                    // permanently leaked node.
+                    error!(
+                        actor = protocol::ACTOR_DAEMON,
+                        workflow_id = %workflow.id,
+                        "delegated node cleanup failed; deferring orphan cancellation so teardown can retry"
+                    );
+                    continue;
+                }
                 let cancelled = cancel_orphaned_running_workflow(hub.clone(), project_root, &workflow).await;
                 if cancelled {
                     recovered = recovered.saturating_add(1);
@@ -994,6 +1030,7 @@ pub(crate) async fn resumable_orphans_for_redispatch(
     // delegating runner's QUALIFIED active/orphan ids (see `bare_subject_id`).
     let active_subject_bare: HashSet<&str> = active_subject_ids.iter().map(|s| bare_subject_id(s)).collect();
     let live_orphan_bare: HashSet<&str> = live_orphan_subjects.iter().map(|s| bare_subject_id(s)).collect();
+    let scoped_root = protocol::scoped_state_root(Path::new(project_root));
 
     let mut candidates = Vec::new();
     let mut evaluated = 0usize;
@@ -1024,6 +1061,7 @@ pub(crate) async fn resumable_orphans_for_redispatch(
         let age_secs = (now - workflow.started_at).num_seconds();
         let within_grace = age_secs < ORPHAN_RECONCILIATION_GRACE_SECS;
         let resumable = is_resumable_orphan(&workflow);
+        let dead_delegate = !within_grace && delegate_is_dead(scoped_root.as_deref(), project_root, &workflow);
 
         let decision = if workflow.machine_state == WorkflowMachineState::MergeConflict {
             ReconcileDecision::MergeConflict
@@ -1031,6 +1069,8 @@ pub(crate) async fn resumable_orphans_for_redispatch(
             ReconcileDecision::WaitingManual
         } else if in_runner_registry {
             ReconcileDecision::ProtectedLiveRunner
+        } else if dead_delegate {
+            ReconcileDecision::TerminalizeDeadDelegate
         } else if in_active_subjects {
             ReconcileDecision::ProtectedActiveSubject
         } else if is_delegated {
@@ -1079,17 +1119,27 @@ pub(crate) async fn resumable_orphans_for_redispatch(
                 selected += 1;
                 candidates.push(workflow);
             }
+            ReconcileDecision::TerminalizeDeadDelegate => {
+                warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %workflow.id,
+                    workflow_ref = workflow.workflow_ref.as_deref().unwrap_or_default(),
+                    "dead delegated node reached redispatch sweep; terminalizing instead of spawning a replacement"
+                );
+                if let Some(scoped_root) = scoped_root.as_deref() {
+                    let _ = terminalize_dead_delegation(hub.clone(), project_root, scoped_root, &workflow).await;
+                }
+            }
             // All other outcomes exclude the run from re-dispatch (no-op). A
-            // dead delegate is terminalized by the cancel leg (which sets it
-            // Cancelled, so it never reaches this Running-only leg); the variant
-            // is matched exhaustively but never arises here.
+            // dead delegate normally gets terminalized by the cancel leg first,
+            // but this leg independently applies the same gate so callers
+            // cannot re-dispatch-and-leak when invoked on its own.
             ReconcileDecision::MergeConflict
             | ReconcileDecision::WaitingManual
             | ReconcileDecision::SkippedLiveOrphan
             | ReconcileDecision::SkippedBlockedResume
             | ReconcileDecision::WithinGrace
             | ReconcileDecision::NotResumable
-            | ReconcileDecision::TerminalizeDeadDelegate
             | ReconcileDecision::PreservedResumable
             | ReconcileDecision::CancelledOrphan => {}
         }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -2004,8 +2004,11 @@ mod tests {
         assert_eq!(reloaded.status, WorkflowStatus::Running, "unverifiable delegate stays Running");
     }
 
-    // TASK-811: terminalize_dead_delegation drives the checkpoint Failed (so it
-    // never re-surfaces for auto-resume) and cancels the workflow.
+    // TASK-811: after the delegated node has been successfully reaped,
+    // terminalize_dead_delegation drives the checkpoint Failed (so it never
+    // re-surfaces for auto-resume) and cancels the workflow. Marking the
+    // fixture binding torn down models that successful cleanup without making
+    // this unit test depend on an installed environment plugin.
     #[tokio::test]
     async fn terminalize_dead_delegation_fails_checkpoint_and_cancels_workflow() {
         let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -2013,6 +2016,8 @@ mod tests {
         let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
         let (scoped_root, phase_id) =
             bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-dead")).await;
+        animus_runtime_shared::phase_session::mark_environment_torn_down(&scoped_root, &workflow_id, &phase_id)
+            .expect("model successful delegated-node teardown");
         let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
 
         let cancelled = super::terminalize_dead_delegation(hub.clone(), &project_root, &scoped_root, &workflow).await;

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -5,7 +5,7 @@ use animus_environment_protocol::{ExecResponse, HarnessCommand};
 use animus_runtime_shared::phase_session::{
     mark_environment_torn_down, read_checkpoint, update_session_failed, EnvironmentBinding,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use orchestrator_core::{
     active_workflow_runner_ids, dispatch_workflow_event, load_agent_runtime_config_or_default, services::ServiceHub,
     workflow_runner_liveness, EnvironmentClient, OrchestratorWorkflow, RunnerLiveness, WorkflowConfig, WorkflowEvent,
@@ -306,6 +306,62 @@ fn current_delegate_binding(
     let checkpoint = read_checkpoint(scoped_root, &workflow.id, &phase_id).ok()??;
     let binding = checkpoint.environment.filter(|binding| !binding.torn_down)?;
     Some((phase_id, binding))
+}
+
+/// Release the exact delegated node retained by a workflow before an external
+/// cancellation is committed. The teardown happens first and the durable
+/// binding is marked only after it succeeds, so a failed cleanup leaves the
+/// workflow and checkpoint retryable. Repeated calls are idempotent because a
+/// marked binding is no longer returned by `current_delegate_binding`.
+pub(crate) fn teardown_retained_environment_for_cancel(
+    project_root: &str,
+    workflow: &OrchestratorWorkflow,
+) -> anyhow::Result<()> {
+    let Some(scoped_root) = protocol::scoped_state_root(Path::new(project_root)) else {
+        return Ok(());
+    };
+    teardown_retained_environment_with(&scoped_root, workflow, |binding| {
+        let client =
+            EnvironmentClient::resolve(Path::new(project_root), &binding.environment_id).with_context(|| {
+                format!(
+                    "cannot resolve environment plugin '{}' to cancel retained node {} for workflow {}",
+                    binding.environment_id, binding.handle.id, workflow.id
+                )
+            })?;
+        client.teardown(&binding.handle).with_context(|| {
+            format!(
+                "failed to teardown retained node {} in environment '{}' for cancelled workflow {}",
+                binding.handle.id, binding.environment_id, workflow.id
+            )
+        })
+    })
+}
+
+fn teardown_retained_environment_with<F>(
+    scoped_root: &Path,
+    workflow: &OrchestratorWorkflow,
+    teardown: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(&EnvironmentBinding) -> anyhow::Result<()>,
+{
+    let Some((phase_id, binding)) = current_delegate_binding(scoped_root, workflow) else {
+        return Ok(());
+    };
+    teardown(&binding)?;
+    mark_environment_torn_down(scoped_root, &workflow.id, &phase_id).with_context(|| {
+        format!(
+            "node {} was torn down but its retained binding could not be marked for workflow {}/{}",
+            binding.handle.id, workflow.id, phase_id
+        )
+    })?;
+    info!(
+        actor = protocol::ACTOR_DAEMON,
+        workflow_id = %workflow.id,
+        node = %binding.handle.id,
+        "released retained delegated node before external workflow cancellation"
+    );
+    Ok(())
 }
 
 /// Liveness of a delegated node, as observed by a trivial exec probe.
@@ -1996,6 +2052,57 @@ mod tests {
         assert!(
             checkpoint.environment.expect("binding present").torn_down,
             "an already-reaped binding stays torn_down (no double-free)"
+        );
+    }
+
+    #[tokio::test]
+    async fn external_cancel_releases_retained_node_once_then_marks_binding() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-held")).await;
+        let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
+        let teardown_calls = AtomicUsize::new(0);
+
+        super::teardown_retained_environment_with(&scoped_root, &workflow, |binding| {
+            assert_eq!(binding.handle.id, "node-held");
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("first cancellation cleanup");
+        super::teardown_retained_environment_with(&scoped_root, &workflow, |_| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("idempotent repeated cleanup");
+
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1, "retained node is torn down exactly once");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(checkpoint.environment.expect("binding").torn_down, "successful cleanup releases the hold");
+    }
+
+    #[tokio::test]
+    async fn failed_external_cancel_cleanup_keeps_binding_retryable() {
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-held")).await;
+        let workflow = hub.workflows().get(&workflow_id).await.expect("workflow loads");
+
+        let err =
+            super::teardown_retained_environment_with(&scoped_root, &workflow, |_| anyhow::bail!("relay unavailable"))
+                .expect_err("failed cleanup must abort cancellation");
+        assert!(format!("{err:#}").contains("relay unavailable"));
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(
+            !checkpoint.environment.expect("binding").torn_down,
+            "failed teardown must leave the durable hold available for retry"
         );
     }
 }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -52,6 +52,9 @@ pub(super) enum ResumeLookup {
 #[async_trait::async_trait(?Send)]
 pub(super) trait ResumeProviderRegistry {
     async fn try_resume(&self, checkpoint: &SessionCheckpoint) -> ResumeLookup;
+    /// Release the broker-owned workflow lease after an adopted final phase
+    /// reaches terminal workflow state. Implementations must be idempotent.
+    async fn teardown_retained_environment(&self, workflow_id: &str);
 }
 
 // Applies a resumed phase outcome back to durable workflow state once the
@@ -69,12 +72,19 @@ pub(super) trait ResumedOutcomeApplier {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ResumedOutcomeApplyResult {
-    // Workflow state was advanced and session checkpoint flipped to Completed.
+    // Workflow state advanced to another phase/paused handoff and the session
+    // checkpoint flipped to Completed. Retain a broker-owned lease.
     Advanced,
+    // Workflow state advanced to a terminal status. A broker-owned retained
+    // lease must now be torn down because no WorkflowProcess exists to do it.
+    AdvancedTerminal,
     // The workflow had already advanced past this phase (durable marker was
     // already on disk from a previous restart). We still flipped the session
     // checkpoint to Completed but did not double-advance.
     AlreadyAdvanced,
+    // Idempotent replay discovered that the workflow was already terminal;
+    // cleanup may have been the crash boundary, so retry broker teardown.
+    AlreadyAdvancedTerminal,
     // The phase is decision-gated (review/QA/testing/etc.) so we refuse to
     // synthesize an `Advance` verdict from the resumed session. The session
     // checkpoint is marked Blocked with an actionable reason so the operator
@@ -296,6 +306,12 @@ impl ResumeProviderRegistry for ProductionResumeProviderRegistry {
         };
         ResumeLookup::Outcome(backend.resume_agent_for_restart(session_id, request).await)
     }
+
+    async fn teardown_retained_environment(&self, workflow_id: &str) {
+        if let Some(broker) = &self.environment_broker {
+            broker.teardown(workflow_id).await;
+        }
+    }
 }
 
 // Production wiring of `ResumedOutcomeApplier` that drives the in-tree
@@ -408,7 +424,11 @@ pub(super) async fn apply_resumed_outcome_in_tree(
                 "workflow already advanced past phase '{phase_id}' but failed to mark session completed: {err}"
             ));
         }
-        return ResumedOutcomeApplyResult::AlreadyAdvanced;
+        return if workflow_terminal {
+            ResumedOutcomeApplyResult::AlreadyAdvancedTerminal
+        } else {
+            ResumedOutcomeApplyResult::AlreadyAdvanced
+        };
     }
 
     // Decision-gated phases (review/QA/testing), phases that own a
@@ -490,7 +510,11 @@ pub(super) async fn apply_resumed_outcome_in_tree(
         ));
     }
 
-    ResumedOutcomeApplyResult::Advanced
+    if workflow_terminal_after {
+        ResumedOutcomeApplyResult::AdvancedTerminal
+    } else {
+        ResumedOutcomeApplyResult::Advanced
+    }
 }
 
 // Returns the set of workflow_ids that have a Running session checkpoint
@@ -574,6 +598,15 @@ where
                 // don't pick it back up.
                 match applier.apply(&checkpoint, session_id.as_deref()).await {
                     ResumedOutcomeApplyResult::Advanced | ResumedOutcomeApplyResult::AlreadyAdvanced => {
+                        report.resumed += 1;
+                    }
+                    ResumedOutcomeApplyResult::AdvancedTerminal
+                    | ResumedOutcomeApplyResult::AlreadyAdvancedTerminal => {
+                        if retained_environment {
+                            registry.teardown_retained_environment(&checkpoint.workflow_id).await;
+                            let _ =
+                                mark_environment_torn_down(scoped_root, &checkpoint.workflow_id, &checkpoint.phase_id);
+                        }
                         report.resumed += 1;
                     }
                     ResumedOutcomeApplyResult::BlockedAwaitingDecision => {
@@ -1496,9 +1529,9 @@ mod tests {
             ResumedOutcomeApplyResult,
         };
         use animus_runtime_shared::phase_session::{
-            read_checkpoint, update_provider_session_id, update_session_environment, update_session_running,
-            update_session_running_after_resume, write_session_pending, EnvironmentBinding, SessionCheckpoint,
-            SessionCheckpointStatus,
+            read_checkpoint, update_provider_session_id, update_session_completed, update_session_environment,
+            update_session_running, update_session_running_after_resume, write_session_pending, EnvironmentBinding,
+            SessionCheckpoint, SessionCheckpointStatus,
         };
         use async_trait::async_trait;
         use orchestrator_plugin_host::session::ResumeAgentOutcome;
@@ -1515,12 +1548,17 @@ mod tests {
 
         struct ScriptedRegistry {
             scripts: Mutex<HashMap<String, Script>>,
+            teardowns: Mutex<Vec<String>>,
         }
 
         impl ScriptedRegistry {
             fn new(entries: Vec<(&str, Script)>) -> Self {
                 let scripts = entries.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
-                Self { scripts: Mutex::new(scripts) }
+                Self { scripts: Mutex::new(scripts), teardowns: Mutex::new(Vec::new()) }
+            }
+
+            fn teardown_calls(&self) -> Vec<String> {
+                self.teardowns.lock().expect("teardowns mutex").clone()
             }
         }
 
@@ -1540,6 +1578,10 @@ mod tests {
                     Some(Script::Failed { reason }) => ResumeLookup::Outcome(ResumeAgentOutcome::Failed { reason }),
                     None => ResumeLookup::NotInstalled,
                 }
+            }
+
+            async fn teardown_retained_environment(&self, workflow_id: &str) {
+                self.teardowns.lock().expect("teardowns mutex").push(workflow_id.to_string());
             }
         }
 
@@ -1593,6 +1635,12 @@ mod tests {
                         &checkpoint.phase_id,
                         new_session_id,
                     );
+                }
+                if matches!(
+                    &self.result,
+                    ResumedOutcomeApplyResult::AdvancedTerminal | ResumedOutcomeApplyResult::AlreadyAdvancedTerminal
+                ) {
+                    let _ = update_session_completed(&self.scoped_root, &checkpoint.workflow_id, &checkpoint.phase_id);
                 }
                 self.result.clone()
             }
@@ -1759,6 +1807,55 @@ mod tests {
                 !after.environment.expect("binding retained").torn_down,
                 "broker-owned node binding remains live for the next phase"
             );
+            assert!(registry.teardown_calls().is_empty(), "a non-terminal resumed phase retains the adopted lease");
+        }
+
+        #[tokio::test]
+        async fn terminal_retained_environment_resume_tears_down_adopted_lease_once() {
+            let temp = TempDir::new().expect("tempdir");
+            let scoped = temp.path();
+            write_session_pending(
+                scoped,
+                "wf-delegated-final",
+                "publish",
+                "claude",
+                "run-delegated-final",
+                Some(json!({"context": {"prompt": "publish", "model": "claude-sonnet-4-6"}})),
+            )
+            .expect("pending");
+            update_session_running(scoped, "wf-delegated-final", "publish").expect("running");
+            update_session_environment(
+                scoped,
+                "wf-delegated-final",
+                "publish",
+                EnvironmentBinding {
+                    environment_id: "railway".to_string(),
+                    handle: animus_environment_protocol::EnvironmentHandle {
+                        id: "adopted-h1".to_string(),
+                        workspace_root: "/workspace".to_string(),
+                        metadata: serde_json::Value::Null,
+                    },
+                    bound_at: chrono::Utc::now().to_rfc3339(),
+                    torn_down: false,
+                },
+            )
+            .expect("environment binding");
+
+            let registry =
+                ScriptedRegistry::new(vec![("claude", Script::RetainedEnvironmentResumed { new_session_id: None })]);
+            let applier =
+                RecordingApplier::new(ResumedOutcomeApplyResult::AdvancedTerminal, false, scoped.to_path_buf());
+
+            let first = auto_resume_running_checkpoints(scoped, &registry, &applier).await;
+            assert_eq!(first.resumed, 1);
+            assert_eq!(registry.teardown_calls(), vec!["wf-delegated-final".to_string()]);
+            let after =
+                read_checkpoint(scoped, "wf-delegated-final", "publish").expect("read").expect("checkpoint present");
+            assert!(after.environment.expect("binding").torn_down, "terminal resume records cleanup");
+
+            let second = auto_resume_running_checkpoints(scoped, &registry, &applier).await;
+            assert_eq!(second.resumed, 0, "completed checkpoint is not resumed twice");
+            assert_eq!(registry.teardown_calls().len(), 1, "terminal lease teardown occurs exactly once");
         }
 
         #[tokio::test]
@@ -2093,7 +2190,7 @@ mod tests {
                 Some("sess-rotated"),
             )
             .await;
-            assert_eq!(result, ResumedOutcomeApplyResult::Advanced);
+            assert_eq!(result, ResumedOutcomeApplyResult::AdvancedTerminal);
 
             let after = read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("present");
             assert_eq!(after.status, SessionCheckpointStatus::Completed);
@@ -2143,7 +2240,7 @@ mod tests {
             let result =
                 apply_resumed_outcome_in_tree(&project_root, &scoped_root, hub.clone(), &checkpoint, Some("sess-x"))
                     .await;
-            assert_eq!(result, ResumedOutcomeApplyResult::Advanced);
+            assert_eq!(result, ResumedOutcomeApplyResult::AdvancedTerminal);
 
             let after = hub.workflows().get(&workflow_id).await.expect("workflow after");
             let advanced = after.current_phase_index > before_index
@@ -2209,7 +2306,7 @@ mod tests {
             let first =
                 apply_resumed_outcome_in_tree(&project_root, &scoped_root, hub.clone(), &checkpoint, Some("sess-1"))
                     .await;
-            assert_eq!(first, ResumedOutcomeApplyResult::Advanced);
+            assert_eq!(first, ResumedOutcomeApplyResult::AdvancedTerminal);
 
             // Re-read the checkpoint (it's now Completed) but pretend a
             // crash left the OLD Running checkpoint for the same phase.
@@ -2228,7 +2325,7 @@ mod tests {
             .await;
             assert_eq!(
                 second,
-                ResumedOutcomeApplyResult::AlreadyAdvanced,
+                ResumedOutcomeApplyResult::AlreadyAdvancedTerminal,
                 "second apply MUST NOT double-advance the workflow"
             );
 

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -29,18 +29,21 @@ use super::daemon_run_host::DefaultDaemonRunHost;
 use super::daemon_scheduler::{runtime_options_from_cli, slim_project_tick_driver, SlimProjectTickDriver};
 use animus_runtime_shared::persist_resumed_phase_completion;
 use animus_runtime_shared::phase_session::{
-    list_running_checkpoints, update_session_blocked, update_session_completed, update_session_running_after_resume,
-    SessionCheckpoint,
+    list_running_checkpoints, mark_environment_torn_down, update_session_blocked, update_session_completed,
+    update_session_running_after_resume, SessionCheckpoint,
 };
 use orchestrator_plugin_host::session::{
     canonical_tool_alias, discover_provider_plugins, PluginSessionBackend, ResumeAgentOutcome,
 };
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(super) enum ResumeLookup {
     NotInstalled,
     Outcome(ResumeAgentOutcome),
+    /// The delegated node could not be verified this sweep. Keep the
+    /// checkpoint Running so liveness can be retried later.
+    Deferred,
 }
 
 #[async_trait::async_trait(?Send)]
@@ -160,6 +163,7 @@ fn phase_requires_explicit_decision_for_resume_in_workflow(
 
 struct ProductionResumeProviderRegistry {
     providers: HashMap<String, Arc<PluginSessionBackend>>,
+    project_root: PathBuf,
 }
 
 impl ProductionResumeProviderRegistry {
@@ -168,7 +172,7 @@ impl ProductionResumeProviderRegistry {
             .into_iter()
             .map(|plugin| (plugin.provider_tool.to_ascii_lowercase(), plugin.into_backend()))
             .collect();
-        Self { providers }
+        Self { providers, project_root: project_root.to_path_buf() }
     }
 }
 
@@ -191,6 +195,56 @@ fn resolve_resume_provider_key(provider_keys: &[String], checkpoint_provider: &s
 #[async_trait::async_trait(?Send)]
 impl ResumeProviderRegistry for ProductionResumeProviderRegistry {
     async fn try_resume(&self, checkpoint: &SessionCheckpoint) -> ResumeLookup {
+        if let Some(binding) = checkpoint.environment.as_ref() {
+            match super::daemon_reconciliation::probe_delegate(self.project_root.to_string_lossy().as_ref(), binding) {
+                super::daemon_reconciliation::DelegateLiveness::Unknown => {
+                    tracing::warn!(
+                        actor = protocol::ACTOR_DAEMON,
+                        workflow_id = %checkpoint.workflow_id,
+                        phase_id = %checkpoint.phase_id,
+                        "delegated node liveness is unknown; preserving Running checkpoint for retry"
+                    );
+                    return ResumeLookup::Deferred;
+                }
+                super::daemon_reconciliation::DelegateLiveness::Dead => {
+                    // Reconciliation owns dead-delegate terminalization because
+                    // it can reap the handle and cancel the workflow as one
+                    // retryable transition. Mapping this to a generic resume
+                    // failure would mark the checkpoint Blocked and shield the
+                    // ghost from every later cleanup sweep.
+                    tracing::warn!(
+                        actor = protocol::ACTOR_DAEMON,
+                        workflow_id = %checkpoint.workflow_id,
+                        phase_id = %checkpoint.phase_id,
+                        "delegated node is dead; deferring to orphan reconciliation for reap and terminalization"
+                    );
+                    return ResumeLookup::Deferred;
+                }
+                super::daemon_reconciliation::DelegateLiveness::Alive => {}
+            }
+            return match super::super::runtime_agent::environment_exec::resume_environment_checkpoint(
+                &self.project_root,
+                checkpoint,
+            )
+            .await
+            {
+                super::super::runtime_agent::environment_exec::EnvironmentCheckpointResume::Outcome(outcome) => {
+                    ResumeLookup::Outcome(outcome)
+                }
+                super::super::runtime_agent::environment_exec::EnvironmentCheckpointResume::CleanupPending {
+                    reason,
+                } => {
+                    tracing::warn!(
+                        actor = protocol::ACTOR_DAEMON,
+                        workflow_id = %checkpoint.workflow_id,
+                        phase_id = %checkpoint.phase_id,
+                        %reason,
+                        "delegated node cleanup is pending; preserving Running checkpoint for teardown retry"
+                    );
+                    ResumeLookup::Deferred
+                }
+            };
+        }
         // Codex round 8 P2 #2: historical workflows wrote
         // `checkpoint.provider = "oai-runner"` (or `"animus-oai-runner"`),
         // but the installed first-party plugin registers under
@@ -416,8 +470,9 @@ pub(super) async fn apply_resumed_outcome_in_tree(
 }
 
 // Returns the set of workflow_ids that have a Running session checkpoint
-// with a captured provider_session_id — i.e. workflows that
-// auto_resume_running_checkpoints can actually attempt to resume. These
+// which auto_resume_running_checkpoints can recover. Local providers require
+// a captured provider_session_id; a delegated checkpoint can also recover
+// without one by re-running the command on its still-live prepared node. These
 // must be excluded from orphan recovery at daemon startup; otherwise
 // recover_orphaned_running_workflows would cancel them before the resume
 // pass ever runs. Returns an empty set when the scoped state root is
@@ -436,7 +491,8 @@ pub(super) fn resumable_workflow_ids_for_project(project_root: &str) -> std::col
         .filter_map(|(_, checkpoint)| {
             let has_sid =
                 checkpoint.provider_session_id.as_deref().map(str::trim).as_ref().is_some_and(|s| !s.is_empty());
-            if has_sid {
+            let has_reusable_environment = checkpoint.environment.as_ref().is_some_and(|binding| !binding.torn_down);
+            if has_sid || has_reusable_environment {
                 Some(checkpoint.workflow_id)
             } else {
                 None
@@ -460,25 +516,6 @@ where
         Err(_) => return report,
     };
     for (_path, checkpoint) in running {
-        // TASK-933: a DELEGATED coding phase's provider session lives INSIDE the
-        // remote node prepared by an `environment` plugin, NOT in a local
-        // provider plugin. The daemon must not try to resume it against a local
-        // plugin — that plugin never issued the session id and would reject it,
-        // mis-blocking the checkpoint with a misleading reinstall hint. Leave it
-        // Running so the companion runner re-dispatch reuses the node (skip
-        // prepare + `--resume` on the live handle); a dead node was already
-        // terminalized by `recover_orphaned_running_workflows`. This branch is
-        // inert until the companion runner persists `environment` (the field is
-        // `None` for every local run and for every runner without the change).
-        if checkpoint.environment.is_some() {
-            tracing::info!(
-                actor = protocol::ACTOR_DAEMON,
-                workflow_id = %checkpoint.workflow_id,
-                phase_id = %checkpoint.phase_id,
-                "delegated phase: skipping local provider resume; preserved for runner re-dispatch to reuse the node (TASK-933)"
-            );
-            continue;
-        }
         // Guard rail: provider plugins can only resume an external session
         // they themselves issued. If no provider_session_id was captured
         // before the daemon crashed, dispatching ANY id (the run_id, an
@@ -487,7 +524,7 @@ where
         // block with an actionable, --force-aware reason instead.
         let provider_sid_present =
             checkpoint.provider_session_id.as_deref().map(str::trim).as_ref().is_some_and(|sid| !sid.is_empty());
-        if !provider_sid_present {
+        if !provider_sid_present && checkpoint.environment.is_none() {
             let reason =
                 "no provider session_id captured before crash; phase will re-run from scratch on resume --force"
                     .to_string();
@@ -497,6 +534,9 @@ where
         }
         match registry.try_resume(&checkpoint).await {
             ResumeLookup::Outcome(ResumeAgentOutcome::Resumed { session_id }) => {
+                if checkpoint.environment.is_some() {
+                    let _ = mark_environment_torn_down(scoped_root, &checkpoint.workflow_id, &checkpoint.phase_id);
+                }
                 // Codex round-7 P1: the resumed agent has finished, but
                 // until we apply the outcome back through the workflow
                 // service the run stays stuck in Running with no
@@ -538,6 +578,7 @@ where
                 let _ = update_session_blocked(scoped_root, &checkpoint.workflow_id, &checkpoint.phase_id, &reason);
                 report.blocked_uninstalled += 1;
             }
+            ResumeLookup::Deferred => {}
         }
     }
     report
@@ -1315,7 +1356,8 @@ mod tests {
         use super::super::resumable_workflow_ids_for_project;
         use super::*;
         use animus_runtime_shared::phase_session::{
-            update_provider_session_id, update_session_running, write_session_pending,
+            update_provider_session_id, update_session_environment, update_session_running, write_session_pending,
+            EnvironmentBinding,
         };
         use serde_json::json;
 
@@ -1365,6 +1407,22 @@ mod tests {
             )
             .expect("seed noid pending");
             update_session_running(&scoped_root, "wf-noid", "impl").expect("seed noid running");
+            update_session_environment(
+                &scoped_root,
+                "wf-noid",
+                "impl",
+                EnvironmentBinding {
+                    environment_id: "railway".to_string(),
+                    handle: animus_environment_protocol::EnvironmentHandle {
+                        id: "node-live".to_string(),
+                        workspace_root: "/workspace".to_string(),
+                        metadata: serde_json::Value::Null,
+                    },
+                    bound_at: chrono::Utc::now().to_rfc3339(),
+                    torn_down: false,
+                },
+            )
+            .expect("bind reusable delegated environment");
 
             let shielded = resumable_workflow_ids_for_project(&project_root);
             assert!(
@@ -1372,10 +1430,10 @@ mod tests {
                 "workflow with provider_session_id MUST be shielded from orphan cancellation"
             );
             assert!(
-                !shielded.contains("wf-noid"),
-                "workflow without provider_session_id MUST NOT be shielded (nothing to resume)"
+                shielded.contains("wf-noid"),
+                "live delegated workflow without a provider session id must reach on-node fresh resume"
             );
-            assert_eq!(shielded.len(), 1, "shield set contains exactly the resumable workflows");
+            assert_eq!(shielded.len(), 2, "shield set contains both recoverable workflows");
         }
 
         #[test]
@@ -1398,8 +1456,9 @@ mod tests {
             ResumedOutcomeApplyResult,
         };
         use animus_runtime_shared::phase_session::{
-            read_checkpoint, update_provider_session_id, update_session_running, update_session_running_after_resume,
-            write_session_pending, SessionCheckpoint, SessionCheckpointStatus,
+            read_checkpoint, update_provider_session_id, update_session_environment, update_session_running,
+            update_session_running_after_resume, write_session_pending, EnvironmentBinding, SessionCheckpoint,
+            SessionCheckpointStatus,
         };
         use async_trait::async_trait;
         use orchestrator_plugin_host::session::ResumeAgentOutcome;
@@ -1608,6 +1667,48 @@ mod tests {
                 "expected explicit 'no provider session_id captured' guidance, got: {reason}"
             );
             assert!(applier.calls().is_empty(), "applier must NOT be invoked when provider_session_id is missing");
+        }
+
+        #[tokio::test]
+        async fn auto_resume_dispatches_delegated_checkpoint_without_provider_session_id() {
+            let temp = TempDir::new().expect("tempdir");
+            let scoped = temp.path();
+            write_session_pending(
+                scoped,
+                "wf-delegated-noid",
+                "impl",
+                "claude",
+                "run-delegated",
+                Some(json!({"context": {"prompt": "continue", "model": "claude-sonnet-4-6"}})),
+            )
+            .expect("pending");
+            update_session_running(scoped, "wf-delegated-noid", "impl").expect("running");
+            update_session_environment(
+                scoped,
+                "wf-delegated-noid",
+                "impl",
+                EnvironmentBinding {
+                    environment_id: "railway".to_string(),
+                    handle: animus_environment_protocol::EnvironmentHandle {
+                        id: "live-node".to_string(),
+                        workspace_root: "/workspace".to_string(),
+                        metadata: serde_json::Value::Null,
+                    },
+                    bound_at: chrono::Utc::now().to_rfc3339(),
+                    torn_down: false,
+                },
+            )
+            .expect("environment binding");
+
+            let registry = ScriptedRegistry::new(vec![("claude", Script::Resumed { new_session_id: None })]);
+            let applier = RecordingApplier::new(ResumedOutcomeApplyResult::Advanced, false, scoped.to_path_buf());
+
+            let report = auto_resume_running_checkpoints(scoped, &registry, &applier).await;
+            assert_eq!(report.resumed, 1);
+            assert_eq!(report.blocked_on_failure, 0);
+            assert_eq!(applier.calls(), vec![("wf-delegated-noid".to_string(), "impl".to_string(), None)]);
+            let after = read_checkpoint(scoped, "wf-delegated-noid", "impl").expect("read").expect("present");
+            assert!(after.environment.expect("binding retained").torn_down);
         }
 
         #[tokio::test]

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -19,7 +19,6 @@ use orchestrator_daemon_runtime::control::{DaemonOpsRouting, PluginRouting, Queu
 use orchestrator_daemon_runtime::{
     discover_installed_plugins, run_daemon, DaemonRunEvent, DaemonRunHooks, ProcessManager,
 };
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -17,7 +17,7 @@ use orchestrator_core::{
 };
 use orchestrator_daemon_runtime::control::{DaemonOpsRouting, PluginRouting, QueueRouting, WorkflowRouting};
 use orchestrator_daemon_runtime::{
-    discover_installed_plugins, run_daemon, DaemonRunEvent, DaemonRunHooks, ProcessManager,
+    discover_installed_plugins, run_daemon, DaemonRunEvent, DaemonRunHooks, EnvironmentBroker, ProcessManager,
 };
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -40,6 +40,10 @@ use std::path::{Path, PathBuf};
 pub(super) enum ResumeLookup {
     NotInstalled,
     Outcome(ResumeAgentOutcome),
+    /// The resumed command ran on a broker-owned workflow lease. Keep its
+    /// binding live so later phases acquire the exact same node; terminal
+    /// workflow completion or explicit cancellation owns teardown.
+    RetainedEnvironmentOutcome(ResumeAgentOutcome),
     /// The delegated node could not be verified this sweep. Keep the
     /// checkpoint Running so liveness can be retried later.
     Deferred,
@@ -163,15 +167,16 @@ fn phase_requires_explicit_decision_for_resume_in_workflow(
 struct ProductionResumeProviderRegistry {
     providers: HashMap<String, Arc<PluginSessionBackend>>,
     project_root: PathBuf,
+    environment_broker: Option<EnvironmentBroker>,
 }
 
 impl ProductionResumeProviderRegistry {
-    fn discover(project_root: &Path) -> Self {
+    fn discover(project_root: &Path, environment_broker: Option<EnvironmentBroker>) -> Self {
         let providers = discover_provider_plugins(project_root)
             .into_iter()
             .map(|plugin| (plugin.provider_tool.to_ascii_lowercase(), plugin.into_backend()))
             .collect();
-        Self { providers, project_root: project_root.to_path_buf() }
+        Self { providers, project_root: project_root.to_path_buf(), environment_broker }
     }
 }
 
@@ -221,14 +226,34 @@ impl ResumeProviderRegistry for ProductionResumeProviderRegistry {
                 }
                 super::daemon_reconciliation::DelegateLiveness::Alive => {}
             }
+            let Some(broker) = self.environment_broker.as_ref() else {
+                tracing::warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %checkpoint.workflow_id,
+                    phase_id = %checkpoint.phase_id,
+                    "delegated node is alive but no environment broker is available to retain it across phases"
+                );
+                return ResumeLookup::Deferred;
+            };
+            if !broker.owns_ready_lease(&checkpoint.workflow_id, &binding.environment_id, &binding.handle).await {
+                tracing::warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %checkpoint.workflow_id,
+                    phase_id = %checkpoint.phase_id,
+                    node = %binding.handle.id,
+                    "delegated node is alive but its exact lease was not adopted by this daemon; preserving for retry"
+                );
+                return ResumeLookup::Deferred;
+            }
             return match super::super::runtime_agent::environment_exec::resume_environment_checkpoint(
                 &self.project_root,
                 checkpoint,
+                true,
             )
             .await
             {
                 super::super::runtime_agent::environment_exec::EnvironmentCheckpointResume::Outcome(outcome) => {
-                    ResumeLookup::Outcome(outcome)
+                    ResumeLookup::RetainedEnvironmentOutcome(outcome)
                 }
                 super::super::runtime_agent::environment_exec::EnvironmentCheckpointResume::CleanupPending {
                     reason,
@@ -531,9 +556,12 @@ where
             report.blocked_on_failure += 1;
             continue;
         }
-        match registry.try_resume(&checkpoint).await {
-            ResumeLookup::Outcome(ResumeAgentOutcome::Resumed { session_id }) => {
-                if checkpoint.environment.is_some() {
+        let lookup = registry.try_resume(&checkpoint).await;
+        let retained_environment = matches!(&lookup, ResumeLookup::RetainedEnvironmentOutcome(_));
+        match lookup {
+            ResumeLookup::Outcome(ResumeAgentOutcome::Resumed { session_id })
+            | ResumeLookup::RetainedEnvironmentOutcome(ResumeAgentOutcome::Resumed { session_id }) => {
+                if checkpoint.environment.is_some() && !retained_environment {
                     let _ = mark_environment_torn_down(scoped_root, &checkpoint.workflow_id, &checkpoint.phase_id);
                 }
                 // Codex round-7 P1: the resumed agent has finished, but
@@ -565,7 +593,8 @@ where
                     }
                 }
             }
-            ResumeLookup::Outcome(ResumeAgentOutcome::Failed { reason }) => {
+            ResumeLookup::Outcome(ResumeAgentOutcome::Failed { reason })
+            | ResumeLookup::RetainedEnvironmentOutcome(ResumeAgentOutcome::Failed { reason }) => {
                 let _ = update_session_blocked(scoped_root, &checkpoint.workflow_id, &checkpoint.phase_id, &reason);
                 report.blocked_on_failure += 1;
             }
@@ -632,10 +661,16 @@ struct CliDaemonRunHost {
     daemon_ops_routing: Arc<dyn DaemonOpsRouting>,
     workflow_routing: Arc<dyn WorkflowRouting>,
     queue_routing: Arc<dyn QueueRouting>,
+    environment_broker: Option<EnvironmentBroker>,
 }
 
 impl CliDaemonRunHost {
-    fn new(project_root: &str, json: bool, start_config: DaemonStartConfig) -> Self {
+    fn new(
+        project_root: &str,
+        json: bool,
+        start_config: DaemonStartConfig,
+        environment_broker: Option<EnvironmentBroker>,
+    ) -> Self {
         let project_root_path = PathBuf::from(project_root);
         let plugin_routing = build_plugin_routing(project_root_path.clone());
         let daemon_ops_routing = build_daemon_ops_routing(project_root_path.clone(), SystemTime::now());
@@ -650,6 +685,7 @@ impl CliDaemonRunHost {
             daemon_ops_routing,
             workflow_routing,
             queue_routing,
+            environment_broker,
         }
     }
 
@@ -714,11 +750,10 @@ impl DaemonRunHooks for CliDaemonRunHost {
         let resume_orphans = journal_resume_enabled(project_root);
 
         // STARTUP passes `skip_live_delegated = false`: `EnvironmentBroker::start`
-        // → `reap_prior_daemon_records` has already torn down the prior daemon
-        // instance's remote nodes, so a delegated `Running` row surviving into
-        // startup is DEAD and must be handled here (resumed/cancelled) — shielding
-        // it would strand it `Running` forever. Only the steady-state sweep, where
-        // the delegate is still alive on its node, passes `true`.
+        // adopts a Ready lease that is still claimed by a resumable checkpoint
+        // and cold-reaps only unclaimed prior-daemon records. The resumable-id
+        // shield preserves an adopted run for auto-resume below; any delegated
+        // Running row outside that shield is dead and must be reconciled here.
         let orphans = recover_orphaned_running_workflows(
             startup_hub as Arc<dyn ServiceHub>,
             project_root,
@@ -729,7 +764,10 @@ impl DaemonRunHooks for CliDaemonRunHost {
         .await;
 
         if let Some(scoped_root) = protocol::repository_scope::scoped_state_root(std::path::Path::new(project_root)) {
-            let registry = ProductionResumeProviderRegistry::discover(std::path::Path::new(project_root));
+            let registry = ProductionResumeProviderRegistry::discover(
+                std::path::Path::new(project_root),
+                self.environment_broker.clone(),
+            );
             let apply_hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(project_root)?);
             let applier = FileResumedOutcomeApplier::new(project_root.to_string(), scoped_root.clone(), apply_hub);
             auto_resume_running_checkpoints(&scoped_root, &registry, &applier).await;
@@ -835,9 +873,10 @@ pub(super) async fn handle_daemon_run(args: DaemonRunArgs, project_root: &str, j
     // REQ-048 cross-phase environment broker: route non-local environments
     // through a daemon-owned node shared by every phase of a run. The routing
     // table decides which dispatches are brokered; the broker binds a private
-    // local socket and reaps any nodes leaked by a prior daemon instance. A
-    // bind failure is non-fatal — the runner then falls back to its own
-    // per-phase environment path.
+    // local socket, adopts a still-claimed Ready lease after restart, and reaps
+    // unclaimed nodes leaked by a prior daemon instance. A bind failure is
+    // non-fatal — the runner then falls back to its own per-phase environment
+    // path.
     process_manager.environment_routing = workflow_config.config.environment_routing.clone();
     // Map each workflow's `environment:` override (id -> environment id, lowercased
     // keys) so the broker gate can honor a workflow-level environment even when no
@@ -849,9 +888,10 @@ pub(super) async fn handle_daemon_run(args: DaemonRunArgs, project_root: &str, j
         .iter()
         .filter_map(|workflow| workflow.environment.as_ref().map(|env| (workflow.id.to_ascii_lowercase(), env.clone())))
         .collect();
-    match orchestrator_daemon_runtime::EnvironmentBroker::start(project_root).await {
+    let environment_broker = match orchestrator_daemon_runtime::EnvironmentBroker::start(project_root).await {
         Ok(broker) => {
-            process_manager = process_manager.with_environment_broker(broker);
+            process_manager = process_manager.with_environment_broker(broker.clone());
+            Some(broker)
         }
         Err(error) => {
             tracing::warn!(
@@ -859,9 +899,10 @@ pub(super) async fn handle_daemon_run(args: DaemonRunArgs, project_root: &str, j
                 %error,
                 "failed to start environment broker; workflow runners fall back to per-phase environment preparation"
             );
+            None
         }
-    }
-    let mut host = CliDaemonRunHost::new(project_root, json, start_config);
+    };
+    let mut host = CliDaemonRunHost::new(project_root, json, start_config, environment_broker);
     let logger = host.logger();
     let mut driver: SlimProjectTickDriver<'_> =
         slim_project_tick_driver(&runtime_options, &mut process_manager, logger);
@@ -1468,6 +1509,7 @@ mod tests {
 
         enum Script {
             Resumed { new_session_id: Option<String> },
+            RetainedEnvironmentResumed { new_session_id: Option<String> },
             Failed { reason: String },
         }
 
@@ -1489,6 +1531,11 @@ mod tests {
                 match guard.remove(&checkpoint.provider) {
                     Some(Script::Resumed { new_session_id }) => {
                         ResumeLookup::Outcome(ResumeAgentOutcome::Resumed { session_id: new_session_id })
+                    }
+                    Some(Script::RetainedEnvironmentResumed { new_session_id }) => {
+                        ResumeLookup::RetainedEnvironmentOutcome(ResumeAgentOutcome::Resumed {
+                            session_id: new_session_id,
+                        })
                     }
                     Some(Script::Failed { reason }) => ResumeLookup::Outcome(ResumeAgentOutcome::Failed { reason }),
                     None => ResumeLookup::NotInstalled,
@@ -1699,7 +1746,8 @@ mod tests {
             )
             .expect("environment binding");
 
-            let registry = ScriptedRegistry::new(vec![("claude", Script::Resumed { new_session_id: None })]);
+            let registry =
+                ScriptedRegistry::new(vec![("claude", Script::RetainedEnvironmentResumed { new_session_id: None })]);
             let applier = RecordingApplier::new(ResumedOutcomeApplyResult::Advanced, false, scoped.to_path_buf());
 
             let report = auto_resume_running_checkpoints(scoped, &registry, &applier).await;
@@ -1707,7 +1755,10 @@ mod tests {
             assert_eq!(report.blocked_on_failure, 0);
             assert_eq!(applier.calls(), vec![("wf-delegated-noid".to_string(), "impl".to_string(), None)]);
             let after = read_checkpoint(scoped, "wf-delegated-noid", "impl").expect("read").expect("present");
-            assert!(after.environment.expect("binding retained").torn_down);
+            assert!(
+                !after.environment.expect("binding retained").torn_down,
+                "broker-owned node binding remains live for the next phase"
+            );
         }
 
         #[tokio::test]

--- a/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
@@ -33,6 +33,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
+use animus_runtime_shared::phase_session::{list_running_checkpoints, update_session_environment, EnvironmentBinding};
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -236,6 +237,7 @@ impl EnvironmentBroker {
 
     /// Idempotently dispose the node for `run_id`: `Ready -> TearingDown ->
     /// TornDown`, delete the durable record, forget the run's pending context.
+    /// A failed teardown retains a retryable durable record.
     /// A no-op when no lease exists (already torn down, or never prepared).
     pub async fn teardown(&self, run_id: &str) {
         let lease = self.inner.leases.lock().await.remove(run_id);
@@ -252,8 +254,17 @@ impl EnvironmentBroker {
                     target: "animus.runtime.environment_broker",
                     run_id,
                     %error,
-                    "environment teardown failed; deleting lease record anyway (node may be reclaimed by the plugin GC sweep)"
+                    "environment teardown failed; retaining lease record for startup retry"
                 );
+                self.write_record(
+                    run_id,
+                    &lease.environment_id,
+                    &lease.project_root,
+                    LeaseState::TearingDown,
+                    Some(&handle),
+                );
+                self.forget_run(run_id);
+                return;
             }
         }
         self.delete_record(run_id);
@@ -290,7 +301,8 @@ impl EnvironmentBroker {
 
         // Slow path: prepare the node ONCE. Record BEFORE prepare so a crash
         // mid-prepare still leaves a durable marker for the startup reaper.
-        self.write_record(run_id, environment_id, &pending.project_root, LeaseState::Preparing, None);
+        self.write_record_required(run_id, environment_id, &pending.project_root, LeaseState::Preparing, None)
+            .with_context(|| format!("persisting preparing lease for run {run_id}"))?;
 
         let mut spec = spec;
         set_run_id_metadata(&mut spec, run_id);
@@ -310,7 +322,46 @@ impl EnvironmentBroker {
 
         match prepared {
             Ok((client, handle)) => {
-                self.write_record(run_id, environment_id, &pending.project_root, LeaseState::Ready, Some(&handle));
+                if let Err(error) = self.write_record_required(
+                    run_id,
+                    environment_id,
+                    &pending.project_root,
+                    LeaseState::Ready,
+                    Some(&handle),
+                ) {
+                    // Never expose/execute a prepared node whose complete
+                    // handle is not durable. Best-effort rollback keeps the
+                    // failure contained to acquire.
+                    let cleanup = client.teardown(&handle).err();
+                    return Err(error).with_context(|| {
+                        format!(
+                            "persisting ready lease for run {run_id}; prepared node cleanup: {}",
+                            cleanup
+                                .map(|error| format!("failed: {error:#}"))
+                                .unwrap_or_else(|| "succeeded".to_string())
+                        )
+                    });
+                }
+                if let Err(error) =
+                    bind_running_phase_checkpoint(&pending.project_root, run_id, environment_id, &handle)
+                {
+                    // The lease record is sufficient for cold reaping, but
+                    // restart resume and liveness reconciliation use the phase
+                    // checkpoint as their recovery oracle. Never let the
+                    // runner execute until that binding is durable too.
+                    let cleanup = client.teardown(&handle).err();
+                    if cleanup.is_none() {
+                        self.delete_record(run_id);
+                    }
+                    return Err(error).with_context(|| {
+                        format!(
+                            "persisting phase environment binding for run {run_id}; prepared node cleanup: {}",
+                            cleanup
+                                .map(|error| format!("failed: {error:#}"))
+                                .unwrap_or_else(|| "succeeded".to_string())
+                        )
+                    });
+                }
                 let response = (handle.workspace_root.clone(), handle.id.clone());
                 self.inner.leases.lock().await.insert(
                     run_id.to_string(),
@@ -393,6 +444,28 @@ impl EnvironmentBroker {
         }
     }
 
+    fn write_record_required(
+        &self,
+        run_id: &str,
+        environment_id: &str,
+        project_root: &str,
+        state: LeaseState,
+        handle: Option<&EnvironmentHandle>,
+    ) -> std::io::Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = LeaseRecord {
+            run_id: run_id.to_string(),
+            daemon_instance_id: self.inner.daemon_instance_id.clone(),
+            environment_id: environment_id.to_string(),
+            project_root: project_root.to_string(),
+            state,
+            handle: handle.cloned(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        write_record_atomic(&self.record_path(run_id), &record)
+    }
+
     fn delete_record(&self, run_id: &str) {
         let _ = std::fs::remove_file(self.record_path(run_id));
     }
@@ -422,6 +495,18 @@ impl EnvironmentBroker {
             if record.daemon_instance_id == self.inner.daemon_instance_id {
                 continue;
             }
+            // A Running delegated checkpoint is a durable claim on this exact
+            // node. Preserve it until startup reconciliation can probe/resume
+            // it; otherwise broker startup destroys the node before TASK-933
+            // recovery runs. Unclaimed records retain the cold-reap behavior.
+            if prior_record_is_claimed_for_resume(&record) {
+                tracing::info!(
+                    target: "animus.runtime.environment_broker",
+                    run_id = %record.run_id,
+                    "startup reap: preserving prior node claimed by a running delegated checkpoint"
+                );
+                continue;
+            }
             if let Some(handle) = record.handle.clone() {
                 let environment_id = record.environment_id.clone();
                 let project_root = record.project_root.clone();
@@ -432,24 +517,88 @@ impl EnvironmentBroker {
                     let client = EnvironmentClient::resolve(Path::new(&project_root), &environment_id)?;
                     client.teardown(&handle)
                 })();
-                if let Err(error) = outcome {
-                    tracing::warn!(
-                        target: "animus.runtime.environment_broker",
-                        run_id = %run_id,
-                        %error,
-                        "startup reap: cold teardown of an orphaned node failed; deleting the record anyway"
-                    );
-                } else {
-                    tracing::info!(
-                        target: "animus.runtime.environment_broker",
-                        run_id = %run_id,
-                        "startup reap: cold tore down a node leaked by a prior daemon instance"
-                    );
+                match outcome {
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "animus.runtime.environment_broker",
+                            run_id = %run_id,
+                            %error,
+                            "startup reap: cold teardown failed; retaining the lease record for retry"
+                        );
+                        continue;
+                    }
+                    Ok(()) => {
+                        tracing::info!(
+                            target: "animus.runtime.environment_broker",
+                            run_id = %run_id,
+                            "startup reap: cold tore down a node leaked by a prior daemon instance"
+                        );
+                    }
                 }
             }
             let _ = std::fs::remove_file(&path);
         }
     }
+}
+
+/// Persist the production broker's prepared handle into the phase checkpoint
+/// before the acquire response exposes the node to a runner. A workflow has at
+/// most one Running phase checkpoint; refusing ambiguous/missing ownership
+/// closes the prepare-to-persistence crash window instead of executing work
+/// that restart reconciliation cannot resume or reap by handle.
+fn bind_running_phase_checkpoint(
+    project_root: &str,
+    run_id: &str,
+    environment_id: &str,
+    handle: &EnvironmentHandle,
+) -> Result<()> {
+    let scoped_root = protocol::repository_scope::scoped_state_root(Path::new(project_root))
+        .ok_or_else(|| anyhow!("project has no scoped state root"))?;
+    let mut matches = list_running_checkpoints(&scoped_root)
+        .context("listing running phase checkpoints")?
+        .into_iter()
+        .map(|(_, checkpoint)| checkpoint)
+        .filter(|checkpoint| checkpoint.workflow_id == run_id);
+    let checkpoint =
+        matches.next().ok_or_else(|| anyhow!("no Running phase checkpoint found for brokered workflow"))?;
+    if matches.next().is_some() {
+        bail!("multiple Running phase checkpoints found for brokered workflow");
+    }
+    update_session_environment(
+        &scoped_root,
+        &checkpoint.workflow_id,
+        &checkpoint.phase_id,
+        EnvironmentBinding {
+            environment_id: environment_id.to_string(),
+            handle: handle.clone(),
+            bound_at: chrono::Utc::now().to_rfc3339(),
+            torn_down: false,
+        },
+    )
+    .context("writing delegated environment binding")
+}
+
+fn prior_record_is_claimed_for_resume(record: &LeaseRecord) -> bool {
+    // Only a fully prepared lease can be resumed. In particular, preserving a
+    // TearingDown record would allow already-completed coding work to be
+    // reattached after restart instead of letting startup finish reaping it.
+    if record.state != LeaseState::Ready {
+        return false;
+    }
+    let Some(handle) = record.handle.as_ref() else {
+        return false;
+    };
+    let Some(scoped_root) = protocol::repository_scope::scoped_state_root(Path::new(&record.project_root)) else {
+        return false;
+    };
+    animus_runtime_shared::phase_session::list_running_checkpoints(&scoped_root).ok().into_iter().flatten().any(
+        |(_, checkpoint)| {
+            checkpoint.workflow_id == record.run_id
+                && checkpoint.environment.as_ref().is_some_and(|binding| {
+                    !binding.torn_down && binding.environment_id == record.environment_id && binding.handle == *handle
+                })
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -796,6 +945,86 @@ mod tests {
         assert_eq!(decoded.run_id, "wf-1");
         assert_eq!(decoded.state, LeaseState::Ready);
         assert_eq!(decoded.handle.unwrap().id, "node-1");
+    }
+
+    #[test]
+    fn broker_binding_is_written_to_the_running_phase_checkpoint() {
+        use animus_runtime_shared::phase_session::{read_checkpoint, update_session_running, write_session_pending};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().to_string_lossy();
+        let scoped_root =
+            protocol::repository_scope::scoped_state_root(temp.path()).expect("scoped project state root");
+        write_session_pending(
+            &scoped_root,
+            "wf-bound",
+            "implementation",
+            "claude",
+            "agent-run",
+            Some(json!({"context": {"prompt": "continue"}})),
+        )
+        .expect("pending checkpoint");
+        update_session_running(&scoped_root, "wf-bound", "implementation").expect("running checkpoint");
+        let handle = EnvironmentHandle {
+            id: "node-bound".to_string(),
+            workspace_root: "/workspace".to_string(),
+            metadata: json!({"relay": "opaque"}),
+        };
+
+        bind_running_phase_checkpoint(&project_root, "wf-bound", "railway", &handle).expect("persist broker binding");
+
+        let checkpoint = read_checkpoint(&scoped_root, "wf-bound", "implementation")
+            .expect("read checkpoint")
+            .expect("checkpoint exists");
+        let binding = checkpoint.environment.expect("environment binding");
+        assert_eq!(binding.environment_id, "railway");
+        assert_eq!(binding.handle, handle);
+        assert!(!binding.torn_down);
+    }
+
+    #[test]
+    fn only_ready_prior_record_is_claimed_for_resume() {
+        use animus_runtime_shared::phase_session::{update_session_running, write_session_pending};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().to_string_lossy().into_owned();
+        let scoped_root =
+            protocol::repository_scope::scoped_state_root(temp.path()).expect("scoped project state root");
+        write_session_pending(&scoped_root, "wf-resume", "implementation", "claude", "agent-run", None)
+            .expect("pending checkpoint");
+        update_session_running(&scoped_root, "wf-resume", "implementation").expect("running checkpoint");
+        let handle = EnvironmentHandle {
+            id: "node-resume".to_string(),
+            workspace_root: "/workspace".to_string(),
+            metadata: json!({"relay": "opaque"}),
+        };
+        bind_running_phase_checkpoint(&project_root, "wf-resume", "railway", &handle)
+            .expect("persist broker binding");
+        let record = LeaseRecord {
+            run_id: "wf-resume".to_string(),
+            daemon_instance_id: "prior-daemon".to_string(),
+            environment_id: "railway".to_string(),
+            project_root,
+            state: LeaseState::Ready,
+            handle: Some(handle),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:01Z".to_string(),
+        };
+
+        assert!(prior_record_is_claimed_for_resume(&record));
+        for state in [
+            LeaseState::Preparing,
+            LeaseState::TearingDown,
+            LeaseState::TornDown,
+            LeaseState::Failed,
+        ] {
+            let mut non_ready = record.clone();
+            non_ready.state = state;
+            assert!(
+                !prior_record_is_claimed_for_resume(&non_ready),
+                "{state:?} record was claimed"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
@@ -998,8 +998,7 @@ mod tests {
             workspace_root: "/workspace".to_string(),
             metadata: json!({"relay": "opaque"}),
         };
-        bind_running_phase_checkpoint(&project_root, "wf-resume", "railway", &handle)
-            .expect("persist broker binding");
+        bind_running_phase_checkpoint(&project_root, "wf-resume", "railway", &handle).expect("persist broker binding");
         let record = LeaseRecord {
             run_id: "wf-resume".to_string(),
             daemon_instance_id: "prior-daemon".to_string(),
@@ -1012,18 +1011,10 @@ mod tests {
         };
 
         assert!(prior_record_is_claimed_for_resume(&record));
-        for state in [
-            LeaseState::Preparing,
-            LeaseState::TearingDown,
-            LeaseState::TornDown,
-            LeaseState::Failed,
-        ] {
+        for state in [LeaseState::Preparing, LeaseState::TearingDown, LeaseState::TornDown, LeaseState::Failed] {
             let mut non_ready = record.clone();
             non_ready.state = state;
-            assert!(
-                !prior_record_is_claimed_for_resume(&non_ready),
-                "{state:?} record was claimed"
-            );
+            assert!(!prior_record_is_claimed_for_resume(&non_ready), "{state:?} record was claimed");
         }
     }
 

--- a/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
@@ -17,7 +17,8 @@
 //!   (one relay = one node), pinned across prepare / exec / teardown.
 //! - [`Self::teardown`] disposes the node once, at terminal workflow state.
 //! - Durable JSON lease records under the scoped state root let a fresh daemon
-//!   reap nodes leaked by a PRIOR daemon instance (its relay is dead) on startup.
+//!   adopt the exact Ready lease still claimed by a Running checkpoint, while
+//!   cold-reaping unclaimed nodes leaked by a PRIOR daemon instance.
 //!
 //! ## IPC
 //!
@@ -39,7 +40,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::Mutex as AsyncMutex;
 
-use orchestrator_core::environment::{EnvironmentHandle, EnvironmentSpec, ExecStream, HarnessCommand};
+use orchestrator_core::environment::{EnvironmentHandle, EnvironmentSpec, ExecResponse, ExecStream, HarnessCommand};
 use orchestrator_core::EnvironmentClient;
 
 /// Local-socket path the per-phase runner dials to reach the broker.
@@ -92,8 +93,8 @@ enum BrokerRequest {
 }
 
 // ---------------------------------------------------------------------------
-// Durable lease record (survives a daemon restart so the reaper can cold-tear
-// down a node the prior daemon instance leaked).
+// Durable lease record (survives a daemon restart so the new broker can adopt
+// an exact claimed lease or cold-tear down an unclaimed leaked node).
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -128,9 +129,56 @@ struct LeaseRecord {
 struct ReadyLease {
     environment_id: String,
     project_root: String,
-    client: Arc<EnvironmentClient>,
+    client: Arc<dyn EnvironmentLeaseClient>,
     handle: EnvironmentHandle,
 }
+
+/// Object-safe surface the broker needs from an environment client. Keeping
+/// resolution behind this seam lets the restart lifecycle be tested as one
+/// broker-to-broker sequence without installing or spawning a real plugin.
+trait EnvironmentLeaseClient: Send + Sync {
+    fn prepare(&self, spec: EnvironmentSpec) -> Result<EnvironmentHandle>;
+    fn exec_stream(
+        &self,
+        handle: &EnvironmentHandle,
+        command: HarnessCommand,
+        stdin: Option<String>,
+        timeout: Option<Duration>,
+        on_output: &(dyn Fn(ExecStream, &str) + Send + Sync),
+    ) -> Result<ExecResponse>;
+    fn teardown(&self, handle: &EnvironmentHandle) -> Result<()>;
+}
+
+impl EnvironmentLeaseClient for EnvironmentClient {
+    fn prepare(&self, spec: EnvironmentSpec) -> Result<EnvironmentHandle> {
+        EnvironmentClient::prepare(self, spec)
+    }
+
+    fn exec_stream(
+        &self,
+        handle: &EnvironmentHandle,
+        command: HarnessCommand,
+        stdin: Option<String>,
+        timeout: Option<Duration>,
+        on_output: &(dyn Fn(ExecStream, &str) + Send + Sync),
+    ) -> Result<ExecResponse> {
+        EnvironmentClient::exec_stream(
+            self,
+            handle,
+            command,
+            std::collections::BTreeMap::new(),
+            stdin,
+            timeout,
+            on_output,
+        )
+    }
+
+    fn teardown(&self, handle: &EnvironmentHandle) -> Result<()> {
+        EnvironmentClient::teardown(self, handle)
+    }
+}
+
+type ClientResolver = dyn Fn(&Path, &str) -> Result<Arc<dyn EnvironmentLeaseClient>> + Send + Sync;
 
 /// Context the daemon registers at spawn time (it, not the runner, is the
 /// authority on `project_root`). `acquire` resolves the [`EnvironmentClient`]
@@ -154,6 +202,7 @@ struct Inner {
     key_locks: StdMutex<HashMap<String, Arc<AsyncMutex<()>>>>,
     /// run_id -> spawn-time context (project_root + expected environment id).
     pending: StdMutex<HashMap<String, PendingContext>>,
+    client_resolver: Arc<ClientResolver>,
     /// The socket acceptor task; aborted + socket unlinked on drop.
     acceptor: StdMutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -179,13 +228,24 @@ pub struct EnvironmentBroker {
 
 impl EnvironmentBroker {
     /// Bind the broker's local socket under `project_root`'s scoped state root,
-    /// start the accept loop on the current Tokio runtime, and reap any lease
-    /// records owned by a PRIOR daemon instance (their relay is dead).
+    /// start the accept loop on the current Tokio runtime, adopt any exact
+    /// Ready lease still claimed by a Running checkpoint, and reap unclaimed
+    /// records owned by a prior daemon instance.
     ///
     /// Must be called from within the daemon's multi-threaded runtime: the
     /// resident [`EnvironmentClient`] the broker drives spawns its warm plugin
     /// host onto THIS runtime and is pinned there for the run's lifetime.
     pub async fn start(project_root: &str) -> std::io::Result<Self> {
+        Self::start_with_resolver(
+            project_root,
+            Arc::new(|project_root, environment_id| {
+                Ok(Arc::new(EnvironmentClient::resolve(project_root, environment_id)?))
+            }),
+        )
+        .await
+    }
+
+    async fn start_with_resolver(project_root: &str, client_resolver: Arc<ClientResolver>) -> std::io::Result<Self> {
         let records_dir = broker_records_dir(project_root);
         std::fs::create_dir_all(&records_dir)?;
         let socket_path = broker_socket_path(&records_dir);
@@ -201,6 +261,7 @@ impl EnvironmentBroker {
             leases: AsyncMutex::new(HashMap::new()),
             key_locks: StdMutex::new(HashMap::new()),
             pending: StdMutex::new(HashMap::new()),
+            client_resolver,
             acceptor: StdMutex::new(None),
         });
 
@@ -233,6 +294,29 @@ impl EnvironmentBroker {
             run_id.to_string(),
             PendingContext { project_root: project_root.to_string(), environment_id: environment_id.to_string() },
         );
+    }
+
+    /// Whether this daemon owns the exact durable lease a restart checkpoint
+    /// names. Resume callers use this as a fail-closed gate: a live node is not
+    /// enough; the new broker must have adopted its client + handle so later
+    /// phases and terminal cleanup stay on the same workflow-scoped lease.
+    pub async fn owns_ready_lease(&self, run_id: &str, environment_id: &str, handle: &EnvironmentHandle) -> bool {
+        self.inner
+            .leases
+            .lock()
+            .await
+            .get(run_id)
+            .is_some_and(|lease| lease.environment_id == environment_id && lease.handle == *handle)
+    }
+
+    #[cfg(test)]
+    fn stop_acceptor_for_restart_test(&self) {
+        if let Some(handle) = self.inner.acceptor.lock().unwrap_or_else(|p| p.into_inner()).take() {
+            handle.abort();
+        }
+        if looks_like_filesystem(&self.inner.socket_path) {
+            let _ = std::fs::remove_file(&self.inner.socket_path);
+        }
     }
 
     /// Idempotently dispose the node for `run_id`: `Ready -> TearingDown ->
@@ -292,11 +376,23 @@ impl EnvironmentBroker {
         let _guard = key_lock.lock().await;
 
         // Fast path: an already-prepared lease is reused by every later phase.
-        if let Some(lease) = self.inner.leases.lock().await.get(run_id) {
-            if lease.environment_id != environment_id {
-                bail!("run {run_id} is already bound to environment '{}'", lease.environment_id);
+        let existing = self
+            .inner
+            .leases
+            .lock()
+            .await
+            .get(run_id)
+            .map(|lease| (lease.environment_id.clone(), lease.handle.clone()));
+        if let Some((lease_environment_id, handle)) = existing {
+            if lease_environment_id != environment_id {
+                bail!("run {run_id} is already bound to environment '{lease_environment_id}'");
             }
-            return Ok((lease.handle.workspace_root.clone(), lease.handle.id.clone()));
+            // Every phase gets its own checkpoint. Reusing an existing
+            // workflow lease must bind the current Running phase too, or a
+            // second restart after the phase boundary cannot prove ownership.
+            bind_running_phase_checkpoint(&pending.project_root, run_id, environment_id, &handle)
+                .with_context(|| format!("persisting reused phase environment binding for run {run_id}"))?;
+            return Ok((handle.workspace_root.clone(), handle.id.clone()));
         }
 
         // Slow path: prepare the node ONCE. Record BEFORE prepare so a crash
@@ -313,9 +409,8 @@ impl EnvironmentBroker {
         // (its own `block_in_place`), so both are called directly — the daemon
         // worker is handed off for the duration of the prepare RPC by the client.
         let prepared = (|| {
-            let client = EnvironmentClient::resolve(Path::new(&project_root), &environment_id_owned)
+            let client = (self.inner.client_resolver)(Path::new(&project_root), &environment_id_owned)
                 .with_context(|| format!("resolving environment '{environment_id_owned}' for run {run_id}"))?;
-            let client = Arc::new(client);
             let handle = client.prepare(spec).with_context(|| format!("preparing environment for run {run_id}"))?;
             Ok::<_, anyhow::Error>((client, handle))
         })();
@@ -388,7 +483,11 @@ impl EnvironmentBroker {
     /// NEVER exec into another run's node), and return the pinned client +
     /// handle to drive `exec_stream` against. The lease lock is NOT held across
     /// the exec, so a long command does not block other broker ops.
-    async fn exec_target(&self, run_id: &str, handle_id: &str) -> Result<(Arc<EnvironmentClient>, EnvironmentHandle)> {
+    async fn exec_target(
+        &self,
+        run_id: &str,
+        handle_id: &str,
+    ) -> Result<(Arc<dyn EnvironmentLeaseClient>, EnvironmentHandle)> {
         let leases = self.inner.leases.lock().await;
         let lease =
             leases.get(run_id).ok_or_else(|| anyhow!("no prepared environment for run {run_id} (acquire first)"))?;
@@ -470,10 +569,10 @@ impl EnvironmentBroker {
         let _ = std::fs::remove_file(self.record_path(run_id));
     }
 
-    /// Cold-teardown every lease record owned by a PRIOR daemon instance: its
-    /// relay died with that daemon, so a fresh `resolve` + `teardown(handle)`
-    /// (dispose-by-id on a fresh plugin process) reclaims the leaked node. Then
-    /// delete the record. Records owned by THIS instance are left untouched.
+    /// Reconcile every lease record owned by a prior daemon instance. Adopt an
+    /// exact Ready lease still claimed by a Running checkpoint; otherwise use
+    /// a fresh `resolve` + `teardown(handle)` to reclaim the leaked node and
+    /// delete its record. Records owned by this instance are left untouched.
     async fn reap_prior_daemon_records(&self) {
         let entries = match std::fs::read_dir(&self.inner.records_dir) {
             Ok(entries) => entries,
@@ -500,11 +599,51 @@ impl EnvironmentBroker {
             // it; otherwise broker startup destroys the node before TASK-933
             // recovery runs. Unclaimed records retain the cold-reap behavior.
             if prior_record_is_claimed_for_resume(&record) {
-                tracing::info!(
-                    target: "animus.runtime.environment_broker",
-                    run_id = %record.run_id,
-                    "startup reap: preserving prior node claimed by a running delegated checkpoint"
-                );
+                let Some(handle) = record.handle.clone() else {
+                    continue;
+                };
+                match (self.inner.client_resolver)(Path::new(&record.project_root), &record.environment_id) {
+                    Ok(client) => {
+                        if let Err(error) = self.write_record_required(
+                            &record.run_id,
+                            &record.environment_id,
+                            &record.project_root,
+                            LeaseState::Ready,
+                            Some(&handle),
+                        ) {
+                            tracing::warn!(
+                                target: "animus.runtime.environment_broker",
+                                run_id = %record.run_id,
+                                %error,
+                                "startup adoption could not rewrite lease ownership; keeping prior durable record"
+                            );
+                            continue;
+                        }
+                        self.inner.leases.lock().await.insert(
+                            record.run_id.clone(),
+                            ReadyLease {
+                                environment_id: record.environment_id.clone(),
+                                project_root: record.project_root.clone(),
+                                client,
+                                handle: handle.clone(),
+                            },
+                        );
+                        tracing::info!(
+                            target: "animus.runtime.environment_broker",
+                            run_id = %record.run_id,
+                            node = %handle.id,
+                            "startup adopted prior node claimed by a running delegated checkpoint"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "animus.runtime.environment_broker",
+                            run_id = %record.run_id,
+                            %error,
+                            "startup could not adopt claimed prior node; preserving durable record for retry"
+                        );
+                    }
+                }
                 continue;
             }
             if let Some(handle) = record.handle.clone() {
@@ -514,7 +653,7 @@ impl EnvironmentBroker {
                 // `resolve` + `teardown` bridge async→sync internally; call
                 // directly (no outer `block_in_place`).
                 let outcome = (|| {
-                    let client = EnvironmentClient::resolve(Path::new(&project_root), &environment_id)?;
+                    let client = (self.inner.client_resolver)(Path::new(&project_root), &environment_id)?;
                     client.teardown(&handle)
                 })();
                 match outcome {
@@ -730,16 +869,10 @@ async fn handle_exec(
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
     let timeout = timeout_secs.map(Duration::from_secs);
     let exec_task = tokio::spawn(async move {
-        client.exec_stream(
-            &handle,
-            command,
-            std::collections::BTreeMap::new(),
-            stdin,
-            timeout,
-            |stream: ExecStream, text: &str| {
-                let _ = tx.send(json!({ "out": exec_stream_str(stream), "text": text }));
-            },
-        )
+        let on_output = |stream: ExecStream, text: &str| {
+            let _ = tx.send(json!({ "out": exec_stream_str(stream), "text": text }));
+        };
+        client.exec_stream(&handle, command, stdin, timeout, &on_output)
     });
 
     while let Some(frame) = rx.recv().await {
@@ -855,6 +988,38 @@ fn write_record_atomic(path: &Path, record: &LeaseRecord) -> std::io::Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FakeLeaseClient {
+        handle: EnvironmentHandle,
+        prepares: AtomicUsize,
+        execs: AtomicUsize,
+        teardowns: AtomicUsize,
+    }
+
+    impl EnvironmentLeaseClient for FakeLeaseClient {
+        fn prepare(&self, _spec: EnvironmentSpec) -> Result<EnvironmentHandle> {
+            self.prepares.fetch_add(1, Ordering::SeqCst);
+            Ok(self.handle.clone())
+        }
+
+        fn exec_stream(
+            &self,
+            _handle: &EnvironmentHandle,
+            _command: HarnessCommand,
+            _stdin: Option<String>,
+            _timeout: Option<Duration>,
+            _on_output: &(dyn Fn(ExecStream, &str) + Send + Sync),
+        ) -> Result<ExecResponse> {
+            self.execs.fetch_add(1, Ordering::SeqCst);
+            Ok(ExecResponse { exit_code: Some(0), stdout: String::new(), stderr: String::new(), timed_out: false })
+        }
+
+        fn teardown(&self, _handle: &EnvironmentHandle) -> Result<()> {
+            self.teardowns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
 
     #[test]
     fn local_environment_ids_are_recognized() {
@@ -1016,6 +1181,101 @@ mod tests {
             non_ready.state = state;
             assert!(!prior_record_is_claimed_for_resume(&non_ready), "{state:?} record was claimed");
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restart_adopts_exact_lease_reuses_it_for_next_phase_and_tears_down_once() {
+        use animus_runtime_shared::phase_session::{
+            read_checkpoint, update_session_completed, update_session_running, write_session_pending,
+        };
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().to_string_lossy().into_owned();
+        let scoped_root =
+            protocol::repository_scope::scoped_state_root(temp.path()).expect("scoped project state root");
+        write_session_pending(&scoped_root, "wf-restart", "code-implement", "claude", "agent-1", None)
+            .expect("first pending checkpoint");
+        update_session_running(&scoped_root, "wf-restart", "code-implement").expect("first running checkpoint");
+
+        let fake = Arc::new(FakeLeaseClient {
+            handle: EnvironmentHandle {
+                id: "node-h1".to_string(),
+                workspace_root: "/workspace".to_string(),
+                metadata: json!({"relay": "opaque"}),
+            },
+            prepares: AtomicUsize::new(0),
+            execs: AtomicUsize::new(0),
+            teardowns: AtomicUsize::new(0),
+        });
+        let resolver: Arc<ClientResolver> = {
+            let fake = fake.clone();
+            Arc::new(move |_, _| Ok(fake.clone()))
+        };
+
+        let first =
+            EnvironmentBroker::start_with_resolver(&project_root, resolver.clone()).await.expect("start first broker");
+        first.register_run("wf-restart", &project_root, "railway");
+        let spec = EnvironmentSpec {
+            kind: "railway".to_string(),
+            repos: Vec::new(),
+            image: None,
+            resources: None,
+            env: std::collections::BTreeMap::new(),
+            metadata: serde_json::Value::Null,
+        };
+        let (_, first_handle) = first.acquire("wf-restart", "railway", spec.clone()).await.expect("first acquire");
+        assert_eq!(first_handle, "node-h1");
+        assert_eq!(fake.prepares.load(Ordering::SeqCst), 1);
+
+        // Simulate daemon replacement without terminal cleanup: the durable
+        // Ready record + Running checkpoint remain, while the old broker socket
+        // disappears with its process.
+        first.stop_acceptor_for_restart_test();
+        drop(first);
+        let replacement =
+            EnvironmentBroker::start_with_resolver(&project_root, resolver).await.expect("start replacement broker");
+        assert!(
+            replacement.owns_ready_lease("wf-restart", "railway", &fake.handle).await,
+            "replacement daemon adopts the exact persisted handle"
+        );
+        let (resume_client, resume_handle) =
+            replacement.exec_target("wf-restart", "node-h1").await.expect("adopted lease is executable");
+        resume_client
+            .exec_stream(
+                &resume_handle,
+                HarnessCommand {
+                    program: "resume-provider".to_string(),
+                    args: Vec::new(),
+                    env: std::collections::BTreeMap::new(),
+                    cwd: None,
+                },
+                None,
+                None,
+                &|_, _| {},
+            )
+            .expect("resume non-terminal phase on adopted lease");
+        assert_eq!(fake.execs.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.teardowns.load(Ordering::SeqCst), 0, "resumed phase must not teardown workflow lease");
+
+        // The resumed phase completes and the workflow advances. The next
+        // phase's acquire must reuse H1 and durably bind that new checkpoint.
+        update_session_completed(&scoped_root, "wf-restart", "code-implement").expect("complete first phase");
+        write_session_pending(&scoped_root, "wf-restart", "code-check", "codex", "agent-2", None)
+            .expect("second pending checkpoint");
+        update_session_running(&scoped_root, "wf-restart", "code-check").expect("second running checkpoint");
+        replacement.register_run("wf-restart", &project_root, "railway");
+        let (_, second_handle) =
+            replacement.acquire("wf-restart", "railway", spec).await.expect("second phase acquire");
+        assert_eq!(second_handle, "node-h1");
+        assert_eq!(fake.prepares.load(Ordering::SeqCst), 1, "no replacement node was prepared");
+        let second_checkpoint = read_checkpoint(&scoped_root, "wf-restart", "code-check")
+            .expect("read second checkpoint")
+            .expect("second checkpoint exists");
+        assert_eq!(second_checkpoint.environment.expect("second phase binding").handle.id, "node-h1");
+
+        replacement.teardown("wf-restart").await;
+        replacement.teardown("wf-restart").await;
+        assert_eq!(fake.teardowns.load(Ordering::SeqCst), 1, "terminal cleanup tears the adopted lease down once");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Outcome

Makes delegated workflow recovery durable across Portal/daemon restarts without spawning a replacement Railway node or losing the existing checkout.

## Changes

- persist and reclaim delegated environment leases across daemon instances
- preserve prior-daemon leases that have a live resumable phase checkpoint
- probe the exact retained node and redispatch the workflow against its persisted handle
- keep uncertain/transient liveness failures fail-safe instead of destroying work
- terminalize definitively dead delegated workflows and retry failed cleanup
- release the exact retained node before an external workflow cancellation; mark teardown only after success
- make teardown idempotent across repeated reconciliation and cancellation calls

## Tasks

- TASK-793 — restart-safe delegated workflow liveness
- TASK-811 — dead delegation terminalization and cleanup
- TASK-933 — same-node delegated workflow resume
- TASK-1121 — companion external-cancellation cleanup for a runner publication hold

## Validation

- `cargo test -p orchestrator-cli --no-fail-fast` — 1,518 passed, 0 failed
- `cargo test -p orchestrator-daemon-runtime --no-fail-fast` — 356 passed, 0 failed
- `cargo clippy -p orchestrator-cli -p orchestrator-daemon-runtime --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

The final acceptance gate remains a controlled production Portal restart proving the same workflow, Railway service, and persisted handle resume without a second node, followed by successful publication and exactly one teardown.
