### PR TITLE
refactor(mcp): route output reads through services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -71,6 +71,8 @@ mod logs_tools;
 mod memory_tools;
 #[path = "ops_mcp/output.rs"]
 mod output;
+#[path = "ops_mcp/output_inproc.rs"]
+mod output_inproc;
 #[path = "ops_mcp/output_inputs.rs"]
 mod output_inputs;
 #[path = "ops_mcp/output_tail_events.rs"]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/output_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/output_inproc.rs
@@ -1,0 +1,191 @@
+use super::daemon_inproc::resolve_project_root;
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::AoMcpServer;
+use crate::services::operations::{
+    output_artifacts_application, output_jsonl_application, output_monitor_application,
+    output_phase_outputs_application, output_read_application,
+};
+use anyhow::Result;
+use rmcp::model::CallToolResult;
+use serde::Serialize;
+use serde_json::json;
+
+impl AoMcpServer {
+    fn run_output_application<T, F>(
+        &self,
+        tool_name: &str,
+        project_root: Option<String>,
+        actor_bound: bool,
+        call: F,
+    ) -> CallToolResult
+    where
+        T: Serialize,
+        F: FnOnce(&str, Option<&animus_actor::Actor>) -> Result<T>,
+    {
+        self.audit_actor_tool_decision(tool_name, actor_bound, if actor_bound { "forward" } else { "management-only" });
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        match call(&project_root, self.pinned_actor()) {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)),
+        }
+    }
+
+    pub(super) fn output_run_inproc(&self, input: super::RunIdInput) -> CallToolResult {
+        self.run_output_application("animus.output.run", input.project_root, true, |root, actor| {
+            output_read_application(root, Some(&input.run_id), None, None, actor)
+        })
+    }
+
+    pub(super) fn output_phase_outputs_inproc(&self, input: super::OutputPhaseOutputsInput) -> CallToolResult {
+        self.run_output_application("animus.output.phase-outputs", input.project_root, true, |root, actor| {
+            output_phase_outputs_application(root, &input.workflow_id, input.phase_id.as_deref(), actor)
+        })
+    }
+
+    pub(super) fn output_monitor_inproc(&self, input: super::OutputMonitorInput) -> CallToolResult {
+        self.run_output_application("animus.output.monitor", input.project_root, false, |root, _actor| {
+            output_monitor_application(root, &input.run_id, input.task_id.as_deref(), input.phase_id.as_deref())
+        })
+    }
+
+    pub(super) fn output_jsonl_inproc(&self, input: super::OutputJsonlInput) -> CallToolResult {
+        self.run_output_application("animus.output.jsonl", input.project_root, false, |root, _actor| {
+            output_jsonl_application(root, &input.run_id, input.entries)
+        })
+    }
+
+    pub(super) fn output_artifacts_inproc(&self, input: super::ExecutionIdInput) -> CallToolResult {
+        self.run_output_application("animus.output.artifacts", input.project_root, false, |root, _actor| {
+            output_artifacts_application(root, &input.execution_id)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use protocol::test_utils::EnvVarGuard;
+    use protocol::RunId;
+    use serde_json::Value;
+
+    #[test]
+    fn output_read_is_in_process_and_conceals_cross_actor_runs() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project root");
+        let alice = animus_actor::Actor {
+            user_id: "alice".to_string(),
+            claims: Vec::new(),
+            tenant_id: Some("workspace-a".to_string()),
+        };
+        let bob = animus_actor::Actor {
+            user_id: "bob".to_string(),
+            claims: Vec::new(),
+            tenant_id: Some("workspace-a".to_string()),
+        };
+        let workflow_id = "wf-owned";
+        let manager = orchestrator_core::WorkflowStateManager::new(&project_root);
+        let workflow = protocol::orchestrator::OrchestratorWorkflow {
+            id: workflow_id.to_string(),
+            task_id: "TASK-971".to_string(),
+            workflow_ref: Some("standard".to_string()),
+            subject: None,
+            input: None,
+            vars: std::collections::HashMap::new(),
+            status: protocol::orchestrator::WorkflowStatus::Running,
+            current_phase_index: 0,
+            phases: Vec::new(),
+            machine_state: Default::default(),
+            current_phase: None,
+            started_at: chrono::Utc::now(),
+            completed_at: None,
+            failure_reason: None,
+            checkpoint_metadata: Default::default(),
+            rework_counts: std::collections::HashMap::new(),
+            total_reworks: 0,
+            decision_history: Vec::new(),
+        };
+        manager.save(&workflow).expect("persist workflow");
+        manager.set_workflow_actor(workflow_id, Some(&alice)).expect("persist workflow owner");
+        let run_dir = crate::run_dir(project_root.to_string_lossy().as_ref(), &RunId(workflow_id.to_string()), None);
+        std::fs::create_dir_all(&run_dir).expect("run dir");
+        std::fs::write(run_dir.join("events.jsonl"), "{\"type\":\"assistant\",\"text\":\"ready\"}\n").expect("events");
+        let phase_dir =
+            animus_runtime_shared::phase_output::phase_output_dir(project_root.to_string_lossy().as_ref(), workflow_id);
+        std::fs::create_dir_all(&phase_dir).expect("phase output dir");
+        std::fs::write(
+            phase_dir.join("build.json"),
+            "{\"phase_id\":\"build\",\"completed_at\":\"2026-07-29T00:00:00Z\",\"verdict\":\"advance\"}",
+        )
+        .expect("phase output");
+
+        let root = project_root.to_string_lossy();
+        let alice_server = super::super::new_ao_mcp_server_with_options(root.as_ref(), false, None, None, Some(alice));
+        let bob_server = super::super::new_ao_mcp_server_with_options(root.as_ref(), false, None, None, Some(bob));
+        let input = || super::super::RunIdInput { run_id: workflow_id.to_string(), project_root: None };
+
+        let allowed = alice_server.output_run_inproc(input());
+        let allowed_is_error = allowed.is_error;
+        let payload = allowed.structured_content.expect("owned output");
+        assert_ne!(allowed_is_error, Some(true), "{payload}");
+        assert_eq!(payload.pointer("/result/0/text").and_then(Value::as_str), Some("ready"), "{payload}");
+
+        let denied = bob_server.output_run_inproc(input());
+        assert_eq!(denied.is_error, Some(true));
+        let payload = denied.structured_content.expect("concealed output");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"), "{payload}");
+
+        let phase_input = || super::super::OutputPhaseOutputsInput {
+            workflow_id: workflow_id.to_string(),
+            phase_id: Some("build".to_string()),
+            project_root: None,
+        };
+        let allowed = alice_server.output_phase_outputs_inproc(phase_input());
+        let allowed_is_error = allowed.is_error;
+        let payload = allowed.structured_content.expect("owned phase output");
+        assert_ne!(allowed_is_error, Some(true), "{payload}");
+        assert_eq!(payload.pointer("/result/outputs/0/verdict").and_then(Value::as_str), Some("advance"));
+
+        let denied = bob_server.output_phase_outputs_inproc(phase_input());
+        assert_eq!(denied.is_error, Some(true));
+        let payload = denied.structured_content.expect("concealed phase output");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"), "{payload}");
+    }
+
+    #[test]
+    fn jsonl_and_monitor_share_typed_run_entries_without_a_child_cli() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project root");
+        let run_id = "run-output";
+        let run_dir = crate::run_dir(project_root.to_string_lossy().as_ref(), &RunId(run_id.to_string()), None);
+        std::fs::create_dir_all(&run_dir).expect("run dir");
+        std::fs::write(
+            run_dir.join("stdout.jsonl"),
+            "{\"task_id\":\"TASK-971\",\"phase_id\":\"build\",\"text\":\"keep\"}\n{\"task_id\":\"OTHER\",\"phase_id\":\"build\",\"text\":\"drop\"}\n",
+        )
+        .expect("stdout events");
+        let server = super::super::new_ao_mcp_server(project_root.to_string_lossy().as_ref());
+
+        let jsonl = server.output_jsonl_inproc(super::super::OutputJsonlInput {
+            run_id: run_id.to_string(),
+            entries: true,
+            project_root: None,
+        });
+        let payload = jsonl.structured_content.expect("jsonl output");
+        assert_eq!(payload.pointer("/result/0/source_file").and_then(Value::as_str), Some("stdout.jsonl"));
+
+        let monitor = server.output_monitor_inproc(super::super::OutputMonitorInput {
+            run_id: run_id.to_string(),
+            task_id: Some("TASK-971".to_string()),
+            phase_id: Some("build".to_string()),
+            project_root: None,
+        });
+        let payload = monitor.structured_content.expect("monitor output");
+        assert_eq!(payload.pointer("/result/0/text").and_then(Value::as_str), Some("keep"));
+        assert_eq!(payload.pointer("/result").and_then(Value::as_array).map(Vec::len), Some(1));
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/output_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/output_tools.rs
@@ -8,9 +8,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<RunIdInput>()
     )]
     async fn ao_output_run(&self, params: Parameters<RunIdInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = vec!["output".to_string(), "read".to_string(), "--run-id".to_string(), input.run_id];
-        self.run_tool("animus.output.run", args, input.project_root).await
+        Ok(self.output_run_inproc(params.0))
     }
 
     #[tool(
