### PR TITLE
refactor(mcp): route agent coordination through services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -27,6 +27,8 @@ use std::time::UNIX_EPOCH;
 
 #[path = "ops_mcp/agent_command_args.rs"]
 mod agent_command_args;
+#[path = "ops_mcp/agent_inproc.rs"]
+mod agent_inproc;
 #[path = "ops_mcp/agent_inputs.rs"]
 mod agent_inputs;
 #[path = "ops_mcp/agent_tools.rs"]
@@ -344,6 +346,8 @@ const ACTOR_BOUND_MCP_TOOLS: &[&str] = &[
     "animus.subject.batch-update",
     "animus.subject.next",
     "animus.subject.status",
+    "animus.agent.list",
+    "animus.agent.get",
     "animus.agent.ask",
     "animus.agent.request_approval",
     "animus.interactions.list",

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/agent_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/agent_inproc.rs
@@ -1,0 +1,207 @@
+use super::daemon_inproc::resolve_project_root;
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::AoMcpServer;
+use crate::services::runtime::{
+    agent_get_application, agent_list_application, agent_memory_append_application, agent_memory_clear_application,
+    agent_memory_get_application, agent_message_list_application, agent_message_send_application,
+};
+use anyhow::Result;
+use rmcp::model::CallToolResult;
+use serde_json::{json, Value};
+
+impl AoMcpServer {
+    fn run_agent_application<F>(
+        &self,
+        tool_name: &str,
+        project_root: Option<String>,
+        actor_bound: bool,
+        call: F,
+    ) -> CallToolResult
+    where
+        F: FnOnce(&str, Option<&animus_actor::Actor>) -> Result<Value>,
+    {
+        self.audit_actor_tool_decision(tool_name, actor_bound, if actor_bound { "forward" } else { "management-only" });
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        match call(&project_root, self.pinned_actor()) {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)),
+        }
+    }
+
+    pub(super) fn agent_list_inproc(&self, project_root: Option<String>) -> CallToolResult {
+        self.run_agent_application("animus.agent.list", project_root, true, agent_list_application)
+    }
+
+    pub(super) fn agent_get_inproc(&self, input: super::AgentProfileInput) -> CallToolResult {
+        self.run_agent_application("animus.agent.get", input.project_root, true, |root, actor| {
+            agent_get_application(root, &input.id, actor)
+        })
+    }
+
+    pub(super) fn agent_memory_get_inproc(&self, input: super::AgentMemoryGetInput) -> CallToolResult {
+        self.run_agent_application("animus.agent.memory.get", input.project_root, false, |root, _actor| {
+            agent_memory_get_application(root, &input.agent)
+        })
+    }
+
+    pub(super) fn agent_memory_append_inproc(&self, input: super::AgentMemoryAppendInput) -> CallToolResult {
+        self.run_agent_application("animus.agent.memory.append", input.project_root, false, |root, _actor| {
+            agent_memory_append_application(root, &input.agent, &input.text, input.source.as_deref())
+        })
+    }
+
+    pub(super) fn agent_memory_clear_inproc(&self, input: super::AgentMemoryGetInput) -> CallToolResult {
+        self.run_agent_application("animus.agent.memory.clear", input.project_root, false, |root, _actor| {
+            agent_memory_clear_application(root, &input.agent)
+        })
+    }
+
+    pub(super) fn agent_message_send_inproc(&self, input: super::AgentMessageSendInput) -> CallToolResult {
+        self.run_agent_application("animus.agent.message.send", input.project_root, false, |root, _actor| {
+            agent_message_send_application(
+                root,
+                &input.channel,
+                &input.from,
+                input.to.as_deref(),
+                &input.text,
+                input.workflow_id.as_deref(),
+                input.phase_id.as_deref(),
+            )
+        })
+    }
+
+    pub(super) fn agent_message_list_inproc(&self, input: super::AgentMessageListInput) -> CallToolResult {
+        self.run_agent_application("animus.agent.message.list", input.project_root, false, |root, _actor| {
+            agent_message_list_application(root, input.channel.as_deref(), input.agent.as_deref(), input.limit)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configured_project(
+    ) -> (tempfile::TempDir, orchestrator_config::workflow_config::config_source_client::test_seam::TestBaseGuard) {
+        let root = tempfile::tempdir().expect("project root");
+        let animus = root.path().join(".animus");
+        std::fs::create_dir_all(&animus).expect("animus dir");
+        std::fs::write(
+            animus.join("workflows.yaml"),
+            "tools_allowlist:\n  - cargo\nphases:\n  work:\n    mode: agent\n    agent_id: rafael\nagents:\n  rafael:\n    description: Workspace agent\n    system_prompt: Help the team\n    skills: []\n    memory:\n      enabled: true\n      max_entries: 2\nworkflows:\n  - id: standard\n    name: Standard\n    phases:\n      - work\n",
+        )
+        .expect("workflow config");
+        let guard =
+            orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(root.path());
+        (root, guard)
+    }
+
+    #[test]
+    fn agent_list_and_get_return_typed_in_process_profiles() {
+        let (root, _guard) = configured_project();
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+
+        let list = server.agent_list_inproc(None);
+        assert_ne!(list.is_error, Some(true));
+        let payload = list.structured_content.expect("list payload");
+        assert_eq!(payload.pointer("/result/agents/0/id").and_then(Value::as_str), Some("rafael"), "{payload}");
+
+        let get =
+            server.agent_get_inproc(super::super::AgentProfileInput { id: "rafael".to_string(), project_root: None });
+        assert_ne!(get.is_error, Some(true));
+        let payload = get.structured_content.expect("get payload");
+        assert_eq!(payload.pointer("/result/id").and_then(Value::as_str), Some("rafael"), "{payload}");
+    }
+
+    #[test]
+    fn agent_memory_mutations_share_the_typed_application_store() {
+        let (root, _guard) = configured_project();
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+
+        let append = server.agent_memory_append_inproc(super::super::AgentMemoryAppendInput {
+            agent: "rafael".to_string(),
+            text: "Arena is the shared workplace".to_string(),
+            source: Some("test".to_string()),
+            project_root: None,
+        });
+        let append_is_error = append.is_error;
+        let append_payload = append.structured_content.expect("append payload");
+        assert_ne!(append_is_error, Some(true), "{append_payload}");
+
+        let get = server.agent_memory_get_inproc(super::super::AgentMemoryGetInput {
+            agent: "rafael".to_string(),
+            project_root: None,
+        });
+        let payload = get.structured_content.expect("memory payload");
+        assert_eq!(
+            payload.pointer("/result/entries/0/text").and_then(Value::as_str),
+            Some("Arena is the shared workplace"),
+            "{payload}"
+        );
+    }
+
+    #[test]
+    fn agent_message_validation_returns_a_typed_not_found_error() {
+        let (root, _guard) = configured_project();
+        let server = super::super::new_ao_mcp_server(root.path().to_string_lossy().as_ref());
+        let result = server.agent_message_send_inproc(super::super::AgentMessageSendInput {
+            channel: "missing".to_string(),
+            from: "rafael".to_string(),
+            to: None,
+            text: "hello".to_string(),
+            workflow_id: None,
+            phase_id: None,
+            project_root: None,
+        });
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"), "{payload}");
+    }
+
+    #[test]
+    fn actor_bound_agent_rosters_are_loaded_from_each_users_partition() {
+        use orchestrator_config::workflow_config::config_source_client::test_seam;
+
+        let root = tempfile::tempdir().expect("project root");
+        let animus = root.path().join(".animus");
+        std::fs::create_dir_all(&animus).expect("animus dir");
+        let config_for = |agent: &str| {
+            format!(
+                "tools_allowlist:\n  - cargo\nphases:\n  work:\n    mode: agent\n    agent_id: {agent}\nagents:\n  {agent}:\n    description: Workspace agent\n    system_prompt: Help the team\n    skills: []\nworkflows:\n  - id: standard\n    name: Standard\n    phases:\n      - work\n"
+            )
+        };
+
+        std::fs::write(animus.join("workflows.yaml"), config_for("rafael")).expect("alice workflow config");
+        let alice_base = orchestrator_core::compile_yaml_workflow_files(root.path())
+            .expect("compile alice config")
+            .expect("alice config present");
+        std::fs::write(animus.join("workflows.yaml"), config_for("maria")).expect("bob workflow config");
+        let bob_base = orchestrator_core::compile_yaml_workflow_files(root.path())
+            .expect("compile bob config")
+            .expect("bob config present");
+
+        let alice = animus_actor::Actor {
+            user_id: "alice".to_string(),
+            claims: Vec::new(),
+            tenant_id: Some("workspace-a".to_string()),
+        };
+        let bob = animus_actor::Actor {
+            user_id: "bob".to_string(),
+            claims: Vec::new(),
+            tenant_id: Some("workspace-a".to_string()),
+        };
+        let _alice_guard = test_seam::install_for_actor(root.path(), &alice, alice_base);
+        let _bob_guard = test_seam::install_for_actor(root.path(), &bob, bob_base);
+        let project_root = root.path().to_string_lossy();
+        let alice_server =
+            super::super::new_ao_mcp_server_with_options(project_root.as_ref(), false, None, None, Some(alice));
+        let bob_server =
+            super::super::new_ao_mcp_server_with_options(project_root.as_ref(), false, None, None, Some(bob));
+
+        let alice_payload = alice_server.agent_list_inproc(None).structured_content.expect("alice roster");
+        let bob_payload = bob_server.agent_list_inproc(None).structured_content.expect("bob roster");
+        assert_eq!(alice_payload.pointer("/result/agents/0/id").and_then(Value::as_str), Some("rafael"));
+        assert_eq!(bob_payload.pointer("/result/agents/0/id").and_then(Value::as_str), Some("maria"));
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/agent_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/agent_tools.rs
@@ -8,7 +8,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ProjectRootInput>()
     )]
     async fn ao_agent_list(&self, params: Parameters<ProjectRootInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool("animus.agent.list", vec!["agent".to_string(), "list".to_string()], params.0.project_root).await
+        Ok(self.agent_list_inproc(params.0.project_root))
     }
 
     #[tool(
@@ -17,9 +17,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<AgentProfileInput>()
     )]
     async fn ao_agent_get(&self, params: Parameters<AgentProfileInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec!["agent".to_string(), "get".to_string(), "--id".to_string(), input.id];
-        self.run_tool("animus.agent.get", args, input.project_root).await
+        Ok(self.agent_get_inproc(params.0))
     }
 
     #[tool(
