### PR TITLE
refactor(mcp): type workflow config writes

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_definition_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_definition_tools.rs
@@ -58,39 +58,26 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.workflow.config.set",
-        description = "Replace the entire workflow config. Purpose: Persist a full RAW source WorkflowConfig through the installed writable config_source plugin (validates the post-pack-merge result before writing). Prerequisites: a writable config_source plugin must be installed. IMPORTANT: the payload must be the RAW SOURCE model, NOT the effective config from animus.workflow.config.get (that is post-pack-merge; feeding it back would bake pack-provided entities into the source). For single-entity edits prefer the entity verbs (agent-set / workflow-set), which read the raw source model and read-modify-write it for you. Use config.set only with an externally-authored raw model. Fails cleanly when the source is read-only (e.g. YAML). Example: {\"file\": \"/tmp/config.json\"}.",
+        description = "Replace the entire workflow config. Purpose: Persist a full RAW source WorkflowConfig through the installed writable config_source plugin (validates the post-pack-merge result before writing). Prerequisites: a writable config_source plugin must be installed. IMPORTANT: `config` must be the RAW SOURCE model, NOT the effective config from animus.workflow.config.get (that is post-pack-merge; feeding it back would bake pack-provided entities into the source). For single-entity edits prefer the entity verbs (agent-set / workflow-set), which read the raw source model and read-modify-write it for you. `file` remains a compatibility alternative and is mutually exclusive with `config`. Fails cleanly when the source is read-only (e.g. YAML). Example: {\"config\": {\"workflows\": [], \"phase_definitions\": {}, \"agent_profiles\": {}}}.",
         input_schema = ao_schema_for_type::<WorkflowConfigSetInput>()
     )]
     async fn ao_workflow_config_set(
         &self,
         params: Parameters<WorkflowConfigSetInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args =
-            vec!["workflow".to_string(), "config".to_string(), "set".to_string(), "--file".to_string(), input.file];
-        self.run_tool("animus.workflow.config.set", args, input.project_root).await
+        self.workflow_config_set_inproc(params.0).await
     }
 
     #[tool(
         name = "animus.workflow.config.agent-set",
-        description = "Create or replace one agent definition. Purpose: Manage a single agent in the workflow config via read-modify-write (loads the current config, upserts the agent, validates, writes the full model). Prerequisites: a writable config_source plugin. This is the DEFINITION-management verb and does NOT collide with the runtime animus.agent.* tools. Example: {\"id\": \"reviewer\", \"input_json\": \"{\\\"description\\\":\\\"...\\\",\\\"system_prompt\\\":\\\"...\\\"}\"}. Sequencing: inspect existing entities with animus.workflow.config.get (read-only; do NOT feed its effective output back into config.set).",
+        description = "Create or replace one agent definition. Purpose: Manage a single agent in the workflow config via read-modify-write (loads the current raw source, upserts the agent, validates, writes the full model). Prerequisites: a writable config_source plugin. `profile` is the structured agent overlay; legacy `input_json` is mutually exclusive. This is the DEFINITION-management verb and does NOT collide with runtime animus.agent.* tools. Example: {\"id\": \"reviewer\", \"profile\": {\"description\":\"...\",\"system_prompt\":\"...\"}}. Sequencing: inspect existing entities with animus.workflow.config.get (read-only; do NOT feed its effective output back into config.set).",
         input_schema = ao_schema_for_type::<WorkflowConfigAgentSetInput>()
     )]
     async fn ao_workflow_config_agent_set(
         &self,
         params: Parameters<WorkflowConfigAgentSetInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec![
-            "workflow".to_string(),
-            "config".to_string(),
-            "agent-set".to_string(),
-            "--id".to_string(),
-            input.id,
-            "--input-json".to_string(),
-            input.input_json,
-        ];
-        self.run_tool("animus.workflow.config.agent-set", args, input.project_root).await
+        self.workflow_config_agent_set_inproc(params.0).await
     }
 
     #[tool(
