### PR TITLE
TASK-971: route workflow reads through typed services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -105,6 +105,8 @@ mod tool_discovery_tools;
 mod workflow_command_args;
 #[path = "ops_mcp/workflow_definition_tools.rs"]
 mod workflow_definition_tools;
+#[path = "ops_mcp/workflow_inproc.rs"]
+mod workflow_inproc;
 #[path = "ops_mcp/workflow_inputs.rs"]
 mod workflow_inputs;
 #[path = "ops_mcp/workflow_runtime_tools.rs"]
@@ -137,9 +139,7 @@ use output_inputs::*;
 use queue_inputs::*;
 use subject_command_args::{validate_subject_batch_create_input, validate_subject_batch_update_input};
 use subject_inputs::*;
-use workflow_command_args::{
-    build_bulk_workflow_run_item_args, build_workflow_list_args, validate_workflow_run_multiple_input,
-};
+use workflow_command_args::{build_bulk_workflow_run_item_args, validate_workflow_run_multiple_input};
 use workflow_inputs::*;
 
 const DEFAULT_DAEMON_EVENTS_LIMIT: usize = 100;
@@ -325,6 +325,8 @@ const ACTOR_BOUND_MCP_TOOLS: &[&str] = &[
     "animus.workflow.get",
     "animus.workflow.run-multiple",
     "animus.workflow.execute",
+    "animus.workflow.decisions",
+    "animus.workflow.checkpoints.list",
     "animus.workflow.config.get",
     "animus.workflow.config.validate",
     "animus.output.run",

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/exec.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/exec.rs
@@ -1,5 +1,5 @@
 use super::exec_errors::{batch_item_error_from_result, build_tool_error_payload, extract_cli_success_data};
-use super::{build_guarded_list_result, AoMcpServer, BatchItemExec, ListGuardInput, OnError, BATCH_RESULT_SCHEMA};
+use super::{AoMcpServer, BatchItemExec, OnError, BATCH_RESULT_SCHEMA};
 use animus_actor::Actor;
 use anyhow::Result;
 use orchestrator_daemon_runtime::{Audit, AuditActor, AuditEvent, AuditEventKind};
@@ -72,39 +72,6 @@ impl AoMcpServer {
                         "tool": tool_name,
                         "result": data,
                     })))