@@ -22,24 +20,16 @@ impl AoMcpServer {
         &self,
         params: Parameters<OutputPhaseOutputsInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args =
-            vec!["output".to_string(), "phase-outputs".to_string(), "--workflow-id".to_string(), input.workflow_id];
-        push_opt(&mut args, "--phase-id", input.phase_id);
-        self.run_tool("animus.output.phase-outputs", args, input.project_root).await
+        Ok(self.output_phase_outputs_inproc(params.0))
     }
 
     #[tool(
         name = "animus.output.monitor",
-        description = "Monitor output for a run, optionally scoped to a task or phase. Purpose: Stream real-time output from running agents. Prerequisites: Run must exist. Example: {\"run_id\": \"abc123\"} or {\"run_id\": \"abc123\", \"task_id\": \"TASK-001\", \"phase_id\": \"implementation\"}. Sequencing: Use after animus.agent.run or animus.workflow.run to monitor progress.",
+        description = "Monitor output for a run, optionally scoped to a task or phase. Purpose: Inspect the currently persisted output from running agents as a bounded snapshot. Prerequisites: Run must exist. Example: {\"run_id\": \"abc123\"} or {\"run_id\": \"abc123\", \"task_id\": \"TASK-001\", \"phase_id\": \"implementation\"}. Sequencing: Use after animus.agent.run or animus.workflow.run to monitor progress.",
         input_schema = ao_schema_for_type::<OutputMonitorInput>()
     )]
     async fn ao_output_monitor(&self, params: Parameters<OutputMonitorInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec!["output".to_string(), "monitor".to_string(), "--run-id".to_string(), input.run_id];
-        push_opt(&mut args, "--task-id", input.task_id);
-        push_opt(&mut args, "--phase-id", input.phase_id);
-        self.run_tool("animus.output.monitor", args, input.project_root).await
+        Ok(self.output_monitor_inproc(params.0))
     }
 
     #[tool(