@@ -102,35 +89,19 @@ impl AoMcpServer {
         &self,
         params: Parameters<WorkflowConfigEntityRemoveInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec![
-            "workflow".to_string(),
-            "config".to_string(),
-            "agent-remove".to_string(),
-            "--id".to_string(),
-            input.id,
-        ];
-        self.run_tool("animus.workflow.config.agent-remove", args, input.project_root).await
+        self.workflow_config_agent_remove_inproc(params.0).await
     }
 
     #[tool(
         name = "animus.workflow.config.workflow-set",
-        description = "Create or replace one workflow definition. Purpose: Manage a single workflow in the config via read-modify-write (validates and writes the full model). Prerequisites: a writable config_source plugin; the JSON must include an 'id'. Example: {\"input_json\": \"{\\\"id\\\":\\\"ship\\\",\\\"name\\\":\\\"Ship\\\",\\\"phases\\\":[\\\"impl\\\"]}\"}. Sequencing: inspect existing entities with animus.workflow.config.get (read-only; do NOT feed its effective output back into config.set).",
+        description = "Create or replace one workflow definition. Purpose: Manage a single workflow in the config via read-modify-write (validates and writes the full model). Prerequisites: a writable config_source plugin; `workflow` must include an `id`. Legacy `input_json` is mutually exclusive. Example: {\"workflow\": {\"id\":\"ship\",\"name\":\"Ship\",\"phases\":[\"impl\"]}}. Sequencing: inspect existing entities with animus.workflow.config.get (read-only; do NOT feed its effective output back into config.set).",
         input_schema = ao_schema_for_type::<WorkflowConfigWorkflowSetInput>()
     )]
     async fn ao_workflow_config_workflow_set(
         &self,
         params: Parameters<WorkflowConfigWorkflowSetInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec![
-            "workflow".to_string(),
-            "config".to_string(),
-            "workflow-set".to_string(),
-            "--input-json".to_string(),
-            input.input_json,
-        ];
-        self.run_tool("animus.workflow.config.workflow-set", args, input.project_root).await
+        self.workflow_config_workflow_set_inproc(params.0).await
     }
 
     #[tool(
@@ -142,14 +113,6 @@ impl AoMcpServer {
         &self,
         params: Parameters<WorkflowConfigEntityRemoveInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec![
-            "workflow".to_string(),
-            "config".to_string(),
-            "workflow-remove".to_string(),
-            "--id".to_string(),
-            input.id,
-        ];
-        self.run_tool("animus.workflow.config.workflow-remove", args, input.project_root).await
+        self.workflow_config_workflow_remove_inproc(params.0).await
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inproc.rs
@@ -2,21 +2,44 @@ use super::daemon_inproc::resolve_project_root;
 use super::exec_errors::build_inproc_tool_error_payload;
 use super::{build_guarded_list_result, AoMcpServer, ListGuardInput};
 use crate::services::operations::{
-    workflow_cancel_application, workflow_checkpoints_list_application, workflow_config_get_application,
-    workflow_config_validate_application, workflow_decisions_application, workflow_definitions_list_application,
-    workflow_get_application, workflow_list_application, workflow_pause_application,
-    workflow_phase_approve_application, workflow_phase_get_application, workflow_phase_reject_application,
-    workflow_phases_list_application, workflow_resume_application, WorkflowControlApplicationRequest,
-    WorkflowListApplicationRequest,
+    workflow_cancel_application, workflow_checkpoints_list_application, workflow_config_agent_remove_application,
+    workflow_config_agent_set_application, workflow_config_get_application, workflow_config_set_application,
+    workflow_config_source_application, workflow_config_validate_application,
+    workflow_config_workflow_remove_application, workflow_config_workflow_set_application,
+    workflow_decisions_application, workflow_definitions_list_application, workflow_get_application,
+    workflow_list_application, workflow_pause_application, workflow_phase_approve_application,
+    workflow_phase_get_application, workflow_phase_reject_application, workflow_phases_list_application,
+    workflow_resume_application, WorkflowControlApplicationRequest, WorkflowListApplicationRequest,
 };
 use anyhow::Result;
 use orchestrator_core::{services::ServiceHub, FileServiceHub};
 use rmcp::model::CallToolResult;
+use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
 fn workflow_hub(project_root: &str) -> Result<Arc<dyn ServiceHub>> {
     Ok(Arc::new(FileServiceHub::new(project_root)?))
+}
+
+fn structured_or_compat_json<T: DeserializeOwned>(
+    structured: Option<Value>,
+    input_json: Option<String>,
+    structured_field: &str,
+) -> Result<T> {
+    let value = match (structured, input_json) {
+        (Some(value), None) => value,
+        (None, Some(raw)) => {
+            serde_json::from_str(&raw).map_err(|error| crate::invalid_input_error(format!("input_json: {error}")))?
+        }
+        (Some(_), Some(_)) => {
+            return Err(crate::invalid_input_error(format!("{structured_field} and input_json are mutually exclusive")))
+        }
+        (None, None) => {
+            return Err(crate::invalid_input_error(format!("one of {structured_field} or input_json is required")))
+        }
+    };
+    serde_json::from_value(value).map_err(|error| crate::invalid_input_error(format!("{structured_field}: {error}")))
 }
 
 impl AoMcpServer {
@@ -244,6 +267,77 @@ impl AoMcpServer {
             })
             .await)
     }