-                } else {
-                    Ok(CallToolResult::structured_error(build_tool_error_payload(tool_name, &result)))
-                }
-            }
-            Err(err) => Ok(CallToolResult::structured_error(json!({
-                "tool": tool_name,
-                "error": err.to_string(),
-            }))),
-        }
-    }
-
-    pub(super) async fn run_list_tool(
-        &self,
-        tool_name: &str,
-        requested_args: Vec<String>,
-        project_root_override: Option<String>,
-        guard: ListGuardInput,
-    ) -> Result<CallToolResult, McpError> {
-        self.audit_actor_tool_invocation(tool_name, &requested_args);
-        match self.execute_ao(requested_args, project_root_override).await {
-            Ok(result) => {
-                if result.success {
-                    let data = extract_cli_success_data(result.stdout_json);
-                    match build_guarded_list_result(tool_name, data, guard) {
-                        Ok(shaped) => Ok(CallToolResult::structured(json!({
-                            "tool": tool_name,
-                            "result": shaped,
-                        }))),
-                        Err(error) => Ok(CallToolResult::structured_error(json!({
-                            "tool": tool_name,
-                            "error": error.to_string(),
-                        }))),
-                    }
                 } else {
                     Ok(CallToolResult::structured_error(build_tool_error_payload(tool_name, &result)))
                 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -785,41 +785,6 @@ fn build_guarded_list_result_supports_workflow_decisions() {
 }
 
 #[test]
-fn build_workflow_list_args_includes_filters_and_sort() {
-    let args = build_workflow_list_args(&WorkflowListInput {
-        status: Some("running".to_string()),
-        workflow_ref: Some("default".to_string()),
-        subject_id: Some("TASK-123".to_string()),
-        phase_id: Some("implementation".to_string()),
-        search: Some("retry".to_string()),
-        sort: Some("started_at".to_string()),
-        limit: Some(10),
-        offset: Some(2),
-        max_tokens: Some(4000),
-        project_root: None,
-    });
-    assert_eq!(
-        args,
-        vec![
-            "workflow".to_string(),
-            "list".to_string(),
-            "--status".to_string(),
-            "running".to_string(),
-            "--workflow-ref".to_string(),
-            "default".to_string(),
-            "--subject-id".to_string(),
-            "TASK-123".to_string(),
-            "--phase-id".to_string(),
-            "implementation".to_string(),
-            "--search".to_string(),
-            "retry".to_string(),
-            "--sort".to_string(),
-            "started_at".to_string(),
-        ]
-    );
-}
-
-#[test]
 fn build_guarded_list_result_rejects_non_array_payloads() {
     let err = build_guarded_list_result(
         "animus.workflow.list",
@@ -1513,35 +1478,6 @@ fn build_cli_error_payload_preserves_json_like_error_text() {
 // control server tests; MCP→CLI→ControlClient is verified by
 // composition.
 // =====================================================================
-
-#[test]
-fn mcp_workflow_list_routes_via_control_when_socket_present() {
-    // The MCP workflow.list tool builds args that resolve to
-    // `animus workflow list ...`. The CLI handler for workflow list
-    // (see ops_workflow/mod.rs) calls
-    // `try_workflow_list_via_control` first, falling back to local
-    // when the socket is missing — so this arg shape is what gets
-    // routed through the wire when the daemon is up.
-    let input = WorkflowListInput {
-        status: Some("running".to_string()),
-        workflow_ref: None,
-        subject_id: Some("TASK-1".to_string()),
-        phase_id: None,
-        search: None,
-        sort: None,
-        limit: None,
-        offset: None,
-        max_tokens: None,
-        project_root: None,
-    };
-    let args = build_workflow_list_args(&input);
-    assert_eq!(args[0], "workflow");
-    assert_eq!(args[1], "list");
-    assert!(args.contains(&"--status".to_string()));
-    assert!(args.contains(&"running".to_string()));
-    assert!(args.contains(&"--subject-id".to_string()));
-    assert!(args.contains(&"TASK-1".to_string()));
-}
 
 #[test]
 fn mcp_queue_list_falls_back_to_local_when_socket_missing() {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_command_args.rs
@@ -1,16 +1,5 @@
 use super::{push_opt, BulkWorkflowRunItem, MAX_BATCH_SIZE};
 
-pub(super) fn build_workflow_list_args(input: &super::WorkflowListInput) -> Vec<String> {
-    let mut args = vec!["workflow".to_string(), "list".to_string()];
-    push_opt(&mut args, "--status", input.status.clone());
-    push_opt(&mut args, "--workflow-ref", input.workflow_ref.clone());
-    push_opt(&mut args, "--subject-id", input.subject_id.clone());
-    push_opt(&mut args, "--phase-id", input.phase_id.clone());
-    push_opt(&mut args, "--search", input.search.clone());
-    push_opt(&mut args, "--sort", input.sort.clone());
-    args
-}
-
 pub(super) fn build_bulk_workflow_run_item_args(item: &BulkWorkflowRunItem) -> Vec<String> {
     let mut args = vec!["workflow".to_string(), "run".to_string()];
     if let Some(workflow_ref) = item.workflow_ref.clone() {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_definition_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_definition_tools.rs
@@ -8,12 +8,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ProjectRootInput>()
     )]
     async fn ao_workflow_phases_list(&self, params: Parameters<ProjectRootInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool(
-            "animus.workflow.phases.list",
-            vec!["workflow".to_string(), "phases".to_string(), "list".to_string()],
-            params.0.project_root,
-        )
-        .await
+        self.workflow_phases_list_inproc(params.0.project_root).await
     }
 
     #[tool(
@@ -25,10 +20,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<WorkflowPhaseGetInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args =
-            vec!["workflow".to_string(), "phases".to_string(), "get".to_string(), "--phase".to_string(), input.phase];
-        self.run_tool("animus.workflow.phases.get", args, input.project_root).await
+        self.workflow_phase_get_inproc(params.0).await
     }
 
     #[tool(
@@ -40,12 +32,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<ProjectRootInput>,
     ) -> Result<CallToolResult, McpError> {
-        self.run_tool(
-            "animus.workflow.definitions.list",
-            vec!["workflow".to_string(), "definitions".to_string(), "list".to_string()],
-            params.0.project_root,
-        )
-        .await
+        self.workflow_definitions_list_inproc(params.0.project_root).await
     }
 
     #[tool(
@@ -54,12 +41,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ProjectRootInput>()
     )]
     async fn ao_workflow_config_get(&self, params: Parameters<ProjectRootInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool(
-            "animus.workflow.config.get",
-            vec!["workflow".to_string(), "config".to_string(), "get".to_string()],
-            params.0.project_root,
-        )
-        .await
+        self.workflow_config_get_inproc(params.0.project_root).await
     }
 
     #[tool(
@@ -71,12 +53,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<ProjectRootInput>,
     ) -> Result<CallToolResult, McpError> {
-        self.run_tool(
-            "animus.workflow.config.validate",
-            vec!["workflow".to_string(), "config".to_string(), "validate".to_string()],
-            params.0.project_root,
-        )
-        .await
+        self.workflow_config_validate_inproc(params.0.project_root).await
     }
 
     #[tool(

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inproc.rs
@@ -1,0 +1,199 @@
+use super::daemon_inproc::resolve_project_root;
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::{build_guarded_list_result, AoMcpServer, ListGuardInput};
+use crate::services::operations::{
+    workflow_checkpoints_list_application, workflow_config_get_application, workflow_config_validate_application,
+    workflow_decisions_application, workflow_definitions_list_application, workflow_get_application,
+    workflow_list_application, workflow_phase_get_application, workflow_phases_list_application,
+    WorkflowListApplicationRequest,
+};
+use anyhow::Result;
+use orchestrator_core::{services::ServiceHub, FileServiceHub};
+use rmcp::model::CallToolResult;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+fn workflow_hub(project_root: &str) -> Result<Arc<dyn ServiceHub>> {
+    Ok(Arc::new(FileServiceHub::new(project_root)?))
+}
+
+impl AoMcpServer {
+    async fn run_workflow_application<F>(
+        &self,
+        tool_name: &str,
+        project_root: Option<String>,
+        call: F,
+    ) -> CallToolResult
+    where
+        F: AsyncFnOnce(String, Option<&animus_actor::Actor>) -> Result<Value>,
+    {
+        self.audit_actor_tool_decision(tool_name, true, "forward");
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        match call(project_root, self.pinned_actor()).await {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(err) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &err)),
+        }
+    }
+
+    pub(super) async fn workflow_list_inproc(
+        &self,
+        input: super::WorkflowListInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        let guard = ListGuardInput { limit: input.limit, offset: input.offset, max_tokens: input.max_tokens };
+        let request = WorkflowListApplicationRequest {
+            status: input.status,
+            workflow_ref: input.workflow_ref,
+            subject_id: input.subject_id,
+            phase_id: input.phase_id,
+            search: input.search,
+            sort: input.sort,
+            // MCP pagination is applied after actor filtering by the common
+            // list guard, so fetch the complete actor-visible application set.
+            limit: None,
+            offset: 0,
+        };
+        Ok(self
+            .run_workflow_application("animus.workflow.list", project_root, async |root, actor| {
+                let items = workflow_list_application(workflow_hub(&root)?, &root, request, actor).await?;
+                build_guarded_list_result("animus.workflow.list", Value::Array(items), guard)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_get_inproc(&self, input: super::IdInput) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.get", project_root, async |root, actor| {
+                workflow_get_application(workflow_hub(&root)?, &root, &input.id, actor).await
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_decisions_inproc(
+        &self,
+        input: super::IdListInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        let guard = ListGuardInput { limit: input.limit, offset: input.offset, max_tokens: input.max_tokens };
+        Ok(self
+            .run_workflow_application("animus.workflow.decisions", project_root, async |root, actor| {
+                let items = workflow_decisions_application(workflow_hub(&root)?, &root, &input.id, actor).await?;
+                build_guarded_list_result("animus.workflow.decisions", items, guard)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_checkpoints_list_inproc(
+        &self,
+        input: super::IdListInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        let guard = ListGuardInput { limit: input.limit, offset: input.offset, max_tokens: input.max_tokens };
+        Ok(self
+            .run_workflow_application("animus.workflow.checkpoints.list", project_root, async |root, actor| {
+                let items =
+                    workflow_checkpoints_list_application(workflow_hub(&root)?, &root, &input.id, actor).await?;
+                build_guarded_list_result("animus.workflow.checkpoints.list", items, guard)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_phases_list_inproc(
+        &self,
+        project_root: Option<String>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(self
+            .run_workflow_application("animus.workflow.phases.list", project_root, async |root, _| {
+                workflow_phases_list_application(&root)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_phase_get_inproc(
+        &self,
+        input: super::WorkflowPhaseGetInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.phases.get", project_root, async |root, _| {
+                workflow_phase_get_application(&root, &input.phase)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_definitions_list_inproc(
+        &self,
+        project_root: Option<String>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(self
+            .run_workflow_application("animus.workflow.definitions.list", project_root, async |root, _| {
+                workflow_definitions_list_application(&root)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_config_get_inproc(
+        &self,
+        project_root: Option<String>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(self
+            .run_workflow_application("animus.workflow.config.get", project_root, async |root, actor| {
+                workflow_config_get_application(&root, actor)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_config_validate_inproc(
+        &self,
+        project_root: Option<String>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(self
+            .run_workflow_application("animus.workflow.config.validate", project_root, async |root, actor| {
+                workflow_config_validate_application(&root, actor)
+            })
+            .await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn workflow_list_validation_is_a_typed_in_process_error() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let result = server
+            .workflow_list_inproc(super::super::WorkflowListInput {
+                project_root: None,
+                status: Some("not-a-workflow-status".to_string()),
+                workflow_ref: None,
+                subject_id: None,
+                phase_id: None,
+                search: None,
+                sort: None,
+                limit: None,
+                offset: None,
+                max_tokens: None,
+            })
+            .await
+            .expect("tool transport succeeds");
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "payload: {payload}");
+    }
+
+    #[tokio::test]
+    async fn workflow_config_get_returns_structured_data_without_cli_exec() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let result = server.workflow_config_get_inproc(None).await.expect("tool transport succeeds");
+
+        assert_ne!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("structured payload");
+        assert_eq!(payload.get("tool").and_then(Value::as_str), Some("animus.workflow.config.get"));
+        assert!(payload.pointer("/result/workflow_config").is_some());
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
@@ -8,14 +8,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<WorkflowListInput>()
     )]
     async fn ao_workflow_list(&self, params: Parameters<WorkflowListInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        self.run_list_tool(
-            "animus.workflow.list",
-            build_workflow_list_args(&input),
-            input.project_root,
-            ListGuardInput { limit: input.limit, offset: input.offset, max_tokens: input.max_tokens },
-        )
-        .await
+        self.workflow_list_inproc(params.0).await
     }
 
     #[tool(
@@ -40,9 +33,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<IdInput>()
     )]
     async fn ao_workflow_get(&self, params: Parameters<IdInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec!["workflow".to_string(), "get".to_string(), "--id".to_string(), input.id];
-        self.run_tool("animus.workflow.get", args, input.project_root).await
+        self.workflow_get_inproc(params.0).await
     }
 
     #[tool(
@@ -98,15 +89,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<IdListInput>()
     )]
     async fn ao_workflow_decisions(&self, params: Parameters<IdListInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec!["workflow".to_string(), "decisions".to_string(), "--id".to_string(), input.id];
-        self.run_list_tool(
-            "animus.workflow.decisions",
-            args,
-            input.project_root,
-            ListGuardInput { limit: input.limit, offset: input.offset, max_tokens: input.max_tokens },
-        )
-        .await
+        self.workflow_decisions_inproc(params.0).await
     }
 
     #[tool(
@@ -115,16 +98,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<IdListInput>()
     )]
     async fn ao_workflow_checkpoints_list(&self, params: Parameters<IdListInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args =
-            vec!["workflow".to_string(), "checkpoints".to_string(), "list".to_string(), "--id".to_string(), input.id];
-        self.run_list_tool(
-            "animus.workflow.checkpoints.list",
-            args,
-            input.project_root,
-            ListGuardInput { limit: input.limit, offset: input.offset, max_tokens: input.max_tokens },
-        )
-        .await
+        self.workflow_checkpoints_list_inproc(params.0).await
     }
 
     #[tool(

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -447,22 +447,130 @@ fn emit_daemon_event(project_root: &str, event_type: &str, data: Value) -> Resul
     Ok(())
 }
 
-fn build_workflow_query(args: crate::WorkflowListArgs) -> Result<WorkflowQuery> {
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowListApplicationRequest {
+    pub(crate) status: Option<String>,
+    pub(crate) workflow_ref: Option<String>,
+    pub(crate) subject_id: Option<String>,
+    pub(crate) phase_id: Option<String>,
+    pub(crate) search: Option<String>,
+    pub(crate) sort: Option<String>,
+    pub(crate) limit: Option<usize>,
+    pub(crate) offset: usize,
+}
+
+impl From<crate::WorkflowListArgs> for WorkflowListApplicationRequest {
+    fn from(args: crate::WorkflowListArgs) -> Self {
+        Self {
+            status: args.status,
+            workflow_ref: args.workflow_ref,
+            subject_id: args.subject_id,
+            phase_id: args.phase_id,
+            search: args.search,
+            sort: args.sort,
+            limit: args.limit,
+            offset: args.offset,
+        }
+    }
+}
+
+fn build_workflow_query(request: WorkflowListApplicationRequest) -> Result<WorkflowQuery> {
     Ok(WorkflowQuery {
         filter: WorkflowFilter {
-            status: parse_workflow_status_opt(args.status.as_deref())?,
-            workflow_ref: args.workflow_ref,
+            status: parse_workflow_status_opt(request.status.as_deref())
+                .map_err(|error| crate::invalid_input_error(error.to_string()))?,
+            workflow_ref: request.workflow_ref,
             // The workflow record's subject-linkage column stores the id in the
             // exact form the dispatch carried (built-in kinds keep the qualified
             // `task:TASK-001`; the filter is an exact match), so pass the
             // `--subject-id` value through verbatim rather than normalizing it.
-            task_id: args.subject_id,
-            phase_id: args.phase_id,
-            search_text: args.search,
+            task_id: request.subject_id,
+            phase_id: request.phase_id,
+            search_text: request.search,
         },
-        page: ListPageRequest { limit: args.limit, offset: args.offset },
-        sort: parse_workflow_query_sort_opt(args.sort.as_deref())?.unwrap_or_default(),
+        page: ListPageRequest { limit: request.limit, offset: request.offset },
+        sort: parse_workflow_query_sort_opt(request.sort.as_deref())
+            .map_err(|error| crate::invalid_input_error(error.to_string()))?
+            .unwrap_or_default(),
     })
+}
+
+pub(crate) async fn workflow_list_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    request: WorkflowListApplicationRequest,
+    actor: Option<&Actor>,
+) -> Result<Vec<Value>> {
+    let requested_limit = request.limit;
+    let requested_offset = request.offset;
+    let mut query = build_workflow_query(request)?;
+    if actor.is_some() {
+        // Ownership must be applied before application pagination.
+        query.page = ListPageRequest { limit: None, offset: 0 };
+    }
+    let page = hub.workflows().query(query).await?;
+    if let Some(actor) = actor {
+        let runtime =
+            animus_runtime_shared::config_context::RuntimeConfigContext::load_for_actor(project_root, Some(actor));
+        return actor_owned_workflow_page(project_root, page.items, actor, requested_offset, requested_limit)
+            .into_iter()
+            .map(|(workflow, owner)| workflow_value_for_application(workflow, &runtime, Some(&owner)))
+            .collect();
+    }
+    let runtime = animus_runtime_shared::config_context::RuntimeConfigContext::load(project_root);
+    page.items.into_iter().map(|workflow| workflow_value_for_application(workflow, &runtime, None)).collect()
+}
+
+pub(crate) async fn workflow_get_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    workflow_id: &str,
+    actor: Option<&Actor>,
+) -> Result<Value> {
+    let owner = authorized_workflow_actor(project_root, workflow_id, actor)?;
+    let runtime = animus_runtime_shared::config_context::RuntimeConfigContext::load_for_actor(project_root, actor);
+    let workflow = hub.workflows().get(workflow_id).await?;
+    workflow_value_for_application(workflow, &runtime, owner.as_ref())
+}
+
+pub(crate) async fn workflow_decisions_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    workflow_id: &str,
+    actor: Option<&Actor>,
+) -> Result<Value> {
+    ensure_workflow_actor_access(project_root, workflow_id, actor)?;
+    Ok(serde_json::to_value(hub.workflows().decisions(workflow_id).await?)?)
+}
+
+pub(crate) async fn workflow_checkpoints_list_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    workflow_id: &str,
+    actor: Option<&Actor>,
+) -> Result<Value> {
+    ensure_workflow_actor_access(project_root, workflow_id, actor)?;
+    Ok(serde_json::to_value(hub.workflows().list_checkpoints(workflow_id).await?)?)
+}
+
+pub(crate) fn workflow_phases_list_application(project_root: &str) -> Result<Value> {
+    phases::list_phase_payload(project_root)
+}
+
+pub(crate) fn workflow_phase_get_application(project_root: &str, phase_id: &str) -> Result<Value> {
+    phases::phase_payload(project_root, phase_id)
+}
+
+pub(crate) fn workflow_definitions_list_application(project_root: &str) -> Result<Value> {
+    Ok(serde_json::to_value(orchestrator_core::load_workflow_config(Path::new(project_root), None)?.workflows)?)
+}
+
+pub(crate) fn workflow_config_get_application(project_root: &str, actor: Option<&Actor>) -> Result<Value> {
+    Ok(config::get_workflow_config_payload(project_root, actor))
+}
+
+pub(crate) fn workflow_config_validate_application(project_root: &str, actor: Option<&Actor>) -> Result<Value> {
+    Ok(config::validate_workflow_config_payload(project_root, actor))
 }
 
 pub(crate) async fn handle_workflow(
@@ -512,43 +620,29 @@ pub(crate) async fn handle_workflow(
             }
             let requested_limit = args.limit;
             let requested_offset = args.offset;
-            let mut query = build_workflow_query(args)?;
+            let request = WorkflowListApplicationRequest::from(args);
+            if json {
+                return print_value(
+                    workflow_list_application(hub.clone(), project_root, request, actor.as_ref()).await?,
+                    true,
+                );
+            }
+            let mut query = build_workflow_query(request)?;
             if actor.is_some() {
-                // Ownership must be applied before application pagination.
-                // Fetch the filtered/sorted local set without DB paging, then
-                // partition and paginate the actor-visible rows.
                 query.page = ListPageRequest { limit: None, offset: 0 };
             }
             let page = workflows.query(query).await?;
-            if let Some(actor) = actor.as_ref() {
-                let owned =
-                    actor_owned_workflow_page(project_root, page.items, actor, requested_offset, requested_limit);
-                if !json {
-                    let items: Vec<_> = owned.into_iter().map(|(workflow, _)| workflow).collect();
-                    print_workflow_list_table(&items);
-                    return Ok(());
+            let items = match actor.as_ref() {
+                Some(actor) => {
+                    actor_owned_workflow_page(project_root, page.items, actor, requested_offset, requested_limit)
+                        .into_iter()
+                        .map(|(workflow, _)| workflow)
+                        .collect()
                 }
-                let runtime = animus_runtime_shared::config_context::RuntimeConfigContext::load_for_actor(
-                    project_root,
-                    Some(actor),
-                );
-                let values = owned
-                    .into_iter()
-                    .map(|(workflow, owner)| workflow_value_for_application(workflow, &runtime, Some(&owner)))
-                    .collect::<Result<Vec<_>>>()?;
-                return print_value(values, true);
-            }
-            if !json {
-                print_workflow_list_table(&page.items);
-                return Ok(());
-            }
-            let runtime = animus_runtime_shared::config_context::RuntimeConfigContext::load(project_root);
-            let values = page
-                .items
-                .into_iter()
-                .map(|workflow| workflow_value_for_application(workflow, &runtime, None))
-                .collect::<Result<Vec<_>>>()?;
-            print_value(values, json)
+                None => page.items,
+            };
+            print_workflow_list_table(&items);
+            Ok(())
         }
         WorkflowCommand::Get(args) => {
             let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
@@ -562,18 +656,22 @@ pub(crate) async fn handle_workflow(
                     return print_value(workflow_value_for_application(run, &runtime, owner.as_ref())?, true);
                 }
             }
-            let workflow = workflows.get(&args.id).await?;
-            match owner.as_ref() {
-                Some(owner) if json => {
-                    print_value(workflow_value_for_application(workflow, &runtime, Some(owner))?, true)
-                }
-                None if json => print_value(workflow_value_for_application(workflow, &runtime, None)?, true),
-                _ => print_value(workflow, json),
+            if json {
+                return print_value(
+                    workflow_get_application(hub.clone(), project_root, &args.id, actor.as_ref()).await?,
+                    true,
+                );
             }
+            print_value(workflows.get(&args.id).await?, false)
         }
-        WorkflowCommand::Decisions(args) => print_value(workflows.decisions(&args.id).await?, json),
+        WorkflowCommand::Decisions(args) => {
+            print_value(workflow_decisions_application(hub.clone(), project_root, &args.id, None).await?, json)
+        }
         WorkflowCommand::Checkpoints { command } => match command {
-            WorkflowCheckpointCommand::List(args) => print_value(workflows.list_checkpoints(&args.id).await?, json),
+            WorkflowCheckpointCommand::List(args) => print_value(
+                workflow_checkpoints_list_application(hub.clone(), project_root, &args.id, None).await?,
+                json,
+            ),
             WorkflowCheckpointCommand::Get(args) => {
                 print_value(workflows.get_checkpoint(&args.id, args.checkpoint).await?, json)
             }
@@ -879,8 +977,10 @@ pub(crate) async fn handle_workflow(
             ),
         },
         WorkflowCommand::Phases { command } => match command {
-            WorkflowPhasesCommand::List => print_value(phases::list_phase_payload(project_root)?, json),
-            WorkflowPhasesCommand::Get(args) => print_value(phases::phase_payload(project_root, &args.phase)?, json),
+            WorkflowPhasesCommand::List => print_value(workflow_phases_list_application(project_root)?, json),
+            WorkflowPhasesCommand::Get(args) => {
+                print_value(workflow_phase_get_application(project_root, &args.phase)?, json)
+            }
             WorkflowPhasesCommand::Upsert(args) => {
                 let definition: orchestrator_core::PhaseExecutionDefinition =
                     serde_json::from_str(&args.input_json).with_context(|| {
@@ -902,10 +1002,7 @@ pub(crate) async fn handle_workflow(
             }
         },
         WorkflowCommand::Definitions { command } => match command {
-            WorkflowDefinitionsCommand::List => {
-                let wf_config = orchestrator_core::load_workflow_config(Path::new(project_root), None)?;
-                print_value(wf_config.workflows, json)
-            }
+            WorkflowDefinitionsCommand::List => print_value(workflow_definitions_list_application(project_root)?, json),
             WorkflowDefinitionsCommand::Upsert(args) => {
                 let workflow: orchestrator_core::WorkflowDefinition =
                     serde_json::from_str(&args.input_json).with_context(|| {
@@ -917,11 +1014,11 @@ pub(crate) async fn handle_workflow(
         WorkflowCommand::Config { command } => match command {
             WorkflowConfigCommand::Get(args) => {
                 let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
-                print_value(config::get_workflow_config_payload(project_root, actor.as_ref()), json)
+                print_value(workflow_config_get_application(project_root, actor.as_ref())?, json)
             }
             WorkflowConfigCommand::Validate(args) => {
                 let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
-                let payload = config::validate_workflow_config_payload(project_root, actor.as_ref());
+                let payload = workflow_config_validate_application(project_root, actor.as_ref())?;
                 if json {
                     print_value(payload, json)
                 } else {


### PR DESCRIPTION
## Summary

- route nine workflow read/model MCP operations through typed in-process application services shared with CLI JSON paths
- preserve actor ownership filtering before pagination and typed workflow projections
- expose decisions and checkpoints on actor-bound MCP servers now that both enforce persisted workflow ownership
- retain the daemon control-wire optimization for direct CLI reads and leave runner execution, destructive controls, and config mutations for separate slices
- remove the now-unused generic MCP list subprocess helper and workflow-list argv builder

Migrated tools:

- `animus.workflow.list`
- `animus.workflow.get`
- `animus.workflow.decisions`
- `animus.workflow.checkpoints.list`
- `animus.workflow.phases.list`
- `animus.workflow.phases.get`
- `animus.workflow.definitions.list`
- `animus.workflow.config.get`
- `animus.workflow.config.validate`

## Verification

- `cargo check -p orchestrator-cli --tests`
- `cargo clippy -p orchestrator-cli --tests -- -D warnings`
- `cargo test -p orchestrator-cli workflow_inproc -- --test-threads=1` (2 passed)
- `cargo test -p orchestrator-cli services::operations::ops_workflow::tests -- --test-threads=1` (13 passed)
- `cargo test -p orchestrator-cli services::operations::ops_mcp::tests -- --test-threads=1` (76 passed)
- `cargo test -p orchestrator-cli --bin animus --quiet -- --test-threads=1` (1,425 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## TASK-971 scope

This is the workflow read/model increment. Workflow run/execute/batch, pause/resume/cancel, manual phase decisions, and config mutations remain, followed by agent, output, cost, environment, and selected daemon/config families.
