### PR TITLE
refactor(mcp): route workflow launches through services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -143,7 +143,7 @@ use output_inputs::*;
 use queue_inputs::*;
 use subject_command_args::{validate_subject_batch_create_input, validate_subject_batch_update_input};
 use subject_inputs::*;
-use workflow_command_args::{build_bulk_workflow_run_item_args, validate_workflow_run_multiple_input};
+use workflow_command_args::validate_workflow_run_multiple_input;
 use workflow_inputs::*;
 
 const DEFAULT_DAEMON_EVENTS_LIMIT: usize = 100;
@@ -206,20 +206,6 @@ impl AoMcpServer {
     fn scoped_state_root(&self) -> std::path::PathBuf {
         protocol::scoped_state_root(std::path::Path::new(&self.default_project_root))
             .unwrap_or_else(|| std::path::PathBuf::from(&self.default_project_root).join(".animus"))
-    }
-}
-
-fn push_opt(args: &mut Vec<String>, flag: &str, value: Option<String>) {
-    if let Some(value) = value {
-        args.push(flag.to_string());
-        args.push(value);
-    }
-}
-
-fn push_opt_num(args: &mut Vec<String>, flag: &str, value: Option<u64>) {
-    if let Some(v) = value {
-        args.push(flag.to_string());
-        args.push(v.to_string());
     }
 }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/ao_exec.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/ao_exec.rs
@@ -1,50 +1,13 @@
-use super::{AoMcpServer, CliExecutionResult};
+#![allow(dead_code)]
+
 use animus_actor::Actor;
 use anyhow::{bail, Context, Result};
-use serde_json::Value;
-use std::process::Stdio;
-use tokio::process::Command as TokioCommand;
 