+
+    pub(super) async fn workflow_config_set_inproc(
+        &self,
+        input: super::WorkflowConfigSetInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.config.set", project_root, async |root, _| {
+                let config = match (input.config, input.file) {
+                    (Some(value), None) => serde_json::from_value(value)
+                        .map_err(|error| crate::invalid_input_error(format!("config: {error}")))?,
+                    (None, Some(file)) => workflow_config_source_application(Some(&file))?,
+                    (Some(_), Some(_)) => {
+                        return Err(crate::invalid_input_error("config and file are mutually exclusive"))
+                    }
+                    (None, None) => return Err(crate::invalid_input_error("one of config or file is required")),
+                };
+                workflow_config_set_application(&root, config)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_config_agent_set_inproc(
+        &self,
+        input: super::WorkflowConfigAgentSetInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.config.agent-set", project_root, async |root, _| {
+                let profile = structured_or_compat_json(input.profile, input.input_json, "profile")?;
+                workflow_config_agent_set_application(&root, &input.id, profile)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_config_agent_remove_inproc(
+        &self,
+        input: super::WorkflowConfigEntityRemoveInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.config.agent-remove", project_root, async |root, _| {
+                workflow_config_agent_remove_application(&root, &input.id)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_config_workflow_set_inproc(
+        &self,
+        input: super::WorkflowConfigWorkflowSetInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.config.workflow-set", project_root, async |root, _| {
+                let workflow = structured_or_compat_json(input.workflow, input.input_json, "workflow")?;
+                workflow_config_workflow_set_application(&root, workflow)
+            })
+            .await)
+    }
+
+    pub(super) async fn workflow_config_workflow_remove_inproc(
+        &self,
+        input: super::WorkflowConfigEntityRemoveInput,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let project_root = input.project_root.clone();
+        Ok(self
+            .run_workflow_application("animus.workflow.config.workflow-remove", project_root, async |root, _| {
+                workflow_config_workflow_remove_application(&root, &input.id)
+            })
+            .await)
+    }
 }
 
 #[cfg(test)]