@@ -66,12 +56,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<OutputJsonlInput>()
     )]
     async fn ao_output_jsonl(&self, params: Parameters<OutputJsonlInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let mut args = vec!["output".to_string(), "jsonl".to_string(), "--run-id".to_string(), input.run_id];
-        if input.entries {
-            args.push("--entries".to_string());
-        }
-        self.run_tool("animus.output.jsonl", args, input.project_root).await
+        Ok(self.output_jsonl_inproc(params.0))
     }
 
     #[tool(
@@ -80,9 +65,6 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ExecutionIdInput>()
     )]
     async fn ao_output_artifacts(&self, params: Parameters<ExecutionIdInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args =
-            vec!["output".to_string(), "artifacts".to_string(), "--execution-id".to_string(), input.execution_id];
-        self.run_tool("animus.output.artifacts", args, input.project_root).await
+        Ok(self.output_artifacts_inproc(params.0))
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_output.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_output.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct ArtifactInfoCli {
+pub(crate) struct ArtifactInfoCli {
     artifact_id: String,
     artifact_type: String,
     #[serde(default)]
@@ -26,6 +26,13 @@ pub(crate) struct RunJsonlEntryCli {
     pub(crate) line: String,
     #[serde(default)]
     pub(crate) timestamp_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct OutputPhaseOutputsResult {
+    pub(crate) workflow_id: String,
+    pub(crate) phase_id: Option<String>,
+    pub(crate) outputs: Vec<PersistedPhaseOutput>,
 }
 
 fn run_dir_candidates(project_root: &str, run_id: &str) -> Vec<PathBuf> {
@@ -317,6 +324,82 @@ fn ensure_safe_workflow_id(workflow_id: &str) -> Result<()> {
     ensure_safe_id_segment("workflow id", workflow_id)
 }
 
+pub(crate) fn output_read_application(
+    project_root: &str,
+    run_id: Option<&str>,
+    workflow_id: Option<&str>,
+    phase: Option<&str>,
+    actor: Option<&animus_actor::Actor>,
+) -> Result<Vec<Value>> {
+    ensure_output_actor_access(project_root, workflow_id, run_id, actor)?;
+    let resolved_run_id = match (phase, workflow_id) {
+        (Some(phase), Some(workflow_id)) => resolve_run_id_for_workflow_phase(project_root, workflow_id, phase)?,
+        _ => resolve_run_id_arg(project_root, run_id.map(str::to_string), workflow_id.map(str::to_string))?,
+    };
+    let run_dir = resolve_run_dir_for_lookup(project_root, &resolved_run_id)?
+        .ok_or_else(|| not_found_error(format!("run directory not found for {resolved_run_id}")))?;
+    let events_path = run_dir.join("events.jsonl");
+    if !events_path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(events_path)?;
+    Ok(content.lines().filter_map(|line| serde_json::from_str::<Value>(line).ok()).collect())
+}
+
+pub(crate) fn output_phase_outputs_application(
+    project_root: &str,
+    workflow_id: &str,
+    phase_id: Option<&str>,
+    actor: Option<&animus_actor::Actor>,
+) -> Result<OutputPhaseOutputsResult> {
+    ensure_output_actor_access(project_root, Some(workflow_id), None, actor)?;
+    Ok(OutputPhaseOutputsResult {
+        workflow_id: workflow_id.to_string(),
+        phase_id: phase_id.map(str::to_string),
+        outputs: get_phase_outputs(project_root, workflow_id, phase_id)?,
+    })
+}
+
+pub(crate) fn output_artifacts_application(project_root: &str, execution_id: &str) -> Result<Vec<ArtifactInfoCli>> {
+    list_artifact_infos(project_root, execution_id)
+}
+
+pub(crate) fn output_jsonl_application(project_root: &str, run_id: &str, include_entries: bool) -> Result<Value> {
+    let entries = get_run_jsonl_entries(project_root, run_id)?;
+    if include_entries {
+        Ok(serde_json::to_value(entries)?)
+    } else {
+        Ok(serde_json::to_value(entries.into_iter().map(|entry| entry.line).collect::<Vec<_>>())?)
+    }
+}
+
+pub(crate) fn output_monitor_application(
+    project_root: &str,
+    run_id: &str,
+    task_id: Option<&str>,
+    phase_id: Option<&str>,
+) -> Result<Vec<Value>> {
+    let entries = get_run_jsonl_entries(project_root, run_id)?;
+    let mut events = Vec::new();
+    for entry in entries {
+        let Ok(payload) = serde_json::from_str::<Value>(&entry.line) else {
+            continue;
+        };
+        if let Some(task_id) = task_id {
+            if payload.get("task_id").and_then(Value::as_str) != Some(task_id) {
+                continue;
+            }
+        }
+        if let Some(phase_id) = phase_id {
+            if payload.get("phase_id").and_then(Value::as_str) != Some(phase_id) {
+                continue;
+            }
+        }
+        events.push(payload);
+    }
+    Ok(events)
+}
+
 pub(crate) fn get_phase_outputs(
     project_root: &str,
     workflow_id: &str,
@@ -362,48 +445,38 @@ pub(crate) async fn handle_output(command: OutputCommand, project_root: &str, js
     match command {
         OutputCommand::Read(args) => {
             let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
-            ensure_output_actor_access(
-                project_root,
-                args.workflow_id.as_deref(),
-                args.run_id.as_deref(),
-                actor.as_ref(),
-            )?;
-            let run_id = match (&args.phase, &args.workflow_id) {
-                (Some(phase), Some(workflow_id)) => {
-                    resolve_run_id_for_workflow_phase(project_root, workflow_id, phase)?
-                }
-                _ => resolve_run_id_arg(project_root, args.run_id, args.workflow_id)?,
-            };
-            let run_dir = resolve_run_dir_for_lookup(project_root, &run_id)?
-                .ok_or_else(|| not_found_error(format!("run directory not found for {run_id}")))?;
-            let events_path = run_dir.join("events.jsonl");
-            if !events_path.exists() {
-                return print_value(Vec::<Value>::new(), json);
-            }
-            let content = fs::read_to_string(events_path)?;
-            let events: Vec<Value> =
-                content.lines().filter_map(|line| serde_json::from_str::<Value>(line).ok()).collect();
-            print_value(events, json)
+            print_value(
+                output_read_application(
+                    project_root,
+                    args.run_id.as_deref(),
+                    args.workflow_id.as_deref(),
+                    args.phase.as_deref(),
+                    actor.as_ref(),
+                )?,
+                json,
+            )
         }
         OutputCommand::PhaseOutputs(args) => {
             let actor = crate::shared::parse_actor_json_flag(args.actor_json.as_deref())?;
-            ensure_output_actor_access(project_root, Some(&args.workflow_id), None, actor.as_ref())?;
-            let outputs = get_phase_outputs(project_root, &args.workflow_id, args.phase_id.as_deref())?;
+            let result = output_phase_outputs_application(
+                project_root,
+                &args.workflow_id,
+                args.phase_id.as_deref(),
+                actor.as_ref(),
+            )?;
             if json {
-                print_value(
-                    serde_json::json!({
-                        "workflow_id": args.workflow_id,
-                        "phase_id": args.phase_id,
-                        "outputs": outputs,
-                    }),
-                    json,
-                )
+                print_value(result, json)
             } else {
-                println!("{}", render_phase_outputs_human(&args.workflow_id, args.phase_id.as_deref(), &outputs));
+                println!(
+                    "{}",
+                    render_phase_outputs_human(&result.workflow_id, result.phase_id.as_deref(), &result.outputs)
+                );
                 Ok(())
             }
         }
-        OutputCommand::Artifacts(args) => print_value(list_artifact_infos(project_root, &args.execution_id)?, json),
+        OutputCommand::Artifacts(args) => {
+            print_value(output_artifacts_application(project_root, &args.execution_id)?, json)
+        }
         OutputCommand::Download(args) => {
             ensure_safe_id_segment("execution id", &args.execution_id)?;
             ensure_safe_id_segment("artifact id", &args.artifact_id)?;
@@ -425,35 +498,12 @@ pub(crate) async fn handle_output(command: OutputCommand, project_root: &str, js
             )
         }
         OutputCommand::Jsonl(args) => {
-            let entries = get_run_jsonl_entries(project_root, &args.run_id)?;
-            if args.entries {
-                print_value(entries, json)
-            } else {
-                let lines: Vec<String> = entries.into_iter().map(|entry| entry.line).collect();
-                print_value(lines, json)
-            }
+            print_value(output_jsonl_application(project_root, &args.run_id, args.entries)?, json)
         }
-        OutputCommand::Monitor(args) => {
-            let entries = get_run_jsonl_entries(project_root, &args.run_id)?;
-            let mut events = Vec::new();
-            for entry in entries {
-                let Ok(payload) = serde_json::from_str::<Value>(&entry.line) else {
-                    continue;
-                };
-                if let Some(task_id) = args.task_id.as_deref() {
-                    if payload.get("task_id").and_then(|value| value.as_str()) != Some(task_id) {
-                        continue;
-                    }
-                }
-                if let Some(phase_id) = args.phase_id.as_deref() {
-                    if payload.get("phase_id").and_then(|value| value.as_str()) != Some(phase_id) {
-                        continue;
-                    }
-                }
-                events.push(payload);
-            }
-            print_value(events, json)
-        }
+        OutputCommand::Monitor(args) => print_value(
+            output_monitor_application(project_root, &args.run_id, args.task_id.as_deref(), args.phase_id.as_deref())?,
+            json,
+        ),
         OutputCommand::Cli(args) => {
             let entries = get_run_jsonl_entries(project_root, &args.run_id)?;
             print_value(

--- a/docs/architecture/actor-bound-application-contract.md
+++ b/docs/architecture/actor-bound-application-contract.md
@@ -78,6 +78,10 @@ protocol has no actor carrier. Each MCP invocation emits an
 Agent roster list/get derive their effective profiles from the pinned actor's
 config-source partition; there is no fallback to the global roster when an
 actor-specific base exists.
+Output run and phase-output MCP reads execute in process and resolve the
+persisted workflow owner before touching transcript or phase payload files.
+Cross-user, cross-tenant, unowned, and unknown records share the same
+`not_found` result.
 
 ## Direct application reads
 
@@ -197,6 +201,9 @@ These surfaces remain absent from actor-bound MCP until their protocols change:
   their MCP implementations are typed in-process services. Agent
   run/control/status also remain outside the actor-bound surface until the
   execution protocol enforces the pinned principal end to end.
+- Output monitor/JSONL/artifact reads: these inputs are not yet guaranteed to
+  identify an actor-owned workflow, so they remain management-only even though
+  their MCP handlers now use typed in-process services.
 - MCP resources: list/read resource requests need the same typed actor/request
   context and backend enforcement.
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -249,6 +249,12 @@ Use output tools for run artifacts and structured execution streams. Use
 `animus.logs.tail` for recent daemon-level logs. This MCP tool is a bounded
 pull, not a live follow stream.
 
+Output reads execute through typed in-process services rather than a child CLI.
+Actor-bound application hosts expose run and phase-output reads only; both
+conceal output owned by another user or tenant. JSONL, monitor, and artifact
+reads remain on the management surface because those stores are not yet
+universally attributable to an actor-owned workflow.
+
 ```json
 { "run_id": "run-abc123" }                  // animus.output.run
 { "run_id": "run-abc123", "entries": true } // animus.output.jsonl

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -305,10 +305,18 @@ never auto-dispatches `Ready` tasks from the subject backend.
 |---|---|---|
 | `animus.output.run` | Get stdout/stderr from an agent execution | `run_id`, `project_root` |
 | `animus.output.tail` | Get most recent output/error/thinking events | `run_id`, `task_id`, `event_types[]`, `limit`, `project_root` |
-| `animus.output.monitor` | Stream real-time output from a run, optionally scoped by task or phase | `run_id`, `task_id`, `phase_id`, `project_root` |
+| `animus.output.monitor` | Inspect aggregated output from a run, optionally scoped by task or phase | `run_id`, `task_id`, `phase_id`, `project_root` |
 | `animus.output.jsonl` | Get structured JSONL event log | `run_id`, `entries`, `project_root` |
 | `animus.output.artifacts` | Get files generated during execution | `execution_id`, `project_root` |
 | `animus.output.phase-outputs` | Get persisted workflow phase outputs | `workflow_id`, `phase_id`, `project_root` |
+
+All six output tools execute in process through typed application services
+(`output.tail` already used its bounded local service). On an actor-bound
+server, `output.run` and `output.phase-outputs` authorize the pinned actor
+against the persisted workflow owner before reading any transcript or phase
+payload; unknown and cross-partition ids are both returned as `not_found`.
+Monitor, JSONL, and artifact reads remain management-only until their inputs
+can be resolved to an actor-owned workflow without ambiguity.
 
 ---
 


### PR DESCRIPTION
## Summary

- route run transcripts, persisted phase outputs, monitor snapshots, JSONL entries, and artifact listings through typed in-process application services shared by CLI and MCP
- preserve source metadata, task/phase filtering, artifact safety checks, human phase rendering, and typed MCP errors
- keep `animus.output.run` and `animus.output.phase-outputs` actor-bound with persisted workflow ownership checks
- document why monitor/JSONL/artifact reads remain management-only until every input can be attributed to an actor-owned workflow

## Verification

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p orchestrator-cli --tests`
- `cargo test -p orchestrator-cli output_inproc::tests --locked -- --test-threads=1` (2 passed; covers owned/cross-user transcript and phase reads plus JSONL/monitor fidelity)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p orchestrator-cli --locked -- --test-threads=1` (1,437 unit tests plus all integration targets passed)
- `cargo animus-lint`

Tracks TASK-971.