-impl AoMcpServer {
-    pub(super) async fn execute_ao(
-        &self,
-        requested_args: Vec<String>,
-        project_root_override: Option<String>,
-    ) -> Result<CliExecutionResult> {
-        let project_root = project_root_override.unwrap_or_else(|| self.default_project_root.clone());
-        let args = build_ao_args(&project_root, &requested_args, self.pinned_actor())?;
-
-        let binary = std::env::current_exe().context("failed to resolve ao binary path")?;
-        let output = TokioCommand::new(binary)
-            .args(&args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await
-            .context("failed to execute ao command")?;
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let stdout_json = parse_json(&stdout);
-        let stderr_json = parse_json(&stderr);
-
-        Ok(CliExecutionResult {
-            command: "animus".to_string(),
-            args,
-            requested_args,
-            project_root,
-            exit_code: output.status.code().unwrap_or(-1),
-            success: output.status.success(),
-            stdout,
-            stderr,
-            stdout_json,
-            stderr_json,
-        })
-    }
-}
-
-fn build_ao_args(project_root: &str, requested_args: &[String], pinned_actor: Option<&Actor>) -> Result<Vec<String>> {
+pub(super) fn build_ao_args(
+    project_root: &str,
+    requested_args: &[String],
+    pinned_actor: Option<&Actor>,
+) -> Result<Vec<String>> {
     let mut args = vec!["--json".to_string(), "--project-root".to_string(), project_root.to_string()];
     args.extend(requested_args.iter().cloned());
 
@@ -94,14 +57,6 @@ pub(super) fn command_accepts_actor(requested_args: &[String]) -> bool {
     // absent. Their config_source write protocol carries no Actor and
     // read_modify_write currently resolves the plugin with actor=None. Passing
     // a flag there would either break clap or falsely claim tenant isolation.
-}
-
-fn parse_json(raw: &str) -> Option<Value> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    serde_json::from_str(trimmed).ok()
 }
 
 #[cfg(test)]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/common_types.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/common_types.rs
@@ -37,12 +37,6 @@ impl OnError {
     }
 }
 
-pub(super) struct BatchItemExec {
-    pub(super) target_id: String,
-    pub(super) command: String,
-    pub(super) args: Vec<String>,
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct IdInput {
     pub(super) id: String,

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/exec.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/exec.rs
@@ -1,25 +1,17 @@
-use super::exec_errors::{batch_item_error_from_result, build_tool_error_payload, extract_cli_success_data};
-use super::{AoMcpServer, BatchItemExec, OnError, BATCH_RESULT_SCHEMA};
+use super::AoMcpServer;
 use animus_actor::Actor;
-use anyhow::Result;
 use orchestrator_daemon_runtime::{Audit, AuditActor, AuditEvent, AuditEventKind};
-use rmcp::{model::CallToolResult, ErrorData as McpError};
-use serde_json::{json, Value};
+use serde_json::json;
 
 impl AoMcpServer {
     /// The transport-asserted caller identity this server is bound to (from
     /// `animus mcp serve --actor-json`, relayed by the workflow runner from the
     /// authenticated run), or `None` for a global-scope / local server.
-    ///
-    /// Every tool call routes through [`Self::run_tool`] / [`Self::run_list_tool`],
-    /// which surface this for per-user audit. Actor-aware child CLI commands
-    /// receive the same identity via their existing `--actor-json` boundary.
-    /// Commands whose protocols do not yet carry Actor remain unchanged rather
-    /// than pretending to enforce a scope they cannot represent.
     pub(super) fn pinned_actor(&self) -> Option<&Actor> {
         self.pinned_actor.as_ref()
     }
 
+    #[allow(dead_code)]
     pub(super) fn audit_actor_tool_invocation(&self, tool_name: &str, requested_args: &[String]) {
         let command_actor_aware = super::ao_exec::command_accepts_actor(requested_args);
         self.audit_actor_tool_decision(
@@ -44,157 +36,4 @@ impl AoMcpServer {
             }),
         ));
     }
-
-    pub(super) async fn run_tool(
-        &self,
-        tool_name: &str,
-        requested_args: Vec<String>,
-        project_root_override: Option<String>,
-    ) -> Result<CallToolResult, McpError> {
-        // Per-user audit: record which actor (if any) this tool call runs as.
-        // The actor reaches this server per-agent-spawn via `--actor-json`; this
-        // is the single choke point every typed tool routes through.
-        if let Some(actor) = self.pinned_actor() {
-            tracing::debug!(
-                tool = tool_name,
-                actor_user = %actor.user_id,
-                actor_tenant = ?actor.tenant_id,
-                "MCP tool invoked for actor"
-            );
-        }
-        self.audit_actor_tool_invocation(tool_name, &requested_args);
-        match self.execute_ao(requested_args, project_root_override).await {
-            Ok(result) => {
-                if result.success {
-                    let data = extract_cli_success_data(result.stdout_json);
-
-                    Ok(CallToolResult::structured(json!({
-                        "tool": tool_name,
-                        "result": data,
-                    })))
-                } else {
-                    Ok(CallToolResult::structured_error(build_tool_error_payload(tool_name, &result)))
-                }
-            }
-            Err(err) => Ok(CallToolResult::structured_error(json!({
-                "tool": tool_name,
-                "error": err.to_string(),
-            }))),
-        }
-    }
-
-    pub(super) async fn run_batch_tool(
-        &self,
-        tool_name: &str,
-        items: Vec<BatchItemExec>,
-        on_error: &OnError,
-        project_root_override: Option<String>,
-    ) -> Result<CallToolResult, McpError> {
-        let result = run_batch_items(tool_name, items, on_error, |args| {
-            self.audit_actor_tool_invocation(tool_name, &args);
-            self.execute_ao(args, project_root_override.clone())
-        })
-        .await;
-        Ok(CallToolResult::structured(result))
-    }
-}
-
-/// Execute batch items one at a time through `exec`, honoring `on_error`
-/// semantics (stop = remaining items are marked skipped and never executed;
-/// continue = every item runs), and assemble the
-/// `animus.mcp.batch.result.v1` envelope. Extracted from `run_batch_tool`
-/// so the dispatch loop is unit-testable without spawning CLI subprocesses.
-pub(super) async fn run_batch_items<F, Fut>(
-    tool_name: &str,
-    items: Vec<BatchItemExec>,
-    on_error: &OnError,
-    mut exec: F,
-) -> Value
-where
-    F: FnMut(Vec<String>) -> Fut,
-    Fut: std::future::Future<Output = Result<super::CliExecutionResult>>,
-{
-    let requested = items.len();
-    let mut outcomes: Vec<Value> = Vec::with_capacity(requested);
-    let mut stopped = false;
-
-    for (index, item) in items.into_iter().enumerate() {
-        if stopped {
-            outcomes.push(json!({
-                "index": index,
-                "status": "skipped",
-                "target_id": item.target_id,
-                "command": item.command,
-                "result": null,
-                "error": null,
-                "exit_code": null,
-                "reason": "stopped after earlier failure",
-            }));
-            continue;
-        }
-
-        match exec(item.args).await {
-            Ok(exec_result) => {
-                if exec_result.success {
-                    let data = extract_cli_success_data(exec_result.stdout_json);
-                    outcomes.push(json!({
-                        "index": index,
-                        "status": "success",
-                        "target_id": item.target_id,
-                        "command": item.command,
-                        "result": data,
-                        "exit_code": exec_result.exit_code,
-                    }));
-                } else {
-                    let error = batch_item_error_from_result(&exec_result);
-                    outcomes.push(json!({
-                        "index": index,
-                        "status": "failed",
-                        "target_id": item.target_id,
-                        "command": item.command,
-                        "result": null,
-                        "error": error,
-                        "exit_code": exec_result.exit_code,
-                    }));
-                    if *on_error == OnError::Stop {
-                        stopped = true;
-                    }
-                }
-            }
-            Err(err) => {
-                outcomes.push(json!({
-                    "index": index,
-                    "status": "failed",
-                    "target_id": item.target_id,
-                    "command": item.command,
-                    "result": null,
-                    "error": { "error": err.to_string() },
-                    "exit_code": null,
-                }));
-                if *on_error == OnError::Stop {
-                    stopped = true;
-                }
-            }
-        }
-    }
-
-    let executed = outcomes.iter().filter(|o| o["status"] != "skipped").count();
-    let succeeded = outcomes.iter().filter(|o| o["status"] == "success").count();
-    let failed = outcomes.iter().filter(|o| o["status"] == "failed").count();
-    let skipped = outcomes.iter().filter(|o| o["status"] == "skipped").count();
-
-    json!({
-        "schema": BATCH_RESULT_SCHEMA,
-        "tool": tool_name,
-        "on_error": on_error.as_str(),
-        "summary": {
-            "requested": requested,
-            "executed": executed,
-            "succeeded": succeeded,
-            "failed": failed,
-            "skipped": skipped,
-            "completed": failed == 0,
-        },
-        "results": outcomes,
-    })
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/exec_errors.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/exec_errors.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::CliExecutionResult;
 use serde_json::{json, Value};
 
@@ -101,19 +103,6 @@ pub(super) fn build_inproc_tool_error_payload(tool_name: &str, err: &anyhow::Err
 
 pub(super) fn build_tool_error_payload(tool_name: &str, result: &CliExecutionResult) -> Value {
     let mut payload = json!({ "tool": tool_name, "exit_code": result.exit_code });
-    if let Some(error) = pick_envelope_error(result) {
-        payload["error"] = error;
-    }
-    let stderr = result.stderr.trim().to_string();
-    if !stderr.is_empty() {
-        payload["stderr"] = json!(stderr);
-    }
-    attach_remediation(&mut payload);
-    payload
-}
-
-pub(super) fn batch_item_error_from_result(result: &CliExecutionResult) -> Value {
-    let mut payload = json!({ "exit_code": result.exit_code });
     if let Some(error) = pick_envelope_error(result) {
         payload["error"] = error;
     }
@@ -328,39 +317,5 @@ mod tests {
         );
         let payload = build_tool_error_payload("animus.subject.get", &result);
         assert!(payload.get("remediation").is_none(), "no daemon guess for generic unavailable: {payload}");
-    }
-
-    /// Batch items share the remediation contract with single-tool payloads.
-    #[test]
-    fn batch_item_error_from_result_carries_remediation() {
-        let result = failure_with_envelopes(
-            None,
-            Some(json!({
-                "schema": CLI_SCHEMA_ID,
-                "ok": false,
-                "error": { "code": "invalid_input", "message": "--title must not be empty", "exit_code": 2 }
-            })),
-            "bad item",
-        );
-        let payload = batch_item_error_from_result(&result);
-        assert_eq!(payload.pointer("/remediation/kind").and_then(Value::as_str), Some("invalid_input"));
-        assert_eq!(payload.pointer("/remediation/help").and_then(Value::as_str), Some("--title must not be empty"));
-    }
-
-    /// Batch helper shares the same envelope-picking contract — make sure a
-    /// stderr envelope from one of the per-item runs survives the round-trip
-    /// into the batch outcome payload (no `tool` field for batch items, but
-    /// the `error` and `exit_code` still need to come through).
-    #[test]
-    fn batch_item_error_from_result_prefers_stderr_envelope() {
-        let result = failure_with_envelopes(
-            None,
-            Some(json!({"schema": CLI_SCHEMA_ID, "ok": false, "error": {"code": "not_found"}})),
-            "missing",
-        );
-        let payload = batch_item_error_from_result(&result);
-        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"));
-        assert_eq!(payload.get("stderr").and_then(Value::as_str), Some("missing"));
-        assert_eq!(payload.get("exit_code").and_then(Value::as_i64), Some(5));
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/exec_types.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/exec_types.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[derive(Debug, Clone, Serialize)]
+#[allow(dead_code)]
 pub(super) struct CliExecutionResult {
     pub(super) command: String,
     pub(super) args: Vec<String>,

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -258,38 +258,6 @@ fn build_cli_error_payload_falls_back_to_stdout_envelope_when_stderr_json_missin
 }
 
 #[test]
-fn build_bulk_workflow_run_item_args_basic() {
-    let item = BulkWorkflowRunItem { subject_id: "TASK-4".to_string(), workflow_ref: None, input_json: None };
-    let args = build_bulk_workflow_run_item_args(&item);
-    assert_eq!(
-        args,
-        vec!["workflow".to_string(), "run".to_string(), "--subject-id".to_string(), "TASK-4".to_string(),]
-    );
-}
-
-#[test]
-fn build_bulk_workflow_run_item_args_with_workflow_ref_and_input() {
-    let item = BulkWorkflowRunItem {
-        subject_id: "TASK-5".to_string(),
-        workflow_ref: Some("my-pipeline".to_string()),
-        input_json: Some(r#"{"key":"val"}"#.to_string()),
-    };
-    let args = build_bulk_workflow_run_item_args(&item);
-    assert_eq!(
-        args,
-        vec![
-            "workflow".to_string(),
-            "run".to_string(),
-            "my-pipeline".to_string(),
-            "--subject-id".to_string(),
-            "TASK-5".to_string(),
-            "--input-json".to_string(),
-            r#"{"key":"val"}"#.to_string(),
-        ]
-    );
-}
-
-#[test]
 fn validate_workflow_run_multiple_rejects_empty() {
     let err = validate_workflow_run_multiple_input("animus.workflow.run-multiple", &[]).unwrap_err();
     assert!(err.contains("must not be empty"), "expected empty-array error, got: {err}");
@@ -297,7 +265,7 @@ fn validate_workflow_run_multiple_rejects_empty() {
 
 #[test]
 fn validate_workflow_run_multiple_rejects_empty_subject_id() {
-    let runs = vec![BulkWorkflowRunItem { subject_id: "".to_string(), workflow_ref: None, input_json: None }];
+    let runs = vec![BulkWorkflowRunItem { subject_id: "".to_string(), ..Default::default() }];
     let err = validate_workflow_run_multiple_input("animus.workflow.run-multiple", &runs).unwrap_err();
     assert!(err.contains("subject_id must not be empty"), "expected empty-subject-id error, got: {err}");
 }
@@ -305,11 +273,11 @@ fn validate_workflow_run_multiple_rejects_empty_subject_id() {
 #[test]
 fn validate_workflow_run_multiple_accepts_valid_runs() {
     let runs = vec![
-        BulkWorkflowRunItem { subject_id: "TASK-1".to_string(), workflow_ref: None, input_json: None },
+        BulkWorkflowRunItem { subject_id: "TASK-1".to_string(), ..Default::default() },
         BulkWorkflowRunItem {
             subject_id: "TASK-2".to_string(),
             workflow_ref: Some("p1".to_string()),
-            input_json: None,
+            ..Default::default()
         },
     ];
     assert!(validate_workflow_run_multiple_input("animus.workflow.run-multiple", &runs).is_ok());
@@ -330,7 +298,7 @@ fn on_error_continue_as_str() {
 #[test]
 fn validate_workflow_run_multiple_rejects_over_max() {
     let runs: Vec<BulkWorkflowRunItem> = (0..=MAX_BATCH_SIZE)
-        .map(|i| BulkWorkflowRunItem { subject_id: format!("TASK-{i}"), workflow_ref: None, input_json: None })
+        .map(|i| BulkWorkflowRunItem { subject_id: format!("TASK-{i}"), ..Default::default() })
         .collect();
     let err = validate_workflow_run_multiple_input("animus.workflow.run-multiple", &runs).unwrap_err();
     assert!(err.contains("exceeds maximum"), "expected max-size error, got: {err}");
@@ -403,133 +371,6 @@ fn validate_subject_batch_inputs_accept_valid_items() {
     assert!(validate_subject_batch_create_input("animus.subject.batch-create", "task", &creates).is_ok());
     let updates = vec![batch_update_item("TASK-1", Some("ready"))];
     assert!(validate_subject_batch_update_input("animus.subject.batch-update", "task", &updates).is_ok());
-}
-
-fn batch_exec_item(target_id: &str) -> BatchItemExec {
-    BatchItemExec {
-        target_id: target_id.to_string(),
-        command: format!("subject create --title {target_id}"),
-        args: vec!["subject".to_string(), "create".to_string(), "--title".to_string(), target_id.to_string()],
-    }
-}
-
-fn batch_success_result(title: &str) -> CliExecutionResult {
-    CliExecutionResult {
-        command: "animus".to_string(),
-        args: vec!["--json".to_string()],
-        requested_args: vec!["subject".to_string(), "create".to_string()],
-        project_root: "/tmp/project".to_string(),
-        exit_code: 0,
-        success: true,
-        stdout: String::new(),
-        stderr: String::new(),
-        stdout_json: Some(json!({
-            "schema": CLI_SCHEMA_ID,
-            "ok": true,
-            "data": { "result": { "title": title } }
-        })),
-        stderr_json: None,
-    }
-}
-
-fn batch_failure_result(message: &str) -> CliExecutionResult {
-    let mut result = sample_cli_failure_result();
-    result.exit_code = 2;
-    result.stderr = message.to_string();
-    result.stderr_json = Some(json!({
-        "schema": CLI_SCHEMA_ID,
-        "ok": false,
-        "error": { "code": "invalid_input", "message": message, "exit_code": 2 }
-    }));
-    result
-}
-
-/// Drive the batch loop with a fake executor: every item succeeds.
-#[tokio::test]
-async fn run_batch_items_happy_path_reports_all_success() {
-    let items = vec![batch_exec_item("A"), batch_exec_item("B")];
-    let result =
-        super::exec::run_batch_items("animus.subject.batch-create", items, &OnError::Stop, |args| async move {
-            let title = args.last().cloned().unwrap_or_default();
-            Ok(batch_success_result(&title))
-        })
-        .await;
-
-    assert_eq!(result.get("schema").and_then(Value::as_str), Some(BATCH_RESULT_SCHEMA));
-    assert_eq!(result.pointer("/summary/requested").and_then(Value::as_u64), Some(2));
-    assert_eq!(result.pointer("/summary/succeeded").and_then(Value::as_u64), Some(2));
-    assert_eq!(result.pointer("/summary/failed").and_then(Value::as_u64), Some(0));
-    assert_eq!(result.pointer("/summary/completed").and_then(Value::as_bool), Some(true));
-    assert_eq!(result.pointer("/results/0/status").and_then(Value::as_str), Some("success"));
-    assert_eq!(result.pointer("/results/1/result/result/title").and_then(Value::as_str), Some("B"));
-}
-
-/// on_error=stop: the failing item halts the batch; later items are marked
-/// skipped and the executor is never invoked for them.
-#[tokio::test]
-async fn run_batch_items_stop_mode_skips_after_first_failure_without_executing() {
-    let items = vec![batch_exec_item("A"), batch_exec_item("BAD"), batch_exec_item("C")];
-    let executed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
-    let executed_in = executed.clone();
-    let result = super::exec::run_batch_items("animus.subject.batch-create", items, &OnError::Stop, move |args| {
-        let executed_in = executed_in.clone();
-        async move {
-            let title = args.last().cloned().unwrap_or_default();
-            executed_in.lock().expect("lock").push(title.clone());
-            if title == "BAD" {
-                Ok(batch_failure_result("--title must not be empty"))
-            } else {
-                Ok(batch_success_result(&title))
-            }
-        }
-    })
-    .await;
-
-    assert_eq!(*executed.lock().expect("lock"), vec!["A".to_string(), "BAD".to_string()], "C must never execute");
-    assert_eq!(result.pointer("/summary/executed").and_then(Value::as_u64), Some(2));
-    assert_eq!(result.pointer("/summary/succeeded").and_then(Value::as_u64), Some(1));
-    assert_eq!(result.pointer("/summary/failed").and_then(Value::as_u64), Some(1));
-    assert_eq!(result.pointer("/summary/skipped").and_then(Value::as_u64), Some(1));
-    assert_eq!(result.pointer("/results/1/status").and_then(Value::as_str), Some("failed"));
-    assert_eq!(result.pointer("/results/2/status").and_then(Value::as_str), Some("skipped"));
-    assert_eq!(result.pointer("/results/2/reason").and_then(Value::as_str), Some("stopped after earlier failure"));
-}
-
-/// on_error=continue: a mid-batch failure is isolated — every other item
-/// still runs and succeeds, and the failed item carries the structured
-/// error (remediation included) without poisoning its neighbors.
-#[tokio::test]
-async fn run_batch_items_continue_mode_isolates_per_item_failures() {
-    let items = vec![batch_exec_item("A"), batch_exec_item("BAD"), batch_exec_item("C")];
-    let result =
-        super::exec::run_batch_items("animus.subject.batch-update", items, &OnError::Continue, |args| async move {
-            let title = args.last().cloned().unwrap_or_default();
-            if title == "BAD" {
-                Ok(batch_failure_result("--id must not be empty"))
-            } else {
-                Ok(batch_success_result(&title))
-            }
-        })
-        .await;
-
-    assert_eq!(result.get("on_error").and_then(Value::as_str), Some("continue"));
-    assert_eq!(result.pointer("/summary/executed").and_then(Value::as_u64), Some(3));
-    assert_eq!(result.pointer("/summary/succeeded").and_then(Value::as_u64), Some(2));
-    assert_eq!(result.pointer("/summary/failed").and_then(Value::as_u64), Some(1));
-    assert_eq!(result.pointer("/summary/skipped").and_then(Value::as_u64), Some(0));
-    assert_eq!(result.pointer("/summary/completed").and_then(Value::as_bool), Some(false));
-    assert_eq!(result.pointer("/results/0/status").and_then(Value::as_str), Some("success"));
-    assert_eq!(result.pointer("/results/1/status").and_then(Value::as_str), Some("failed"));
-    assert_eq!(
-        result.pointer("/results/1/error/error/message").and_then(Value::as_str),
-        Some("--id must not be empty")
-    );
-    assert_eq!(
-        result.pointer("/results/1/error/remediation/kind").and_then(Value::as_str),
-        Some("invalid_input"),
-        "per-item errors carry the remediation payload"
-    );
-    assert_eq!(result.pointer("/results/2/status").and_then(Value::as_str), Some("success"));
 }
 
 #[test]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_command_args.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_command_args.rs
@@ -1,15 +1,4 @@
-use super::{push_opt, BulkWorkflowRunItem, MAX_BATCH_SIZE};
-
-pub(super) fn build_bulk_workflow_run_item_args(item: &BulkWorkflowRunItem) -> Vec<String> {
-    let mut args = vec!["workflow".to_string(), "run".to_string()];
-    if let Some(workflow_ref) = item.workflow_ref.clone() {
-        args.push(workflow_ref);
-    }
-    args.push("--subject-id".to_string());
-    args.push(item.subject_id.clone());
-    push_opt(&mut args, "--input-json", item.input_json.clone());
-    args
-}
+use super::{BulkWorkflowRunItem, MAX_BATCH_SIZE};
 
 pub(super) fn validate_workflow_run_multiple_input(
     tool_name: &str,

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inproc.rs
@@ -6,10 +6,12 @@ use crate::services::operations::{
     workflow_config_agent_set_application, workflow_config_get_application, workflow_config_set_application,
     workflow_config_source_application, workflow_config_validate_application,
     workflow_config_workflow_remove_application, workflow_config_workflow_set_application,
-    workflow_decisions_application, workflow_definitions_list_application, workflow_get_application,
-    workflow_list_application, workflow_pause_application, workflow_phase_approve_application,
-    workflow_phase_get_application, workflow_phase_reject_application, workflow_phases_list_application,
-    workflow_resume_application, WorkflowControlApplicationRequest, WorkflowListApplicationRequest,
+    workflow_decisions_application, workflow_definitions_list_application, workflow_dispatch_application,
+    workflow_execute_application, workflow_get_application, workflow_launch_application, workflow_list_application,
+    workflow_pause_application, workflow_phase_approve_application, workflow_phase_get_application,
+    workflow_phase_reject_application, workflow_phases_list_application, workflow_resume_application,
+    WorkflowControlApplicationRequest, WorkflowDispatchApplicationRequest, WorkflowExecuteArgs,
+    WorkflowLaunchApplicationRequest, WorkflowListApplicationRequest,
 };
 use anyhow::Result;
 use orchestrator_core::{services::ServiceHub, FileServiceHub};
@@ -17,6 +19,17 @@ use rmcp::model::CallToolResult;
 use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 use std::sync::Arc;
+
+fn workflow_input(input: Option<Value>, input_json: Option<String>) -> Result<Option<Value>> {
+    match (input, input_json) {
+        (Some(_), Some(_)) => Err(crate::invalid_input_error("input and input_json are mutually exclusive")),
+        (Some(value), None) => Ok(Some(value)),
+        (None, Some(raw)) => serde_json::from_str(&raw)
+            .map(Some)
+            .map_err(|error| crate::invalid_input_error(format!("input_json: {error}"))),
+        (None, None) => Ok(None),
+    }
+}
 
 fn workflow_hub(project_root: &str) -> Result<Arc<dyn ServiceHub>> {
     Ok(Arc::new(FileServiceHub::new(project_root)?))
@@ -84,6 +97,192 @@ impl AoMcpServer {
                 build_guarded_list_result("animus.workflow.list", Value::Array(items), guard)
             })
             .await)
+    }
+
+    pub(super) async fn workflow_run_inproc(
+        &self,
+        input: super::WorkflowRunInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.run", project_root, async |root, actor| {
+                let dispatch = workflow_dispatch_application(
+                    &root,
+                    WorkflowDispatchApplicationRequest {
+                        title: input.title,
+                        subject_id: input.subject_id,
+                        description: input.description,
+                        workflow_ref: input.workflow_ref,
+                        input: workflow_input(input.input, input.input_json)?,
+                        vars: input.vars,
+                    },
+                    actor,
+                )
+                .await?;
+                workflow_launch_application(
+                    workflow_hub(&root)?,
+                    &root,
+                    WorkflowLaunchApplicationRequest {
+                        dispatch,
+                        model: input.model,
+                        tool: input.tool,
+                        phase_timeout_secs: input.phase_timeout_secs,
+                        idempotency_key: input.idempotency_key,
+                    },
+                    actor,
+                )
+                .await
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_execute_inproc(
+        &self,
+        input: super::WorkflowExecuteInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.execute", project_root, async |root, actor| {
+                let workflow_input = workflow_input(input.input, input.input_json)?;
+                let workflow_ref = input.workflow_ref;
+                let dispatch = workflow_dispatch_application(
+                    &root,
+                    WorkflowDispatchApplicationRequest {
+                        title: None,
+                        subject_id: Some(input.subject_id),
+                        description: None,
+                        workflow_ref: workflow_ref.clone(),
+                        input: workflow_input.clone(),
+                        vars: input.vars.clone(),
+                    },
+                    actor,
+                )
+                .await?;
+                workflow_execute_application(
+                    WorkflowExecuteArgs {
+                        workflow_id: None,
+                        title: None,
+                        subject_dispatch: Some(dispatch),
+                        description: None,
+                        workflow_ref,
+                        phase: input.phase,
+                        model: input.model,
+                        tool: input.tool,
+                        phase_timeout_secs: input.phase_timeout_secs,
+                        input: workflow_input,
+                        vars: input.vars,
+                        actor: actor.cloned(),
+                    },
+                    workflow_hub(&root)?,
+                    &root,
+                )
+                .await
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_run_multiple_inproc(
+        &self,
+        input: super::WorkflowRunMultipleInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let tool_name = "animus.workflow.run-multiple";
+        if let Err(message) = super::validate_workflow_run_multiple_input(tool_name, &input.runs) {
+            let error = crate::invalid_input_error(message);
+            return Ok(CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)));
+        }
+        self.audit_actor_tool_decision(tool_name, true, "forward");
+        let project_root = resolve_project_root(&self.default_project_root, input.project_root);
+        let requested = input.runs.len();
+        let mut results = Vec::with_capacity(requested);
+        let mut stopped = false;
+        for (index, item) in input.runs.into_iter().enumerate() {
+            if stopped {
+                results.push(json!({
+                    "index": index,
+                    "status": "skipped",
+                    "target_id": item.subject_id,
+                    "command": "workflow.run",
+                    "result": null,
+                    "error": null,
+                    "exit_code": null,
+                    "reason": "stopped after earlier failure",
+                }));
+                continue;
+            }
+            let target_id = item.subject_id.clone();
+            let outcome = async {
+                let dispatch = workflow_dispatch_application(
+                    &project_root,
+                    WorkflowDispatchApplicationRequest {
+                        title: None,
+                        subject_id: Some(item.subject_id),
+                        description: None,
+                        workflow_ref: item.workflow_ref,
+                        input: workflow_input(item.input, item.input_json)?,
+                        vars: item.vars,
+                    },
+                    self.pinned_actor(),
+                )
+                .await?;
+                workflow_launch_application(
+                    workflow_hub(&project_root)?,
+                    &project_root,
+                    WorkflowLaunchApplicationRequest {
+                        dispatch,
+                        model: item.model,
+                        tool: item.tool,
+                        phase_timeout_secs: item.phase_timeout_secs,
+                        idempotency_key: item.idempotency_key,
+                    },
+                    self.pinned_actor(),
+                )
+                .await
+            }
+            .await;
+            match outcome {
+                Ok(result) => results.push(json!({
+                    "index": index,
+                    "status": "success",
+                    "target_id": target_id,
+                    "command": "workflow.run",
+                    "result": result,
+                    "exit_code": 0,
+                })),
+                Err(error) => {
+                    let mut payload = build_inproc_tool_error_payload(tool_name, &error);
+                    payload.as_object_mut().map(|map| map.remove("tool"));
+                    let exit_code = payload.get("exit_code").cloned().unwrap_or(Value::Null);
+                    results.push(json!({
+                        "index": index,
+                        "status": "failed",
+                        "target_id": target_id,
+                        "command": "workflow.run",
+                        "result": null,
+                        "error": payload,
+                        "exit_code": exit_code,
+                    }));
+                    stopped = input.on_error == super::OnError::Stop;
+                }
+            }
+        }
+        let executed = results.iter().filter(|item| item["status"] != "skipped").count();
+        let succeeded = results.iter().filter(|item| item["status"] == "success").count();
+        let failed = results.iter().filter(|item| item["status"] == "failed").count();
+        let skipped = results.iter().filter(|item| item["status"] == "skipped").count();
+        Ok(CallToolResult::structured(json!({
+            "schema": super::BATCH_RESULT_SCHEMA,
+            "tool": tool_name,
+            "on_error": input.on_error.as_str(),
+            "summary": {
+                "requested": requested,
+                "executed": executed,
+                "succeeded": succeeded,
+                "failed": failed,
+                "skipped": skipped,
+                "completed": failed == 0,
+            },
+            "results": results,
+        })))
     }
 
     pub(super) async fn workflow_get_inproc(&self, input: super::IdInput) -> Result<CallToolResult, rmcp::ErrorData> {
@@ -498,6 +697,130 @@ mod tests {
         assert_eq!(result.is_error, Some(true));
         let payload = result.structured_content.expect("typed error payload");
         assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"), "{payload}");
+    }
+
+    fn workflow_run_input() -> super::super::WorkflowRunInput {
+        super::super::WorkflowRunInput {
+            title: Some("Typed launch".to_string()),
+            subject_id: None,
+            description: None,
+            workflow_ref: None,
+            input_json: None,
+            input: None,
+            vars: Default::default(),
+            model: None,
+            tool: None,
+            phase_timeout_secs: None,
+            idempotency_key: None,
+            project_root: None,
+        }
+    }
+
+    fn bulk_workflow_run(subject_id: &str) -> super::super::BulkWorkflowRunItem {
+        super::super::BulkWorkflowRunItem { subject_id: subject_id.to_string(), ..Default::default() }
+    }
+
+    #[test]
+    fn workflow_input_preserves_nested_values_and_supports_legacy_json() {
+        let nested = json!({"request": {"items": [1, true, {"name": "alpha"}]}});
+        assert_eq!(workflow_input(Some(nested.clone()), None).expect("typed input"), Some(nested.clone()));
+        assert_eq!(workflow_input(None, Some(nested.to_string())).expect("legacy JSON input"), Some(nested));
+    }
+
+    #[test]
+    fn workflow_input_rejects_conflicting_and_malformed_encodings() {
+        let conflict = workflow_input(Some(json!({"typed": true})), Some("{}".to_string())).unwrap_err();
+        assert_eq!(crate::classify_cli_error_kind(&conflict).code(), "invalid_input");
+        let malformed = workflow_input(None, Some("{".to_string())).unwrap_err();
+        assert_eq!(crate::classify_cli_error_kind(&malformed).code(), "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn workflow_run_input_conflict_is_a_typed_in_process_error() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let mut input = workflow_run_input();
+        input.input = Some(json!({"typed": true}));
+        input.input_json = Some("{}".to_string());
+        let result = server.workflow_run_inproc(input).await.expect("tool transport succeeds");
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+    }
+
+    #[tokio::test]
+    async fn workflow_execute_input_conflict_is_a_typed_in_process_error() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let result = server
+            .workflow_execute_inproc(super::super::WorkflowExecuteInput {
+                subject_id: "TASK-1".to_string(),
+                workflow_ref: None,
+                phase: None,
+                model: None,
+                tool: None,
+                phase_timeout_secs: None,
+                input_json: Some("{}".to_string()),
+                input: Some(json!({"typed": true})),
+                vars: Default::default(),
+                project_root: None,
+            })
+            .await
+            .expect("tool transport succeeds");
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+    }
+
+    #[tokio::test]
+    async fn workflow_run_multiple_stop_skips_after_a_typed_item_failure() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let mut first = bulk_workflow_run("TASK-1");
+        first.input = Some(json!({"typed": true}));
+        first.input_json = Some("{}".to_string());
+        let result = server
+            .workflow_run_multiple_inproc(super::super::WorkflowRunMultipleInput {
+                runs: vec![first, bulk_workflow_run("TASK-2")],
+                on_error: super::super::OnError::Stop,
+                project_root: None,
+            })
+            .await
+            .expect("tool transport succeeds");
+
+        let payload = result.structured_content.expect("structured batch payload");
+        assert_eq!(payload.pointer("/summary/failed").and_then(Value::as_u64), Some(1), "{payload}");
+        assert_eq!(payload.pointer("/summary/skipped").and_then(Value::as_u64), Some(1), "{payload}");
+        assert_eq!(payload.pointer("/results/0/error/error/code").and_then(Value::as_str), Some("invalid_input"));
+        assert_eq!(payload.pointer("/results/1/status").and_then(Value::as_str), Some("skipped"));
+    }
+
+    #[tokio::test]
+    async fn workflow_run_multiple_continue_isolates_typed_item_failures() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let mut first = bulk_workflow_run("TASK-1");
+        first.input = Some(json!({"typed": true}));
+        first.input_json = Some("{}".to_string());
+        let mut second = bulk_workflow_run("TASK-2");
+        second.input_json = Some("{".to_string());
+        let result = server
+            .workflow_run_multiple_inproc(super::super::WorkflowRunMultipleInput {
+                runs: vec![first, second],
+                on_error: super::super::OnError::Continue,
+                project_root: None,
+            })
+            .await
+            .expect("tool transport succeeds");
+
+        let payload = result.structured_content.expect("structured batch payload");
+        assert_eq!(payload.pointer("/summary/executed").and_then(Value::as_u64), Some(2), "{payload}");
+        assert_eq!(payload.pointer("/summary/failed").and_then(Value::as_u64), Some(2), "{payload}");
+        assert_eq!(payload.pointer("/summary/skipped").and_then(Value::as_u64), Some(0), "{payload}");
+        assert_eq!(payload.pointer("/results/0/error/error/code").and_then(Value::as_str), Some("invalid_input"));
+        assert_eq!(payload.pointer("/results/1/error/error/code").and_then(Value::as_str), Some("invalid_input"));
     }
 
     #[tokio::test]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
@@ -43,11 +43,27 @@ pub(super) struct WorkflowRunInput {
     pub(super) workflow_ref: Option<String>,
     #[serde(default)]
     pub(super) input_json: Option<String>,
+    /// Structured workflow input. Prefer this over `input_json`; the latter is
+    /// retained for compatibility with older MCP clients.
+    #[serde(default)]
+    pub(super) input: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) vars: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub(super) model: Option<String>,
+    #[serde(default)]
+    pub(super) tool: Option<String>,
+    #[serde(default)]
+    pub(super) phase_timeout_secs: Option<u64>,
+    /// Durable actor/workspace-scoped operation key. Reusing the same key and
+    /// effective request replays the canonical workflow; changed input conflicts.
+    #[serde(default)]
+    pub(super) idempotency_key: Option<String>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 pub(super) struct BulkWorkflowRunItem {
     /// Subject to run the workflow for. Accepts a qualified id (`task:TASK-001`)
     /// or a bare id (`TASK-001`, kind resolved via the subject router).
@@ -56,6 +72,18 @@ pub(super) struct BulkWorkflowRunItem {
     pub(super) workflow_ref: Option<String>,
     #[serde(default)]
     pub(super) input_json: Option<String>,
+    #[serde(default)]
+    pub(super) input: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) vars: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub(super) model: Option<String>,
+    #[serde(default)]
+    pub(super) tool: Option<String>,
+    #[serde(default)]
+    pub(super) phase_timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub(super) idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -148,6 +176,11 @@ pub(super) struct WorkflowExecuteInput {
     pub(super) phase_timeout_secs: Option<u64>,
     #[serde(default)]
     pub(super) input_json: Option<String>,
+    /// Structured workflow input. Prefer this over `input_json`.
+    #[serde(default)]
+    pub(super) input: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) vars: std::collections::HashMap<String, String>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_runtime_tools.rs
@@ -17,14 +17,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<WorkflowRunInput>()
     )]
     async fn ao_workflow_run(&self, params: Parameters<WorkflowRunInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec!["workflow".to_string(), "run".to_string()];
-        push_workflow_run_pipeline_arg(&mut args, input.workflow_ref);
-        push_opt(&mut args, "--title", input.title);
-        push_opt(&mut args, "--subject-id", input.subject_id);
-        push_opt(&mut args, "--description", input.description);
-        push_opt(&mut args, "--input-json", input.input_json);
-        self.run_tool("animus.workflow.run", args, input.project_root).await
+        self.workflow_run_inproc(params.0).await
     }
 
     #[tool(
@@ -96,23 +89,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<WorkflowRunMultipleInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        if let Err(msg) = validate_workflow_run_multiple_input("animus.workflow.run-multiple", &input.runs) {
-            return Ok(CallToolResult::structured_error(json!({
-                "tool": "animus.workflow.run-multiple",
-                "error": msg,
-            })));
-        }
-        let items: Vec<BatchItemExec> = input
-            .runs
-            .into_iter()
-            .map(|item| {
-                let args = build_bulk_workflow_run_item_args(&item);
-                let command = args.join(" ");
-                BatchItemExec { target_id: item.subject_id, command, args }
-            })
-            .collect();
-        self.run_batch_tool("animus.workflow.run-multiple", items, &input.on_error, input.project_root).await
+        self.workflow_run_multiple_inproc(params.0).await
     }
 
     #[tool(
@@ -121,18 +98,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<WorkflowExecuteInput>()
     )]
     async fn ao_workflow_execute(&self, params: Parameters<WorkflowExecuteInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec!["workflow".to_string(), "run".to_string()];
-        push_workflow_run_pipeline_arg(&mut args, input.workflow_ref);
-        args.push("--sync".to_string());
-        args.push("--subject-id".to_string());
-        args.push(input.subject_id);
-        push_opt(&mut args, "--phase", input.phase);
-        push_opt(&mut args, "--model", input.model);
-        push_opt(&mut args, "--tool", input.tool);
-        push_opt_num(&mut args, "--phase-timeout-secs", input.phase_timeout_secs);
-        push_opt(&mut args, "--input-json", input.input_json);
-        self.run_tool("animus.workflow.execute", args, input.project_root).await
+        self.workflow_execute_inproc(params.0).await
     }
 
     #[tool(
@@ -157,11 +123,5 @@ impl AoMcpServer {
         params: Parameters<WorkflowPhaseRejectInput>,
     ) -> Result<CallToolResult, McpError> {
         self.workflow_phase_reject_inproc(params.0).await
-    }
-}
-
-fn push_workflow_run_pipeline_arg(args: &mut Vec<String>, workflow_ref: Option<String>) {
-    if let Some(workflow_ref) = workflow_ref {
-        args.push(workflow_ref);
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_subject.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_subject.rs
@@ -437,7 +437,7 @@ fn read_batch_items<T: serde::de::DeserializeOwned>(file: &Path, tool_name: &str
 /// resolution, honoring `on_error` (stop = remaining items are marked
 /// skipped; continue = every item runs) and assembling an
 /// `animus.cli.batch.result.v1` envelope whose per-item result shape matches
-/// the MCP `run_batch_items` output. The `items` carry `(target_id, method,
+/// the MCP batch-tool contract. The `items` carry `(target_id, method,
 /// params)` triples; routing goes through the same `route_or_not_found` path
 /// the single-item verbs use.
 async fn run_subject_batch(

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/execute.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use animus_actor::Actor;
 use anyhow::{anyhow, Result};
 use orchestrator_core::services::ServiceHub;
+use serde_json::Value;
 
 use crate::print_value;
 use crate::services::plugin_clients;
@@ -26,8 +27,8 @@ pub(crate) struct WorkflowExecuteArgs {
     pub(crate) model: Option<String>,
     pub(crate) tool: Option<String>,
     pub(crate) phase_timeout_secs: Option<u64>,
-    pub(crate) input_json: Option<String>,
-    pub(crate) vars: Vec<String>,
+    pub(crate) input: Option<Value>,
+    pub(crate) vars: std::collections::HashMap<String, String>,
     /// Transport-asserted caller identity, relayed verbatim into the runner
     /// `WorkflowExecuteRequest` so the runner can scope subject/journal/config
     /// plugins to the user.
@@ -45,12 +46,24 @@ pub(crate) async fn handle_workflow_execute(
     project_root: &str,
     json: bool,
 ) -> Result<()> {
+    let result = workflow_execute_application(args, hub, project_root).await?;
+    if json {
+        return print_value(result, true);
+    }
+    Ok(())
+}
+
+pub(crate) async fn workflow_execute_application(
+    args: WorkflowExecuteArgs,
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+) -> Result<Value> {
     if args.workflow_id.is_some() && !args.vars.is_empty() {
         anyhow::bail!(
             "--var cannot be used with --workflow-id; persisted workflow vars are authoritative for existing workflows"
         );
     }
-    let vars = super::parse_workflow_vars(&args.vars)?;
+    let vars = args.vars.clone();
 
     // Re-attach invocations (`--workflow-id`, including the detached
     // children spawned by the async `workflow run` path) must not mutate
@@ -92,8 +105,7 @@ pub(crate) async fn handle_workflow_execute(
     // execute ...` on a fresh checkout) and no plugin is installed,
     // we surface an actionable error rather than falling through to
     // a runtime that the rest of v0.5.1 no longer exercises.
-    let plugin_input_json: Option<serde_json::Value> =
-        args.input_json.as_deref().map(serde_json::from_str).transpose()?;
+    let plugin_input = args.input.clone();
     let plugin_request = if let Some(existing) = existing_workflow.as_ref() {
         let mut request = super::phases::workflow_execute_request_for_existing(existing);
         if let Some(execution) = execution_fence_from_environment(Some(&existing.id))? {
@@ -108,8 +120,8 @@ pub(crate) async fn handle_workflow_execute(
         if args.workflow_ref.is_some() {
             request.workflow_ref = args.workflow_ref.clone();
         }
-        if plugin_input_json.is_some() {
-            request.input = plugin_input_json;
+        if plugin_input.is_some() {
+            request.input = plugin_input;
         }
         request.model = args.model.clone();
         request.tool = args.tool.clone();
@@ -134,7 +146,7 @@ pub(crate) async fn handle_workflow_execute(
             title: args.title.clone(),
             description: args.description.clone(),
             workflow_ref: args.workflow_ref.clone(),
-            input: plugin_input_json,
+            input: plugin_input,
             vars,
             model: args.model.clone(),
             tool: args.tool.clone(),
@@ -189,24 +201,18 @@ pub(crate) async fn handle_workflow_execute(
             }
         }
     }
-    if json {
-        return print_value(
-            serde_json::json!({
-                "workflow_id": plugin_result.workflow_id,
-                "workflow_ref": plugin_result.workflow_ref,
-                "workflow_status": plugin_result.workflow_status,
-                "subject_id": plugin_result.subject_id,
-                "execution_cwd": plugin_result.execution_cwd,
-                "phases_requested": plugin_result.phases_requested,
-                "total_duration_secs": plugin_result.total_duration_secs,
-                "results": plugin_result.phase_results,
-                "post_success": plugin_result.post_success,
-                "via": "plugin_host",
-            }),
-            true,
-        );
-    }
-    Ok(())
+    Ok(serde_json::json!({
+        "workflow_id": plugin_result.workflow_id,
+        "workflow_ref": plugin_result.workflow_ref,
+        "workflow_status": plugin_result.workflow_status,
+        "subject_id": plugin_result.subject_id,
+        "execution_cwd": plugin_result.execution_cwd,
+        "phases_requested": plugin_result.phases_requested,
+        "total_duration_secs": plugin_result.total_duration_secs,
+        "results": plugin_result.phase_results,
+        "post_success": plugin_result.post_success,
+        "via": "plugin_host",
+    }))
 }
 
 fn execution_fence_from_environment(

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -24,7 +24,7 @@ use protocol::SubjectDispatchExt;
 use serde_json::Value;
 use uuid::Uuid;
 
-use self::execute::WorkflowExecuteArgs;
+pub(crate) use self::execute::{workflow_execute_application, WorkflowExecuteArgs};
 use crate::{
     dry_run_envelope, ensure_destructive_confirmation, parse_workflow_query_sort_opt, parse_workflow_status_opt,
     print_value, render_table, WorkflowAgentRuntimeCommand, WorkflowCheckpointCommand, WorkflowCommand,
@@ -778,6 +778,107 @@ pub(crate) async fn workflow_phase_reject_application(
     project_manual_phase_result_for_application(result, project_root, actor, owner.as_ref())
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowDispatchApplicationRequest {
+    pub(crate) title: Option<String>,
+    pub(crate) subject_id: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) workflow_ref: Option<String>,
+    pub(crate) input: Option<Value>,
+    pub(crate) vars: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowLaunchApplicationRequest {
+    pub(crate) dispatch: protocol::SubjectDispatch,
+    pub(crate) model: Option<String>,
+    pub(crate) tool: Option<String>,
+    pub(crate) phase_timeout_secs: Option<u64>,
+    pub(crate) idempotency_key: Option<String>,
+}
+
+pub(crate) async fn workflow_dispatch_application(
+    project_root: &str,
+    request: WorkflowDispatchApplicationRequest,
+    actor: Option<&Actor>,
+) -> Result<protocol::SubjectDispatch> {
+    if request.title.is_some() && request.subject_id.is_some() {
+        return Err(crate::invalid_input_error("title and subject_id are mutually exclusive"));
+    }
+    if let Some(subject_id) = request.subject_id.as_deref() {
+        let subject = resolve_subject_id_ref_via_router(project_root, subject_id, actor).await?;
+        let workflow_ref = request.workflow_ref.unwrap_or_else(|| default_project_workflow_ref(project_root));
+        return Ok(protocol::SubjectDispatch::for_subject_with_metadata(
+            subject,
+            workflow_ref,
+            "application-workflow-run",
+            Utc::now(),
+        )
+        .with_input(request.input)
+        .with_vars(request.vars));
+    }
+    if let Some(title) = request.title {
+        return Ok(protocol::SubjectDispatch::for_custom(
+            title,
+            request.description.unwrap_or_default(),
+            request.workflow_ref.unwrap_or_else(|| default_project_workflow_ref(project_root)),
+            request.input,
+            "application-workflow-run",
+        )
+        .with_vars(request.vars));
+    }
+    Err(crate::invalid_input_error("one of subject_id or title must be provided"))
+}
+
+fn validate_workflow_launch_idempotency_key(key: &str) -> Result<()> {
+    let bytes = key.as_bytes();
+    if bytes.is_empty() || bytes.len() > orchestrator_core::MAX_WORKFLOW_LAUNCH_IDEMPOTENCY_KEY_BYTES {
+        return Err(crate::invalid_input_error(format!(
+            "idempotency key must contain 1..={} bytes",
+            orchestrator_core::MAX_WORKFLOW_LAUNCH_IDEMPOTENCY_KEY_BYTES
+        )));
+    }
+    if !key.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-')) {
+        return Err(crate::invalid_input_error(
+            "idempotency key may contain only ASCII letters, digits, '.', '_', ':', and '-'",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) async fn workflow_launch_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    request: WorkflowLaunchApplicationRequest,
+    actor: Option<&Actor>,
+) -> Result<Value> {
+    let runner_overrides = phases::DetachedRunnerOverrides {
+        model: request.model,
+        tool: request.tool,
+        phase_timeout_secs: request.phase_timeout_secs,
+        actor: actor.cloned(),
+    };
+    let input = request.dispatch.to_workflow_run_input();
+    let workflow = match request.idempotency_key {
+        Some(key) => {
+            validate_workflow_launch_idempotency_key(&key)?;
+            let actor = actor.ok_or_else(|| {
+                crate::invalid_input_error("idempotency_key requires a transport-authenticated actor")
+            })?;
+            if actor.user_id.trim().is_empty() || actor.tenant_id.as_deref().is_none_or(|value| value.trim().is_empty())
+            {
+                return Err(crate::invalid_input_error(
+                    "idempotent workflow launch requires non-empty actor user_id and tenant_id",
+                ));
+            }
+            idempotency::start_workflow_idempotently(hub, project_root, input, runner_overrides, key).await?
+        }
+        None => phases::start_workflow_with_runner(hub, project_root, input, runner_overrides).await?,
+    };
+    let runtime = animus_runtime_shared::config_context::RuntimeConfigContext::load_for_actor(project_root, actor);
+    workflow_value_for_application(workflow, &runtime, actor)
+}
+
 pub(crate) async fn handle_workflow(
     command: WorkflowCommand,
     hub: Arc<dyn ServiceHub>,
@@ -938,8 +1039,8 @@ pub(crate) async fn handle_workflow(
                     model: args.model,
                     tool: args.tool,
                     phase_timeout_secs: args.phase_timeout_secs,
-                    input_json: args.input_json,
-                    vars: args.vars,
+                    input: args.input_json.as_deref().map(serde_json::from_str).transpose()?,
+                    vars: parse_workflow_vars(&args.vars)?,
                     // Actor precedence: an explicit transport-asserted
                     // `--actor-json` flag wins. Otherwise this `--sync` branch
                     // is also the entry point of the daemon-spawned detached
@@ -966,16 +1067,6 @@ pub(crate) async fn handle_workflow(
                 } else {
                     std::collections::HashMap::new()
                 };
-                let runner_overrides = phases::DetachedRunnerOverrides {
-                    model: args.model.clone(),
-                    tool: args.tool.clone(),
-                    phase_timeout_secs: args.phase_timeout_secs,
-                    // The transport-asserted `--actor-json` (if any) is relayed
-                    // to the detached runner child via WORKFLOW_ACTOR_ENV. With
-                    // no flag this is `None` => global scope; an authenticated
-                    // inbound control request supplies its own actor instead.
-                    actor: effective_actor.clone(),
-                };
                 let dispatch = if let Some(subject_dispatch) = subject_id_dispatch {
                     // Generic subject: the kind-correct dispatch was built up
                     // front; the detached runner resolves it via `<kind>/get`.
@@ -994,31 +1085,24 @@ pub(crate) async fn handle_workflow(
                         )?,
                     }
                 };
-                // Post-v0.5 there is no in-process executor: a bare
-                // `workflows.run(...)` only bootstraps a Running record
-                // that nothing drives (the orphan reconciler then
-                // zombie-cancels it). Hand execution to a detached
-                // workflow_runner spawn instead.
-                let input = dispatch.to_workflow_run_input();
-                let workflow = match args.idempotency_key {
-                    Some(key) => {
-                        idempotency::start_workflow_idempotently(
-                            hub.clone(),
-                            project_root,
-                            input,
-                            runner_overrides,
-                            key,
-                        )
-                        .await?
-                    }
-                    None => {
-                        phases::start_workflow_with_runner(hub.clone(), project_root, input, runner_overrides).await?
-                    }
-                };
+                let workflow = workflow_launch_application(
+                    hub.clone(),
+                    project_root,
+                    WorkflowLaunchApplicationRequest {
+                        dispatch,
+                        model: args.model,
+                        tool: args.tool,
+                        phase_timeout_secs: args.phase_timeout_secs,
+                        idempotency_key: args.idempotency_key,
+                    },
+                    effective_actor.as_ref(),
+                )
+                .await?;
                 if !json {
+                    let workflow_id = workflow.get("id").and_then(Value::as_str).unwrap_or("unknown");
+                    let status = workflow.get("status").and_then(Value::as_str).unwrap_or("unknown");
                     eprintln!(
-                        "dispatched workflow {} (status={:?}) — tail with: animus daemon events --follow, or rerun with --sync to stream phase events",
-                        workflow.id, workflow.status
+                        "dispatched workflow {workflow_id} (status={status}) — tail with: animus daemon events --follow, or rerun with --sync to stream phase events"
                     );
                 }
                 print_value(workflow, json)


### PR DESCRIPTION
## Summary

- route workflow run, run-multiple, and execute through typed in-process application services
- preserve structured workflow input, vars, runner overrides, actor scope, and idempotency keys without argv serialization
- retain legacy input_json compatibility with typed validation and standard batch stop/continue envelopes
- remove the now-unused generic child-CLI batch executor

## Verification

- cargo check -p orchestrator-cli --tests
- cargo test -p orchestrator-cli (all unit, binary, and integration suites passed)