@@ -431,5 +525,64 @@ mod tests {
         let payload = result.structured_content.expect("structured payload");
         assert_eq!(payload.get("tool").and_then(Value::as_str), Some("animus.workflow.config.get"));
         assert!(payload.pointer("/result/workflow_config").is_some());
+    }
+
+    #[test]
+    fn structured_agent_profile_and_compat_json_decode_to_the_same_typed_model() {
+        let value = json!({
+            "description": "Reviews changes",
+            "system_prompt": "Review the implementation",
+            "extra_config": {"reasoning_effort": "high"}
+        });
+        let structured: orchestrator_config::AgentProfileOverlay =
+            structured_or_compat_json(Some(value.clone()), None, "profile").expect("structured profile");
+        let compatibility: orchestrator_config::AgentProfileOverlay =
+            structured_or_compat_json(None, Some(value.to_string()), "profile").expect("compatibility profile");
+
+        assert_eq!(serde_json::to_value(structured).unwrap(), serde_json::to_value(compatibility).unwrap());
+    }
+
+    #[tokio::test]
+    async fn workflow_config_set_rejects_conflicting_sources_before_file_access() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let result = server
+            .workflow_config_set_inproc(super::super::WorkflowConfigSetInput {
+                config: Some(json!({})),
+                file: Some("/path/that/must/not/be/read.json".to_string()),
+                project_root: None,
+            })
+            .await
+            .expect("tool transport succeeds");
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+        assert!(
+            payload
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| message.contains("mutually exclusive")),
+            "{payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn workflow_config_agent_set_rejects_structured_and_compat_payloads() {
+        let root = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let result = server
+            .workflow_config_agent_set_inproc(super::super::WorkflowConfigAgentSetInput {
+                id: "reviewer".to_string(),
+                profile: Some(json!({"description": "review", "system_prompt": "review"})),
+                input_json: Some("{}".to_string()),
+                project_root: None,
+            })
+            .await
+            .expect("tool transport succeeds");
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/workflow_inputs.rs
@@ -87,9 +87,13 @@ pub(super) struct WorkflowPhaseGetInput {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct WorkflowConfigSetInput {
-    /// Path to a JSON file with the full WorkflowConfig. Omit to read from stdin
-    /// (not available over MCP — a file path is required here).
-    pub(super) file: String,
+    /// Structured raw WorkflowConfig source model. Prefer this over `file`.
+    #[serde(default)]
+    pub(super) config: Option<Value>,
+    /// Compatibility path to a JSON file containing the raw WorkflowConfig.
+    /// Mutually exclusive with `config`.
+    #[serde(default)]
+    pub(super) file: Option<String>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }
@@ -97,14 +101,24 @@ pub(super) struct WorkflowConfigSetInput {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct WorkflowConfigAgentSetInput {
     pub(super) id: String,
-    pub(super) input_json: String,
+    /// Structured agent profile overlay. Prefer this over `input_json`.
+    #[serde(default)]
+    pub(super) profile: Option<Value>,
+    /// Compatibility JSON string. Mutually exclusive with `profile`.
+    #[serde(default)]
+    pub(super) input_json: Option<String>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct WorkflowConfigWorkflowSetInput {
-    pub(super) input_json: String,
+    /// Structured workflow definition. Prefer this over `input_json`.
+    #[serde(default)]
+    pub(super) workflow: Option<Value>,
+    /// Compatibility JSON string. Mutually exclusive with `workflow`.
+    #[serde(default)]
+    pub(super) input_json: Option<String>,
     #[serde(default)]
     pub(super) project_root: Option<String>,
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/config.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/config.rs
@@ -539,20 +539,30 @@ fn write_back_payload(project_root: &str, config: &orchestrator_core::WorkflowCo
     }))
 }
 
-/// `animus workflow config set` — replace the entire config from a JSON file or
-/// stdin. The kernel validates before writing and rejects a read-only source.
-pub(crate) fn set_workflow_config_payload(project_root: &str, file: Option<&str>) -> Result<Value> {
+/// CLI compatibility adapter for reading a full raw config from a JSON file or
+/// stdin. Application callers should pass the structured model directly.
+pub(crate) fn read_workflow_config_source(file: Option<&str>) -> Result<orchestrator_core::WorkflowConfig> {
     let raw = read_json_source(file)?;
-    let config: orchestrator_core::WorkflowConfig = serde_json::from_str(&raw)
-        .context("invalid WorkflowConfig JSON for workflow config set; expected a full config model")?;
+    serde_json::from_str(&raw)
+        .context("invalid WorkflowConfig JSON for workflow config set; expected a full config model")
+}
+
+/// Replace the entire raw workflow config from a typed application model. The
+/// kernel validates before writing and rejects a read-only source.
+pub(crate) fn set_workflow_config_payload(
+    project_root: &str,
+    config: orchestrator_core::WorkflowConfig,
+) -> Result<Value> {
     orchestrator_core::write_full_workflow_config(Path::new(project_root), &config)?;
     write_back_payload(project_root, &config)
 }
 
 /// `animus workflow config agent-set` — upsert one agent definition.
-pub(crate) fn set_config_agent_payload(project_root: &str, id: &str, input_json: &str) -> Result<Value> {
-    let profile: orchestrator_config::AgentProfileOverlay =
-        serde_json::from_str(input_json).context("invalid agent profile JSON for workflow config agent-set")?;
+pub(crate) fn set_config_agent_payload(
+    project_root: &str,
+    id: &str,
+    profile: orchestrator_config::AgentProfileOverlay,
+) -> Result<Value> {
     let config = orchestrator_core::upsert_agent_profile(Path::new(project_root), id, profile)?;
     write_back_payload(project_root, &config)
 }
@@ -561,9 +571,11 @@ pub(crate) fn set_config_agent_payload(project_root: &str, id: &str, input_json:
 /// config_source base (`WorkflowConfig.phase_definitions`), NOT the agent-runtime
 /// overlay that `workflow phases upsert` writes. A workflow set afterwards that
 /// references this phase then resolves during post-pack-merge validation.
-pub(crate) fn set_config_phase_payload(project_root: &str, id: &str, input_json: &str) -> Result<Value> {
-    let definition: orchestrator_config::PhaseExecutionDefinition = serde_json::from_str(input_json)
-        .context("invalid phase execution definition JSON for workflow config phase-set")?;
+pub(crate) fn set_config_phase_payload(
+    project_root: &str,
+    id: &str,
+    definition: orchestrator_config::PhaseExecutionDefinition,
+) -> Result<Value> {
     let config = orchestrator_core::set_phase_definition(Path::new(project_root), id, definition)?;
     write_back_payload(project_root, &config)
 }
@@ -575,9 +587,10 @@ pub(crate) fn remove_config_agent_payload(project_root: &str, id: &str) -> Resul
 }
 
 /// `animus workflow config workflow-set` — upsert one workflow definition.
-pub(crate) fn set_config_workflow_payload(project_root: &str, input_json: &str) -> Result<Value> {
-    let definition: orchestrator_core::WorkflowDefinition = serde_json::from_str(input_json)
-        .context("invalid workflow definition JSON for workflow config workflow-set; must include an 'id' field")?;
+pub(crate) fn set_config_workflow_payload(
+    project_root: &str,
+    definition: orchestrator_core::WorkflowDefinition,
+) -> Result<Value> {
     let config = orchestrator_core::upsert_workflow_definition(Path::new(project_root), definition)?;
     write_back_payload(project_root, &config)
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_workflow/mod.rs
@@ -573,6 +573,44 @@ pub(crate) fn workflow_config_validate_application(project_root: &str, actor: Op
     Ok(config::validate_workflow_config_payload(project_root, actor))
 }
 
+pub(crate) fn workflow_config_source_application(file: Option<&str>) -> Result<orchestrator_core::WorkflowConfig> {
+    config::read_workflow_config_source(file)
+}
+
+pub(crate) fn workflow_config_set_application(
+    project_root: &str,
+    config: orchestrator_core::WorkflowConfig,
+) -> Result<Value> {
+    config::set_workflow_config_payload(project_root, config)
+}
+
+pub(crate) fn workflow_config_agent_set_application(
+    project_root: &str,
+    id: &str,
+    profile: orchestrator_config::AgentProfileOverlay,
+) -> Result<Value> {
+    config::set_config_agent_payload(project_root, id, profile)
+}
+
+pub(crate) fn workflow_config_agent_remove_application(project_root: &str, id: &str) -> Result<Value> {
+    config::remove_config_agent_payload(project_root, id)
+}
+
+pub(crate) fn workflow_config_workflow_set_application(
+    project_root: &str,
+    workflow: orchestrator_core::WorkflowDefinition,
+) -> Result<Value> {
+    config::set_config_workflow_payload(project_root, workflow)
+}
+
+pub(crate) fn workflow_config_workflow_remove_application(project_root: &str, id: &str) -> Result<Value> {
+    config::remove_config_workflow_payload(project_root, id)
+}
+
+fn workflow_config_phase_from_json(input_json: &str) -> Result<orchestrator_config::PhaseExecutionDefinition> {
+    serde_json::from_str(input_json).context("invalid phase execution definition JSON for workflow config phase-set")
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct WorkflowControlApplicationRequest {
     pub(crate) id: String,
@@ -1120,22 +1158,29 @@ pub(crate) async fn handle_workflow(
             WorkflowConfigCommand::Compile => print_value(config::compile_yaml_workflows_payload(project_root)?, json),
             WorkflowConfigCommand::Reload => print_value(config::reload_workflow_config_payload(project_root), json),
             WorkflowConfigCommand::Set(args) => {
-                print_value(config::set_workflow_config_payload(project_root, args.file.as_deref())?, json)
+                let config = workflow_config_source_application(args.file.as_deref())?;
+                print_value(workflow_config_set_application(project_root, config)?, json)
             }
             WorkflowConfigCommand::AgentSet(args) => {
-                print_value(config::set_config_agent_payload(project_root, &args.id, &args.input_json)?, json)
+                let profile: orchestrator_config::AgentProfileOverlay = serde_json::from_str(&args.input_json)
+                    .context("invalid agent profile JSON for workflow config agent-set")?;
+                print_value(workflow_config_agent_set_application(project_root, &args.id, profile)?, json)
             }
             WorkflowConfigCommand::AgentRemove(args) => {
-                print_value(config::remove_config_agent_payload(project_root, &args.id)?, json)
+                print_value(workflow_config_agent_remove_application(project_root, &args.id)?, json)
             }
             WorkflowConfigCommand::PhaseSet(args) => {
-                print_value(config::set_config_phase_payload(project_root, &args.id, &args.input_json)?, json)
+                let definition = workflow_config_phase_from_json(&args.input_json)?;
+                print_value(config::set_config_phase_payload(project_root, &args.id, definition)?, json)
             }
             WorkflowConfigCommand::WorkflowSet(args) => {
-                print_value(config::set_config_workflow_payload(project_root, &args.input_json)?, json)
+                let workflow: orchestrator_core::WorkflowDefinition = serde_json::from_str(&args.input_json).context(
+                    "invalid workflow definition JSON for workflow config workflow-set; must include an 'id' field",
+                )?;
+                print_value(workflow_config_workflow_set_application(project_root, workflow)?, json)
             }
             WorkflowConfigCommand::WorkflowRemove(args) => {
-                print_value(config::remove_config_workflow_payload(project_root, &args.id)?, json)
+                print_value(workflow_config_workflow_remove_application(project_root, &args.id)?, json)
             }
         },
         WorkflowCommand::StateMachine { command } => match command {
@@ -1507,8 +1552,7 @@ mod tests {
 
     #[test]
     fn set_config_phase_payload_reports_actionable_json_error() {
-        let error =
-            set_config_phase_payload("/tmp/unused", "my-phase", "{invalid").expect_err("invalid payload should fail");
+        let error = workflow_config_phase_from_json("{invalid").expect_err("invalid payload should fail");
         let message = format!("{error:#}");
         assert!(
             message.contains("invalid phase execution definition JSON for workflow config phase-set"),

--- a/docs/architecture/actor-bound-application-contract.md
+++ b/docs/architecture/actor-bound-application-contract.md
@@ -181,7 +181,9 @@ These surfaces remain absent from actor-bound MCP until their protocols change:
 
 - Config writes: `animus_config_protocol::ConfigWriteRequest` needs an
   `actor: Option<Actor>` field and config-source write implementations must
-  resolve and write the same actor partition used by reads.
+  resolve and write the same actor partition used by reads. Management-mode
+  MCP already routes these operations through typed in-process application
+  services; that removes argv/JSON-string loss but does not grant actor safety.
 - Queue list/control/mutation: queue requests need actor filters and
   authorization context, and the queue/subject dispatch bridge must preserve
   the current `Actor`.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -202,13 +202,17 @@ and are the **definition**-management surface — distinct from the runtime
 (after pack overlays are merged), so writing it back would bake pack-provided
 entities into your source and shadow later pack updates. Use `config.set` only
 with an externally-authored raw model; for edits, use the entity verbs.
+Pass structured `config`, `profile`, and `workflow` values so they stay typed
+through the in-process application service. The legacy `file` and `input_json`
+fields remain compatibility alternatives and cannot be combined with their
+structured equivalents.
 
 ```json
-{ "file": "/tmp/config.json" }                           // animus.workflow.config.set (full model)
-{ "id": "reviewer", "input_json": "{...}" }              // animus.workflow.config.agent-set
-{ "id": "reviewer" }                                      // animus.workflow.config.agent-remove
-{ "input_json": "{\"id\":\"ship\",\"name\":\"Ship\",\"phases\":[\"impl\"]}" } // animus.workflow.config.workflow-set
-{ "id": "ship" }                                          // animus.workflow.config.workflow-remove
+{ "config": { "workflows": [], "phase_definitions": {}, "agent_profiles": {} } } // config.set
+{ "id": "reviewer", "profile": { "description": "Review", "system_prompt": "Review changes" } } // agent-set
+{ "id": "reviewer" } // agent-remove
+{ "workflow": { "id": "ship", "name": "Ship", "phases": ["impl"] } } // workflow-set
+{ "id": "ship" } // workflow-remove
 ```
 
 ## Daemon and Queue Operations

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -251,11 +251,17 @@ and task projection instead of falling back to global scope.
 | `animus.workflow.definitions.list` | List workflow definitions | `project_root` |
 | `animus.workflow.config.get` | Read effective workflow configuration | `project_root` |
 | `animus.workflow.config.validate` | Validate workflow config for shape errors and broken references | `project_root` |
-| `animus.workflow.config.set` | Replace the full config via the writable config_source plugin (validates first; rejected on read-only sources) | `file`, `project_root` |
-| `animus.workflow.config.agent-set` | Create or replace one agent definition (read-modify-write the full config) | `id`, `input_json`, `project_root` |
+| `animus.workflow.config.set` | Replace the full raw config via the writable config_source plugin (validates first; rejected on read-only sources) | `config` (structured, preferred) or compatibility `file`, `project_root` |
+| `animus.workflow.config.agent-set` | Create or replace one agent definition (read-modify-write the full config) | `id`, `profile` (structured, preferred) or compatibility `input_json`, `project_root` |
 | `animus.workflow.config.agent-remove` | Remove one agent definition | `id`, `project_root` |
-| `animus.workflow.config.workflow-set` | Create or replace one workflow definition (read-modify-write) | `input_json`, `project_root` |
+| `animus.workflow.config.workflow-set` | Create or replace one workflow definition (read-modify-write) | `workflow` (structured, preferred) or compatibility `input_json`, `project_root` |
 | `animus.workflow.config.workflow-remove` | Remove one workflow definition | `id`, `project_root` |
+
+The five config write tools execute through typed in-process application
+services; structured values are deserialized once into the kernel model and do
+not cross a child-CLI/argv boundary. Compatibility fields are mutually
+exclusive with their structured equivalents. These remain management-only
+because the config write protocol does not yet carry an authenticated actor.
 
 ---
 


### PR DESCRIPTION
## What changed

- routes all five workflow configuration write MCP tools through typed in-process application services
- adds structured `config`, `profile`, and `workflow` inputs while retaining mutually exclusive `file`/`input_json` compatibility fields
- shares the same typed kernel write boundary with the CLI and preserves validate-before-write/read-modify-write behavior
- documents that these tools remain management-only until the config write protocol carries an authenticated actor

## Why

Config writes still spawned a child CLI and either read a server-side file or embedded JSON strings inside MCP JSON. That duplicated parsing, lost type structure at the boundary, and made the Portal application layer harder to use safely.

## Impact

Management applications can send nested config models directly without argv or JSON-string round trips. Existing compatibility inputs continue to work, and actor-bound servers remain fail-closed because the backend write protocol still lacks ownership context.

## Validation

- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo animus-lint`
- `cargo test -p orchestrator-cli --locked -- --test-threads=1` outside the sandbox (1,431 unit tests plus all binary/integration targets)
- focused structured/compatibility equivalence and typed conflict-error tests
- `git diff --check`