@@ -68,10 +66,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<AgentMemoryGetInput>()
     )]
     async fn ao_agent_memory_get(&self, params: Parameters<AgentMemoryGetInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args =
-            vec!["agent".to_string(), "memory".to_string(), "get".to_string(), "--agent".to_string(), input.agent];
-        self.run_tool("animus.agent.memory.get", args, input.project_root).await
+        Ok(self.agent_memory_get_inproc(params.0))
     }
 
     #[tool(
@@ -83,18 +78,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<AgentMemoryAppendInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec![
-            "agent".to_string(),
-            "memory".to_string(),
-            "append".to_string(),
-            "--agent".to_string(),
-            input.agent,
-            "--text".to_string(),
-            input.text,
-        ];
-        push_opt(&mut args, "--source", input.source);
-        self.run_tool("animus.agent.memory.append", args, input.project_root).await
+        Ok(self.agent_memory_append_inproc(params.0))
     }
 
     #[tool(
@@ -103,10 +87,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<AgentMemoryGetInput>()
     )]
     async fn ao_agent_memory_clear(&self, params: Parameters<AgentMemoryGetInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args =
-            vec!["agent".to_string(), "memory".to_string(), "clear".to_string(), "--agent".to_string(), input.agent];
-        self.run_tool("animus.agent.memory.clear", args, input.project_root).await
+        Ok(self.agent_memory_clear_inproc(params.0))
     }
 
     #[tool(
@@ -118,22 +99,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<AgentMessageSendInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec![
-            "agent".to_string(),
-            "message".to_string(),
-            "send".to_string(),
-            "--channel".to_string(),
-            input.channel,
-            "--from".to_string(),
-            input.from,
-            "--text".to_string(),
-            input.text,
-        ];
-        push_opt(&mut args, "--to", input.to);
-        push_opt(&mut args, "--workflow-id", input.workflow_id);
-        push_opt(&mut args, "--phase-id", input.phase_id);
-        self.run_tool("animus.agent.message.send", args, input.project_root).await
+        Ok(self.agent_message_send_inproc(params.0))
     }
 
     #[tool(
@@ -145,11 +111,6 @@ impl AoMcpServer {
         &self,
         params: Parameters<AgentMessageListInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec!["agent".to_string(), "message".to_string(), "list".to_string()];
-        push_opt(&mut args, "--channel", input.channel);
-        push_opt(&mut args, "--agent", input.agent);
-        push_opt(&mut args, "--limit", input.limit.map(|value| value.to_string()));
-        self.run_tool("animus.agent.message.list", args, input.project_root).await
+        Ok(self.agent_message_list_inproc(params.0))
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -185,6 +185,10 @@ fn actor_bound_server_exposes_only_actor_enforced_tools() {
     assert!(names.contains("animus.workflow.resume"));
     assert!(names.contains("animus.workflow.phase.approve"));
     assert!(names.contains("animus.workflow.phase.reject"));
+    assert!(names.contains("animus.agent.list"));
+    assert!(names.contains("animus.agent.get"));
+    assert!(!names.contains("animus.agent.memory.get"));
+    assert!(!names.contains("animus.agent.message.send"));
     assert!(!names.contains("animus.queue.list"));
     assert!(!names.contains("animus.workflow.config.set"));
     assert!(!names.contains("animus.memory.get"));

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent.rs
@@ -14,6 +14,10 @@ mod status;
 
 pub(crate) use interactions::handle_agent_approve_hook;
 use interactions::{handle_agent_interactions_answer, handle_agent_interactions_list, handle_agent_interactions_show};
+pub(crate) use profiles::{
+    agent_get_application, agent_list_application, agent_memory_append_application, agent_memory_clear_application,
+    agent_memory_get_application, agent_message_list_application, agent_message_send_application,
+};
 use profiles::{
     handle_agent_get, handle_agent_list, handle_agent_memory_append, handle_agent_memory_clear,
     handle_agent_memory_get, handle_agent_message_list, handle_agent_message_send,

--- a/crates/orchestrator-cli/src/services/runtime/runtime_agent/profiles.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_agent/profiles.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use orchestrator_core::agent_runtime_config::AgentProfile;
 use orchestrator_daemon_runtime::DaemonEventLog;
 use serde_json::{json, Value};
@@ -11,14 +11,19 @@ use crate::{
 };
 
 fn ensure_agent_exists(project_root: &str, agent_id: &str) -> Result<()> {
-    load_agent_profile(project_root, agent_id).map(|_| ())
+    load_agent_profile(project_root, agent_id, None).map(|_| ())
 }
 
-fn load_agent_profile(project_root: &str, agent_id: &str) -> Result<AgentProfile> {
-    let config =
-        orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata(Path::new(project_root))?
-            .config;
-    config.agent_profile(agent_id).cloned().ok_or_else(|| anyhow!("unknown agent profile '{}'", agent_id))
+fn load_agent_profile(project_root: &str, agent_id: &str, actor: Option<&animus_actor::Actor>) -> Result<AgentProfile> {
+    let config = orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata_for_actor(
+        Path::new(project_root),
+        actor,
+    )?
+    .config;
+    config
+        .agent_profile(agent_id)
+        .cloned()
+        .ok_or_else(|| crate::not_found_error(format!("unknown agent profile '{agent_id}'")))
 }
 
 // Best-effort observability tee into the daemon event log, mirroring
@@ -37,9 +42,11 @@ pub(crate) fn emit_agent_coordination_event(event_type: &str, project_root: &str
     let _ = DaemonEventLog::append(&event);
 }
 
-pub(super) fn handle_agent_list(project_root: &str, json_output: bool) -> Result<()> {
-    let loaded =
-        orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata(Path::new(project_root))?;
+pub(crate) fn agent_list_application(project_root: &str, actor: Option<&animus_actor::Actor>) -> Result<Value> {
+    let loaded = orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata_for_actor(
+        Path::new(project_root),
+        actor,
+    )?;
     let agents = loaded
         .config
         .agents
@@ -59,161 +66,139 @@ pub(super) fn handle_agent_list(project_root: &str, json_output: bool) -> Result
         })
         .collect::<Vec<_>>();
 
-    if !json_output {
-        if agents.is_empty() {
-            println!("No agent profiles configured.");
-            return Ok(());
-        }
-        let rows: Vec<Vec<String>> = loaded
-            .config
-            .agents
-            .iter()
-            .map(|(id, profile)| {
-                vec![
-                    id.clone(),
-                    profile.name.clone().unwrap_or_else(|| "--".to_string()),
-                    profile.model.clone().unwrap_or_else(|| "--".to_string()),
-                    profile.tool.clone().unwrap_or_else(|| "--".to_string()),
-                    profile.role.clone().unwrap_or_else(|| "--".to_string()),
-                ]
-            })
-            .collect();
-        render_table(&["ID", "NAME", "MODEL", "TOOL", "ROLE"], &rows);
-        return Ok(());
-    }
-
-    print_value(
-        json!({
-            "source": loaded.metadata.source,
-            "path": loaded.path.display().to_string(),
-            "agents": agents,
-        }),
-        json_output,
-    )
+    Ok(json!({
+        "source": loaded.metadata.source,
+        "path": loaded.path.display().to_string(),
+        "agents": agents,
+    }))
 }
 
-pub(super) fn handle_agent_get(args: AgentGetArgs, project_root: &str, json_output: bool) -> Result<()> {
-    let loaded =
-        orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata(Path::new(project_root))?;
-    let Some(profile) = loaded.config.agent_profile(&args.id) else {
-        return Err(anyhow!("unknown agent profile '{}'", args.id));
-    };
-    print_value(json!({ "id": args.id, "profile": profile }), json_output)
-}
-
-pub(super) fn handle_agent_memory_get(args: AgentMemoryGetArgs, project_root: &str, json_output: bool) -> Result<()> {
-    ensure_agent_exists(project_root, &args.agent)?;
-    let memory = animus_runtime_shared::load_agent_memory(project_root, &args.agent)?;
-    print_value(memory, json_output)
-}
-
-pub(super) fn handle_agent_memory_append(
-    args: AgentMemoryAppendArgs,
+pub(crate) fn agent_get_application(
     project_root: &str,
-    json_output: bool,
-) -> Result<()> {
-    let profile = load_agent_profile(project_root, &args.agent)?;
+    agent_id: &str,
+    actor: Option<&animus_actor::Actor>,
+) -> Result<Value> {
+    let profile = load_agent_profile(project_root, agent_id, actor)?;
+    Ok(json!({ "id": agent_id, "profile": profile }))
+}
+
+pub(crate) fn agent_memory_get_application(project_root: &str, agent_id: &str) -> Result<Value> {
+    ensure_agent_exists(project_root, agent_id)?;
+    Ok(serde_json::to_value(animus_runtime_shared::load_agent_memory(project_root, agent_id)?)?)
+}
+
+pub(crate) fn agent_memory_append_application(
+    project_root: &str,
+    agent_id: &str,
+    text: &str,
+    source: Option<&str>,
+) -> Result<Value> {
+    let profile = load_agent_profile(project_root, agent_id, None)?;
     let memory = animus_runtime_shared::append_agent_memory_capped(
         project_root,
-        &args.agent,
-        &args.text,
-        args.source.as_deref(),
+        agent_id,
+        text,
+        source,
         profile.memory.max_entries,
     )?;
     emit_agent_coordination_event(
         "agent-memory-updated",
         project_root,
         json!({
-            "agent_id": args.agent,
+            "agent_id": agent_id,
             "operation": "append",
             "entry_count": memory.entries.len(),
         }),
     );
-    print_value(memory, json_output)
+    Ok(serde_json::to_value(memory)?)
 }
 
-pub(super) fn handle_agent_memory_clear(
-    args: AgentMemoryClearArgs,
-    project_root: &str,
-    json_output: bool,
-) -> Result<()> {
-    ensure_agent_exists(project_root, &args.agent)?;
-    let memory = animus_runtime_shared::clear_agent_memory(project_root, &args.agent)?;
+pub(crate) fn agent_memory_clear_application(project_root: &str, agent_id: &str) -> Result<Value> {
+    ensure_agent_exists(project_root, agent_id)?;
+    let memory = animus_runtime_shared::clear_agent_memory(project_root, agent_id)?;
     emit_agent_coordination_event(
         "agent-memory-updated",
         project_root,
         json!({
-            "agent_id": args.agent,
+            "agent_id": agent_id,
             "operation": "clear",
             "entry_count": memory.entries.len(),
         }),
     );
-    print_value(memory, json_output)
+    Ok(serde_json::to_value(memory)?)
 }
 
-pub(super) fn handle_agent_message_list(
-    args: AgentMessageListArgs,
+pub(crate) fn agent_message_list_application(
     project_root: &str,
-    json_output: bool,
-) -> Result<()> {
-    if let Some(agent) = args.agent.as_deref() {
-        ensure_agent_exists(project_root, agent)?;
+    channel: Option<&str>,
+    agent_id: Option<&str>,
+    limit: Option<usize>,
+) -> Result<Value> {
+    if let Some(agent_id) = agent_id {
+        ensure_agent_exists(project_root, agent_id)?;
     }
-    let messages = animus_runtime_shared::list_agent_messages(
-        project_root,
-        args.channel.as_deref(),
-        args.agent.as_deref(),
-        args.limit,
-    )?;
-    print_value(json!({ "messages": messages }), json_output)
+    let messages = animus_runtime_shared::list_agent_messages(project_root, channel, agent_id, limit)?;
+    Ok(json!({ "messages": messages }))
 }
 
-pub(super) fn handle_agent_message_send(
-    args: AgentMessageSendArgs,
+pub(crate) fn agent_message_send_application(
     project_root: &str,
-    json_output: bool,
-) -> Result<()> {
+    channel_id: &str,
+    from_agent: &str,
+    to_agent: Option<&str>,
+    text: &str,
+    workflow_id: Option<&str>,
+    phase_id: Option<&str>,
+) -> Result<Value> {
     let runtime =
         orchestrator_core::agent_runtime_config::load_agent_runtime_config_with_metadata(Path::new(project_root))?
             .config;
     let workflow = orchestrator_core::load_workflow_config_or_default(Path::new(project_root)).config;
-    let Some(sender) = runtime.agent_profile(&args.from) else {
-        return Err(anyhow!("unknown sender agent profile '{}'", args.from));
+    let Some(sender) = runtime.agent_profile(from_agent) else {
+        return Err(crate::not_found_error(format!("unknown sender agent profile '{from_agent}'")));
     };
-    let Some(channel) = workflow.agent_channels.get(&args.channel) else {
-        return Err(anyhow!("unknown agent channel '{}'", args.channel));
+    let Some(channel) = workflow.agent_channels.get(channel_id) else {
+        return Err(crate::not_found_error(format!("unknown agent channel '{channel_id}'")));
     };
     if !sender.communication.enabled {
-        return Err(anyhow!("agent '{}' communication is not enabled", args.from));
+        return Err(crate::invalid_input_error(format!("agent '{from_agent}' communication is not enabled")));
     }
-    if !sender.communication.channels.iter().any(|channel| channel.eq_ignore_ascii_case(&args.channel)) {
-        return Err(anyhow!("agent '{}' is not configured for channel '{}'", args.from, args.channel));
+    if !sender.communication.channels.iter().any(|channel| channel.eq_ignore_ascii_case(channel_id)) {
+        return Err(crate::invalid_input_error(format!(
+            "agent '{from_agent}' is not configured for channel '{channel_id}'"
+        )));
     }
-    if !channel.participants.iter().any(|agent| agent.eq_ignore_ascii_case(&args.from)) {
-        return Err(anyhow!("agent '{}' is not a participant in channel '{}'", args.from, args.channel));
+    if !channel.participants.iter().any(|agent| agent.eq_ignore_ascii_case(from_agent)) {
+        return Err(crate::invalid_input_error(format!(
+            "agent '{from_agent}' is not a participant in channel '{channel_id}'"
+        )));
     }
-    if let Some(target) = args.to.as_deref() {
+    if let Some(target) = to_agent {
         if runtime.agent_profile(target).is_none() {
-            return Err(anyhow!("unknown recipient agent profile '{}'", target));
+            return Err(crate::not_found_error(format!("unknown recipient agent profile '{target}'")));
         }
         if !channel.participants.iter().any(|agent| agent.eq_ignore_ascii_case(target)) {
-            return Err(anyhow!("agent '{}' is not a participant in channel '{}'", target, args.channel));
+            return Err(crate::invalid_input_error(format!(
+                "agent '{target}' is not a participant in channel '{channel_id}'"
+            )));
         }
         if !sender.communication.can_message.is_empty()
             && !sender.communication.can_message.iter().any(|agent| agent.eq_ignore_ascii_case(target))
         {
-            return Err(anyhow!("agent '{}' is not allowed to message '{}'", args.from, target));
+            return Err(crate::invalid_input_error(format!(
+                "agent '{from_agent}' is not allowed to message '{target}'"
+            )));
         }
     }
 
     let message = animus_runtime_shared::send_agent_message(
         project_root,
-        &args.channel,
-        &args.from,
-        args.to.as_deref(),
-        &args.text,
-        args.workflow_id.as_deref(),
-        args.phase_id.as_deref(),
+        channel_id,
+        from_agent,
+        to_agent,
+        text,
+        workflow_id,
+        phase_id,
     )?;
     emit_agent_coordination_event(
         "agent-message-sent",
@@ -227,5 +212,90 @@ pub(super) fn handle_agent_message_send(
             "phase_id": message.phase_id,
         }),
     );
-    print_value(message, json_output)
+    Ok(serde_json::to_value(message)?)
+}
+
+pub(super) fn handle_agent_list(project_root: &str, json_output: bool) -> Result<()> {
+    let payload = agent_list_application(project_root, None)?;
+    let agents = payload.get("agents").and_then(Value::as_array).cloned().unwrap_or_default();
+
+    if !json_output {
+        if agents.is_empty() {
+            println!("No agent profiles configured.");
+            return Ok(());
+        }
+        let rows: Vec<Vec<String>> = agents
+            .iter()
+            .map(|agent| {
+                vec![
+                    agent.get("id").and_then(Value::as_str).unwrap_or("--").to_string(),
+                    agent.get("name").and_then(Value::as_str).unwrap_or("--").to_string(),
+                    agent.get("model").and_then(Value::as_str).unwrap_or("--").to_string(),
+                    agent.get("tool").and_then(Value::as_str).unwrap_or("--").to_string(),
+                    agent.get("role").and_then(Value::as_str).unwrap_or("--").to_string(),
+                ]
+            })
+            .collect();
+        render_table(&["ID", "NAME", "MODEL", "TOOL", "ROLE"], &rows);
+        return Ok(());
+    }
+
+    print_value(payload, json_output)
+}
+
+pub(super) fn handle_agent_get(args: AgentGetArgs, project_root: &str, json_output: bool) -> Result<()> {
+    print_value(agent_get_application(project_root, &args.id, None)?, json_output)
+}
+
+pub(super) fn handle_agent_memory_get(args: AgentMemoryGetArgs, project_root: &str, json_output: bool) -> Result<()> {
+    print_value(agent_memory_get_application(project_root, &args.agent)?, json_output)
+}
+
+pub(super) fn handle_agent_memory_append(
+    args: AgentMemoryAppendArgs,
+    project_root: &str,
+    json_output: bool,
+) -> Result<()> {
+    print_value(
+        agent_memory_append_application(project_root, &args.agent, &args.text, args.source.as_deref())?,
+        json_output,
+    )
+}
+
+pub(super) fn handle_agent_memory_clear(
+    args: AgentMemoryClearArgs,
+    project_root: &str,
+    json_output: bool,
+) -> Result<()> {
+    print_value(agent_memory_clear_application(project_root, &args.agent)?, json_output)
+}
+
+pub(super) fn handle_agent_message_list(
+    args: AgentMessageListArgs,
+    project_root: &str,
+    json_output: bool,
+) -> Result<()> {
+    print_value(
+        agent_message_list_application(project_root, args.channel.as_deref(), args.agent.as_deref(), args.limit)?,
+        json_output,
+    )
+}
+
+pub(super) fn handle_agent_message_send(
+    args: AgentMessageSendArgs,
+    project_root: &str,
+    json_output: bool,
+) -> Result<()> {
+    print_value(
+        agent_message_send_application(
+            project_root,
+            &args.channel,
+            &args.from,
+            args.to.as_deref(),
+            &args.text,
+            args.workflow_id.as_deref(),
+            args.phase_id.as_deref(),
+        )?,
+        json_output,
+    )
 }

--- a/docs/architecture/actor-bound-application-contract.md
+++ b/docs/architecture/actor-bound-application-contract.md
@@ -63,6 +63,8 @@ The actor-bound tool router currently exposes exactly:
 - `animus.subject.batch-update`
 - `animus.subject.next`
 - `animus.subject.status`
+- `animus.agent.list`
+- `animus.agent.get`
 - `animus.agent.ask`
 - `animus.agent.request_approval`
 - `animus.interactions.list`
@@ -73,6 +75,9 @@ The actor-bound tool router currently exposes exactly:
 MCP resources are unavailable on an actor-bound server because the resource
 protocol has no actor carrier. Each MCP invocation emits an
 `mcp_tool_invocation` audit record attributed to the pinned user and tenant.
+Agent roster list/get derive their effective profiles from the pinned actor's
+config-source partition; there is no fallback to the global roster when an
+actor-specific base exists.
 
 ## Direct application reads
 
@@ -187,6 +192,11 @@ These surfaces remain absent from actor-bound MCP until their protocols change:
 - Queue list/control/mutation: queue requests need actor filters and
   authorization context, and the queue/subject dispatch bridge must preserve
   the current `Actor`.
+- Agent memory/message operations: their project stores are currently keyed by
+  agent/project rather than actor, so they remain management-only even though
+  their MCP implementations are typed in-process services. Agent
+  run/control/status also remain outside the actor-bound surface until the
+  execution protocol enforces the pinned principal end to end.
 - MCP resources: list/read resource requests need the same typed actor/request
   context and backend enforcement.
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -1,7 +1,9 @@
 # Working with Animus via MCP Tools
 
 This guide explains the current MCP surface exposed by `animus mcp serve`.
-Each built-in tool maps to an `animus` CLI command and accepts JSON input.
+Each built-in tool accepts JSON input. Typed application-service tools execute
+in process; remaining compatibility tools may still delegate to an `animus`
+CLI command.
 
 For the full parameter table, see [MCP Tools Reference](../reference/mcp-tools.md).
 
@@ -47,14 +49,16 @@ startup rather than falling back to global scope. The actor-bound router exposes
 only paths that enforce the pin: workflow run/list/get/control/execute,
 decisions/checkpoints/manual-phase and config reads, workflow output reads,
 subject list/get/create/update/batch-create/batch-update/next/status,
-interaction creation/management, and tool discovery. A child command cannot
-override the server actor. Workflow controls authorize the persisted owner
-before mutation and lifecycle continuations retain that owner when launching a
-runner.
+interaction creation/management, actor roster list/get, and tool discovery. A
+child command cannot override the server actor. Agent roster reads load the
+pinned user's config-source partition. Workflow controls authorize the
+persisted owner before mutation and lifecycle continuations retain that owner
+when launching a runner.
 
-Queue operations, config writes, and other global tools are absent from an
-actor-bound server. Their pinned protocols cannot yet enforce the same
-authenticated actor, so exposing them would create an identity downgrade.
+Queue operations, config writes, agent memory/messaging/execution, and other
+global tools are absent from an actor-bound server. Their pinned protocols or
+stores cannot yet enforce the same authenticated actor, so exposing them would
+create an identity downgrade.
 Actor-bound subject calls use the v2 subject protocol and never fall back to
 legacy v1 methods.
 See [Actor-bound application contract](../architecture/actor-bound-application-contract.md).

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -29,9 +29,11 @@ every route whose command/protocol cannot enforce it. The retained surface is
 workflow run/list/get/control/execute/decisions/checkpoints/manual-phase and
 config-read operations, workflow output reads, subject
 list/get/create/update/batch-create/batch-update/next/status, interaction
-creation/management, and tool discovery. Queue operations, config writes,
-resources, and other global routes are deliberately unavailable rather than
-silently downgraded. Actor-bound workflow controls conceal unowned ids before
+creation/management, actor roster list/get, and tool discovery. Queue
+operations, config writes, agent memory/messaging/execution, resources, and
+other global routes are deliberately unavailable rather than silently
+downgraded. Actor-bound agent roster reads derive profiles from the pinned
+user's config-source partition. Actor-bound workflow controls conceal unowned ids before
 performing confirmation or mutation, and actor-bound subject calls use the v2
 subject protocol without falling back to legacy v1 methods. See
 [Actor-bound application contract](../architecture/actor-bound-application-contract.md).
@@ -89,6 +91,13 @@ pre-v0.4 resource names can still enumerate and read the same data.
 | `animus.agent.message.list` | List project-scoped agent messages | `channel`, `agent`, `limit`, `project_root` |
 | `animus.agent.ask` | Ask a human one or more questions and wait for the answer. Two forms: (1) flat single question — `question` + optional `options[]`, returns `{ id, answer, answered_by }`; (2) structured `questions[]` (multi-question / multi-select / described options — gives codex/gemini/opencode parity with claude's native AskUserQuestion channel), each entry `{ question, header?, options:[{ label, description? }], multi_select? }`, returns `{ id, answers: { <question>: <label \| [labels] \| text> }, response?, answer }` where `answer` is a readable join for back-compat. Block mode parks until answered or timed out (structured timeout error tells the agent to proceed with its best judgment); suspend mode returns `{ status: "pending", interaction_id, instruction }` immediately and pauses the bound workflow | `agent_id`, `question`, `options[]`, `questions[]`, `timeout_secs` (default 600, max 3600), `workflow_id`, `task_id`, `wait` (`block` \| `suspend`) |
 | `animus.agent.request_approval` | Request human approval for a sensitive action and wait for the decision; the agent profile's `approval_policy` can auto-allow/auto-deny without escalating (`default: allow` approves everything, `deny` rejects, `llm` auto-approves via a judge model that reads the tool call and returns allow/deny recorded with `source: "llm"`, falling back to manual escalation on any evaluator failure), and a block-mode timeout denies (fail closed). Doubles as the claude CLI's `--permission-prompt-tool`: invoked with `{ tool_name, input, tool_use_id }` it answers with the SDK permission payload in the result text — `{ behavior: "allow", updatedInput: <original or modified input>, updatedPermissions? }` or `{ behavior: "deny", message }` — with the legacy `{ tool, result: { decision, source, … } }` envelope alongside. `tool_name: "AskUserQuestion"` becomes a structured Question record (bypasses the approval policy) whose allow answer carries `updatedInput { questions, answers, response? }`. Suspend mode pauses the bound workflow: voluntary calls get the pending payload; native prompt-tool calls get `behavior: "deny"` with the end-your-turn instruction (the session resumes with the answer as feedback) | `agent_id`, `action` (derived from `tool_name` when omitted), `tool_name`, `input` \| `arguments`, `tool_use_id`, `suggestions`, `timeout_secs` (default 600, max 3600), `workflow_id`, `task_id`, `wait` (`block` \| `suspend`) |
+
+Agent list/get and the memory/message wrappers execute through typed in-process
+application services. On an actor-bound server, list/get resolve the pinned
+actor's config-source partition and are the only profile/coordination tools
+retained. Memory and message stores are not actor-partitioned, while
+run/control/status still use the compatibility execution boundary, so those
+routes remain management-only.
 
 Unlike most tools on this server, the two blocking escalation tools accept no
 `project_root` override — they always operate on the server's own project


### PR DESCRIPTION
## Summary

- route agent roster, memory, and messaging MCP tools through typed in-process application services
- expose `animus.agent.list` and `animus.agent.get` safely on actor-bound Portal servers
- load each signed-in user's roster from that actor's config-source partition while keeping unpartitioned memory, messaging, and execution surfaces management-only
- document the ownership boundary and add typed error/isolation coverage

## Verification

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p orchestrator-cli --tests`
- `cargo test -p orchestrator-cli agent_inproc::tests --locked -- --test-threads=1` (4 passed)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p orchestrator-cli --locked -- --test-threads=1` (1,435 unit tests plus all integration targets passed)
- `cargo animus-lint`

Tracks TASK-971.