### PR TITLE
refactor(mcp): type cost and daemon config services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_cost.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_cost.rs
@@ -365,11 +365,40 @@ fn completed_subjects_in_window(
 }
 
 #[derive(Debug, Serialize)]
-struct DecisionsView {
+pub(crate) struct DecisionsView {
     schema: &'static str,
     since: Option<String>,
     count: usize,
     records: Vec<crate::services::cost::BudgetExceededRecord>,
+}
+
+pub(crate) fn cost_decisions_application(project_root: &str, since: Option<&str>) -> Result<DecisionsView> {
+    let records = read_decision_records(Path::new(project_root))?;
+    decisions_view(records, since)
+}
+
+pub(crate) fn budget_get_application(project_root: &str) -> crate::services::cost::BudgetReport {
+    crate::services::cost::build_budget_report(Path::new(project_root))
+}
+
+pub(crate) fn budget_set_application(
+    project_root: &str,
+    max_daily_usd: Option<f64>,
+    clear: bool,
+) -> Result<serde_json::Value> {
+    let cap = match (max_daily_usd, clear) {
+        (Some(_), true) => return Err(crate::invalid_input_error("pass either max_daily_usd or clear, not both")),
+        (Some(value), false) if value.is_finite() => value,
+        (Some(_), false) => return Err(crate::invalid_input_error("max_daily_usd must be finite")),
+        (None, true) => 0.0,
+        (None, false) => {
+            return Err(crate::invalid_input_error("provide max_daily_usd (USD cap) or clear=true"));
+        }
+    };
+    crate::services::runtime::daemon_config_application(
+        project_root,
+        crate::services::runtime::DaemonConfigApplicationRequest { max_daily_usd: Some(cap), ..Default::default() },
+    )
 }
 
 fn decisions_view(
@@ -377,7 +406,8 @@ fn decisions_view(
     since: Option<&str>,
 ) -> Result<DecisionsView> {
     if let Some(window) = since {
-        let cutoff = Utc::now() - parse_duration(window)?;
+        let duration = parse_duration(window).map_err(|error| crate::invalid_input_error(error.to_string()))?;
+        let cutoff = Utc::now() - duration;
         records.retain(|record| record.observed_at >= cutoff);
     }
     Ok(DecisionsView { schema: DECISIONS_SCHEMA, since: since.map(str::to_string), count: records.len(), records })
@@ -387,8 +417,7 @@ fn decisions_view(
 /// — the fleet-level record stream, distinct from the per-run
 /// `runs/<run_id>/decisions.jsonl` that `animus output decisions` renders.
 fn handle_decisions(project_path: &Path, args: CostDecisionsArgs, json: bool) -> Result<()> {
-    let records = read_decision_records(project_path)?;
-    let view = decisions_view(records, args.since.as_deref())?;
+    let view = cost_decisions_application(project_path.to_string_lossy().as_ref(), args.since.as_deref())?;
     if json {
         return print_value(&view, json);
     }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -39,6 +39,8 @@ mod ao_exec;
 mod common_types;
 #[path = "ops_mcp/compaction.rs"]
 mod compaction;
+#[path = "ops_mcp/cost_inproc.rs"]
+mod cost_inproc;
 #[path = "ops_mcp/cost_tools.rs"]
 mod cost_tools;
 #[path = "ops_mcp/daemon.rs"]
@@ -123,8 +125,7 @@ use common_types::*;
 use compaction::compact_json_str;
 use compaction::compact_json_text;
 use daemon::{
-    build_daemon_config_set_args, build_daemon_events_poll_result, build_daemon_logs_result, build_daemon_observe_args,
-    build_daemon_start_args,
+    build_daemon_events_poll_result, build_daemon_logs_result, build_daemon_observe_args, build_daemon_start_args,
 };
 #[cfg(test)]
 use daemon::{daemon_events_poll_limit, resolve_daemon_events_project_root};

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/cost_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/cost_inproc.rs
@@ -1,0 +1,90 @@
+use super::cost_tools::{BudgetSetInput, CostDecisionsInput};
+use super::daemon_inproc::resolve_project_root;
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::AoMcpServer;
+use crate::services::operations::{budget_get_application, budget_set_application, cost_decisions_application};
+use anyhow::Result;
+use rmcp::model::CallToolResult;
+use serde::Serialize;
+use serde_json::json;
+
+impl AoMcpServer {
+    fn run_cost_application<T, F>(&self, tool_name: &str, project_root: Option<String>, call: F) -> CallToolResult
+    where
+        T: Serialize,
+        F: FnOnce(&str) -> Result<T>,
+    {
+        self.audit_actor_tool_decision(tool_name, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        match call(&project_root) {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)),
+        }
+    }
+
+    pub(super) fn cost_decisions_inproc(&self, input: CostDecisionsInput) -> CallToolResult {
+        self.run_cost_application("animus.cost.decisions", input.project_root, |root| {
+            cost_decisions_application(root, input.since.as_deref())
+        })
+    }
+
+    pub(super) fn budget_get_inproc(&self, project_root: Option<String>) -> CallToolResult {
+        self.run_cost_application("animus.budget.get", project_root, |root| Ok(budget_get_application(root)))
+    }
+
+    pub(super) fn budget_set_inproc(&self, input: BudgetSetInput) -> CallToolResult {
+        self.run_cost_application("animus.budget.set", input.project_root, |root| {
+            budget_set_application(root, input.max_daily_usd, input.clear)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::cost_tools::{BudgetSetInput, CostDecisionsInput};
+    use protocol::test_utils::EnvVarGuard;
+    use serde_json::Value;
+
+    #[test]
+    fn budget_set_and_get_share_typed_daemon_configuration() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project root");
+        let server = super::super::new_ao_mcp_server(project_root.to_string_lossy().as_ref());
+
+        let set =
+            server.budget_set_inproc(BudgetSetInput { max_daily_usd: Some(18.5), clear: false, project_root: None });
+        let set_is_error = set.is_error;
+        let payload = set.structured_content.expect("budget set payload");
+        assert_ne!(set_is_error, Some(true), "{payload}");
+        assert_eq!(payload.pointer("/result/max_daily_usd").and_then(Value::as_f64), Some(18.5));
+
+        let get = server.budget_get_inproc(None);
+        let payload = get.structured_content.expect("budget get payload");
+        assert_eq!(payload.pointer("/result/daily_cap/max_daily_usd").and_then(Value::as_f64), Some(18.5));
+
+        let clear = server.budget_set_inproc(BudgetSetInput { max_daily_usd: None, clear: true, project_root: None });
+        let payload = clear.structured_content.expect("budget clear payload");
+        assert_eq!(payload.pointer("/result/max_daily_usd").and_then(Value::as_f64), Some(0.0));
+    }
+
+    #[test]
+    fn cost_and_budget_validation_return_typed_invalid_input_errors() {
+        let temp = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(temp.path().to_string_lossy().as_ref());
+
+        let decisions = server
+            .cost_decisions_inproc(CostDecisionsInput { since: Some("yesterday".to_string()), project_root: None });
+        assert_eq!(decisions.is_error, Some(true));
+        let payload = decisions.structured_content.expect("decisions error");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+
+        let budget =
+            server.budget_set_inproc(BudgetSetInput { max_daily_usd: Some(10.0), clear: true, project_root: None });
+        assert_eq!(budget.is_error, Some(true));
+        let payload = budget.structured_content.expect("budget error");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/cost_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/cost_tools.rs
@@ -11,12 +11,6 @@ pub(super) struct CostDecisionsInput {
     pub(super) project_root: Option<String>,
 }
 
-fn build_cost_decisions_args(input: &CostDecisionsInput) -> Vec<String> {
-    let mut args = vec!["cost".to_string(), "decisions".to_string()];
-    push_opt(&mut args, "--since", input.since.clone());
-    args
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
 pub(super) struct BudgetGetInput {
     #[serde(default)]
@@ -37,27 +31,6 @@ pub(super) struct BudgetSetInput {
     pub(super) project_root: Option<String>,
 }
 
-/// Build the `daemon config` args for `budget_set`, or an error message when
-/// the caller passed neither / both of `max_daily_usd` and `clear`.
-fn build_budget_set_args(input: &BudgetSetInput) -> Result<Vec<String>, String> {
-    let mut args = vec!["daemon".to_string(), "config".to_string()];
-    match (input.max_daily_usd, input.clear) {
-        (Some(_), true) => Err("pass either max_daily_usd or clear, not both".to_string()),
-        (Some(value), false) => {
-            args.push("--max-daily-usd".to_string());
-            args.push(value.to_string());
-            Ok(args)
-        }
-        (None, true) => {
-            // An explicit 0 persists as "uncapped" (see daily_cap::read_max_daily_usd).
-            args.push("--max-daily-usd".to_string());
-            args.push("0".to_string());
-            Ok(args)
-        }
-        (None, false) => Err("provide max_daily_usd (USD cap) or clear=true".to_string()),
-    }
-}
-
 #[tool_router(router = cost_tool_router, vis = "pub(super)")]
 impl AoMcpServer {
     #[tool(
@@ -66,9 +39,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<CostDecisionsInput>()
     )]
     async fn ao_cost_decisions(&self, params: Parameters<CostDecisionsInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = build_cost_decisions_args(&input);
-        self.run_tool("animus.cost.decisions", args, input.project_root).await
+        Ok(self.cost_decisions_inproc(params.0))
     }
 
     #[tool(
@@ -77,69 +48,15 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<BudgetGetInput>()
     )]
     async fn ao_budget_get(&self, params: Parameters<BudgetGetInput>) -> Result<CallToolResult, McpError> {
-        let project_root =
-            super::daemon_inproc::resolve_project_root(&self.default_project_root, params.0.project_root);
-        let report = crate::services::cost::build_budget_report(Path::new(&project_root));
-        let payload = json!({
-            "tool": "animus.budget.get",
-            "result": serde_json::to_value(report).unwrap_or(Value::Null),
-        });
-        Ok(CallToolResult::structured(payload))
+        Ok(self.budget_get_inproc(params.0.project_root))
     }
 
     #[tool(
         name = "animus.budget.set",
-        description = "Set or clear the fleet daily spend cap (admin). Purpose: Bound the daemon's TOTAL rolling-24h spend; when crossed the daemon pauses new dispatch until spend ages out of the window or the cap is raised. Wraps `daemon config --max-daily-usd`; hot-reloaded by the running daemon. Prerequisites: None. Example: {\"max_daily_usd\": 25.0} to cap at $25/day, or {\"clear\": true} to remove the cap. Sequencing: Use animus.budget.get to read the current cap first.",
+        description = "Set or clear the fleet daily spend cap (admin). Purpose: Bound the daemon's TOTAL rolling-24h spend; when crossed the daemon pauses new dispatch until spend ages out of the window or the cap is raised. Uses the same typed daemon-configuration service and is hot-reloaded by the running daemon. Prerequisites: None. Example: {\"max_daily_usd\": 25.0} to cap at $25/day, or {\"clear\": true} to remove the cap. Sequencing: Use animus.budget.get to read the current cap first.",
         input_schema = ao_schema_for_type::<BudgetSetInput>()
     )]
     async fn ao_budget_set(&self, params: Parameters<BudgetSetInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        match build_budget_set_args(&input) {
-            Ok(args) => self.run_tool("animus.budget.set", args, input.project_root).await,
-            Err(message) => Ok(CallToolResult::structured_error(json!({
-                "tool": "animus.budget.set",
-                "error": message,
-            }))),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn build_cost_decisions_args_defaults_minimal() {
-        let args = build_cost_decisions_args(&CostDecisionsInput::default());
-        assert_eq!(args, vec!["cost".to_string(), "decisions".to_string()]);
-    }
-
-    #[test]
-    fn build_cost_decisions_args_wires_since() {
-        let input = CostDecisionsInput { since: Some("7d".to_string()), project_root: Some("/repo".to_string()) };
-        let args = build_cost_decisions_args(&input);
-        assert_eq!(args, vec!["cost".to_string(), "decisions".to_string(), "--since".to_string(), "7d".to_string(),]);
-    }
-
-    #[test]
-    fn budget_set_args_wires_max_daily_usd() {
-        let input = BudgetSetInput { max_daily_usd: Some(25.0), clear: false, project_root: None };
-        let args = build_budget_set_args(&input).expect("valid");
-        assert_eq!(args, vec!["daemon", "config", "--max-daily-usd", "25"]);
-    }
-
-    #[test]
-    fn budget_set_args_clear_persists_zero() {
-        let input = BudgetSetInput { max_daily_usd: None, clear: true, project_root: None };
-        let args = build_budget_set_args(&input).expect("valid");
-        assert_eq!(args, vec!["daemon", "config", "--max-daily-usd", "0"]);
-    }
-
-    #[test]
-    fn budget_set_args_rejects_empty_and_conflicting_input() {
-        let empty = BudgetSetInput::default();
-        assert!(build_budget_set_args(&empty).is_err(), "neither cap nor clear must error");
-        let both = BudgetSetInput { max_daily_usd: Some(10.0), clear: true, project_root: None };
-        assert!(build_budget_set_args(&both).is_err(), "cap + clear together must error");
+        Ok(self.budget_set_inproc(params.0))
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon.rs
@@ -1,6 +1,6 @@
 use super::{
-    push_bool_set, push_opt, push_opt_num, push_opt_usize, DaemonConfigSetInput, DaemonEventsInput, DaemonLogsInput,
-    DaemonObserveInput, DaemonStartInput, DEFAULT_DAEMON_EVENTS_LIMIT, MAX_DAEMON_EVENTS_LIMIT,
+    push_bool_set, push_opt, push_opt_num, push_opt_usize, DaemonEventsInput, DaemonLogsInput, DaemonObserveInput,
+    DaemonStartInput, DEFAULT_DAEMON_EVENTS_LIMIT, MAX_DAEMON_EVENTS_LIMIT,
 };
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -16,25 +16,6 @@ pub(super) fn build_daemon_start_args(input: &DaemonStartInput) -> Vec<String> {
     push_opt_num(&mut args, "--phase-timeout-secs", input.phase_timeout_secs);
     push_bool_set(&mut args, "--startup-cleanup", input.startup_cleanup);
     push_bool_set(&mut args, "--reconcile-stale", input.reconcile_stale);
-    args
-}
-
-pub(super) fn build_daemon_config_set_args(input: &DaemonConfigSetInput) -> Vec<String> {
-    let mut args = vec!["daemon".to_string(), "config".to_string()];
-    push_opt_usize(&mut args, "--pool-size", input.pool_size);
-    push_opt_num(&mut args, "--interval-secs", input.interval_secs);
-    push_opt_usize(&mut args, "--max-tasks-per-tick", input.max_tasks_per_tick);
-    push_opt_num(&mut args, "--stale-threshold-hours", input.stale_threshold_hours);
-    push_opt_num(&mut args, "--phase-timeout-secs", input.phase_timeout_secs);
-    if let Some(max_daily_usd) = input.max_daily_usd {
-        args.push("--max-daily-usd".to_string());
-        args.push(max_daily_usd.to_string());
-    }
-    push_opt(&mut args, "--notification-config-json", input.notification_config_json.clone());
-    push_opt(&mut args, "--notification-config-file", input.notification_config_file.clone());
-    if input.clear_notification_config {
-        args.push("--clear-notification-config".to_string());
-    }
     args
 }
 
@@ -113,24 +94,6 @@ pub(super) fn build_daemon_logs_result(default_project_root: &str, input: Daemon
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn build_daemon_config_set_args_includes_notification_config_flags() {
-        let input = DaemonConfigSetInput {
-            notification_config_json: Some("{\"schema\":\"animus.daemon-notification-config.v1\"}".to_string()),
-            notification_config_file: Some(".animus/notification-config.json".to_string()),
-            clear_notification_config: true,
-            ..Default::default()
-        };
-
-        let args = build_daemon_config_set_args(&input);
-
-        assert!(args.contains(&"--notification-config-json".to_string()));
-        assert!(args.contains(&"{\"schema\":\"animus.daemon-notification-config.v1\"}".to_string()));
-        assert!(args.contains(&"--notification-config-file".to_string()));
-        assert!(args.contains(&".animus/notification-config.json".to_string()));
-        assert!(args.contains(&"--clear-notification-config".to_string()));
-    }
 
     #[test]
     fn build_daemon_observe_args_defaults_minimal() {

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inproc.rs
@@ -1,14 +1,17 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use orchestrator_core::DaemonStatus;
 use orchestrator_daemon_runtime::control::ControlClient;
 use protocol::is_process_alive;
 use serde_json::{json, Value};
 use std::path::Path;
 
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::AoMcpServer;
 use crate::services::runtime::{
-    canonicalize_lossy, overlay_budget_health, overlay_daily_cap_status, overlay_runtime_pause, read_daemon_pid,
-    remove_daemon_pid, set_daemon_pid,
+    canonicalize_lossy, daemon_config_application, overlay_budget_health, overlay_daily_cap_status,
+    overlay_runtime_pause, read_daemon_pid, remove_daemon_pid, set_daemon_pid, DaemonConfigApplicationRequest,
 };
+use rmcp::model::CallToolResult;
 
 pub(super) fn resolve_project_root(default_root: &str, override_value: Option<String>) -> String {
     let candidate = override_value
@@ -115,6 +118,88 @@ pub(super) async fn daemon_agents_inproc(default_project_root: &str, project_roo
     Ok(json!({ "active_agents": health.active_agents }))
 }
 
+fn notification_config_from_input(input: &super::DaemonConfigSetInput) -> Result<Option<Value>> {
+    let supplied = usize::from(input.notification_config.is_some())
+        + usize::from(input.notification_config_json.is_some())
+        + usize::from(input.notification_config_file.is_some());
+    if supplied > 1 {
+        return Err(crate::invalid_input_error(
+            "provide only one of notification_config, notification_config_json, or notification_config_file",
+        ));
+    }
+    if supplied > 0 && input.clear_notification_config {
+        return Err(crate::invalid_input_error(
+            "notification configuration and clear_notification_config cannot be used together",
+        ));
+    }
+    if let Some(value) = input.notification_config.clone() {
+        return Ok(Some(value));
+    }
+    if let Some(raw_json) = input.notification_config_json.as_deref() {
+        return Ok(Some(serde_json::from_str(raw_json).context("invalid notification_config_json")?));
+    }
+    if let Some(path) = input.notification_config_file.as_deref() {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read daemon notification config file at {path}"))?;
+        return Ok(Some(
+            serde_json::from_str(&raw)
+                .with_context(|| format!("failed to parse daemon notification config file at {path}"))?,
+        ));
+    }
+    Ok(None)
+}
+
+impl AoMcpServer {
+    fn run_daemon_config_application(
+        &self,
+        tool_name: &str,
+        project_root: Option<String>,
+        request: DaemonConfigApplicationRequest,
+    ) -> CallToolResult {
+        self.audit_actor_tool_decision(tool_name, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        match daemon_config_application(&project_root, request) {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)),
+        }
+    }
+
+    pub(super) fn daemon_config_inproc(&self, project_root: Option<String>) -> CallToolResult {
+        self.run_daemon_config_application(
+            "animus.daemon.config",
+            project_root,
+            DaemonConfigApplicationRequest::default(),
+        )
+    }
+
+    pub(super) fn daemon_config_set_inproc(&self, input: super::DaemonConfigSetInput) -> CallToolResult {
+        let notification_config = match notification_config_from_input(&input) {
+            Ok(value) => value,
+            Err(error) => {
+                return CallToolResult::structured_error(build_inproc_tool_error_payload(
+                    "animus.daemon.config-set",
+                    &error,
+                ));
+            }
+        };
+        self.run_daemon_config_application(
+            "animus.daemon.config-set",
+            input.project_root,
+            DaemonConfigApplicationRequest {
+                pool_size: input.pool_size,
+                interval_secs: input.interval_secs,
+                max_tasks_per_tick: input.max_tasks_per_tick,
+                stale_threshold_hours: input.stale_threshold_hours,
+                phase_timeout_secs: input.phase_timeout_secs,
+                max_daily_usd: input.max_daily_usd,
+                silent_threshold_mins: input.silent_threshold_mins,
+                notification_config,
+                clear_notification_config: input.clear_notification_config,
+            },
+        )
+    }
+}
+
 pub(super) fn wrap_tool_result(tool_name: &str, result: Result<Value>) -> Value {
     match result {
         Ok(data) => json!({ "tool": tool_name, "result": data }),
@@ -124,4 +209,63 @@ pub(super) fn wrap_tool_result(tool_name: &str, result: Result<Value>) -> Value 
 
 pub(super) fn is_tool_error(payload: &Value) -> bool {
     payload.get("error").is_some()
+}
+
+#[cfg(test)]
+mod config_tests {
+    use protocol::test_utils::EnvVarGuard;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn daemon_config_read_and_write_share_the_typed_application_service() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project root");
+        let server = super::super::new_ao_mcp_server(project_root.to_string_lossy().as_ref());
+
+        let set = server.daemon_config_set_inproc(super::super::DaemonConfigSetInput {
+            pool_size: Some(6),
+            interval_secs: Some(15),
+            max_tasks_per_tick: Some(4),
+            stale_threshold_hours: Some(48),
+            phase_timeout_secs: Some(300),
+            max_daily_usd: Some(25.0),
+            silent_threshold_mins: Some(9),
+            notification_config: Some(json!({"channels": {"ops": {"enabled": true}}})),
+            project_root: None,
+            ..Default::default()
+        });
+        let set_is_error = set.is_error;
+        let payload = set.structured_content.expect("set payload");
+        assert_ne!(set_is_error, Some(true), "{payload}");
+        assert_eq!(payload.pointer("/result/pool_size").and_then(Value::as_u64), Some(6));
+        assert_eq!(payload.pointer("/result/max_daily_usd").and_then(Value::as_f64), Some(25.0));
+        assert_eq!(
+            payload.pointer("/result/notification_config/channels/ops/enabled").and_then(Value::as_bool),
+            Some(true)
+        );
+
+        let read = server.daemon_config_inproc(None);
+        let payload = read.structured_content.expect("read payload");
+        assert_eq!(payload.pointer("/result/pool_size").and_then(Value::as_u64), Some(6));
+        assert_eq!(payload.pointer("/result/updated").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    fn daemon_config_rejects_ambiguous_notification_sources_before_writing() {
+        let temp = tempfile::tempdir().expect("project root");
+        let server = super::super::new_ao_mcp_server(temp.path().to_string_lossy().as_ref());
+        let result = server.daemon_config_set_inproc(super::super::DaemonConfigSetInput {
+            notification_config: Some(json!({"enabled": true})),
+            notification_config_json: Some("{\"enabled\":false}".to_string()),
+            project_root: None,
+            ..Default::default()
+        });
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed conflict error");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+    }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inputs.rs
@@ -83,6 +83,12 @@ pub(super) struct DaemonConfigSetInput {
     #[serde(default)]
     pub(super) max_daily_usd: Option<f64>,
     #[serde(default)]
+    pub(super) silent_threshold_mins: Option<u64>,
+    /// Structured notification configuration. Prefer this over the legacy
+    /// JSON string/file compatibility inputs.
+    #[serde(default)]
+    pub(super) notification_config: Option<serde_json::Value>,
+    #[serde(default)]
     pub(super) notification_config_json: Option<String>,
     #[serde(default)]
     pub(super) notification_config_file: Option<String>,

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_tools.rs
@@ -137,19 +137,16 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<DaemonConfigInput>()
     )]
     async fn ao_daemon_config(&self, params: Parameters<DaemonConfigInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool("animus.daemon.config", vec!["daemon".to_string(), "config".to_string()], params.0.project_root)
-            .await
+        Ok(self.daemon_config_inproc(params.0.project_root))
     }
 
     #[tool(
         name = "animus.daemon.config-set",
-        description = "Update daemon configuration. Purpose: Persist daemon automation settings and runtime-reconfigurable settings (pool_size, interval_secs, max_tasks_per_tick, stale_threshold_hours, phase_timeout_secs, max_daily_usd, notification_config_json, notification_config_file, clear_notification_config). Runtime settings are hot-reloaded by the running daemon without restart. For the fleet daily spend cap prefer animus.budget.set. Prerequisites: None. Example: {\"pool_size\": 4, \"interval_secs\": 10}. Sequencing: Use animus.daemon.config to read current values first.",
+        description = "Update daemon configuration through the typed in-process application service. Purpose: Persist daemon automation settings and runtime-reconfigurable settings (pool_size, interval_secs, max_tasks_per_tick, stale_threshold_hours, phase_timeout_secs, max_daily_usd, silent_threshold_mins, notification_config, clear_notification_config). Prefer the structured notification_config object; notification_config_json and notification_config_file remain one-time compatibility inputs and cannot be combined with it. Runtime settings are hot-reloaded by the running daemon without restart. For the fleet daily spend cap prefer animus.budget.set. Prerequisites: None. Example: {\"pool_size\": 4, \"interval_secs\": 10}. Sequencing: Use animus.daemon.config to read current values first.",
         input_schema = ao_schema_for_type::<DaemonConfigSetInput>()
     )]
     async fn ao_daemon_config_set(&self, params: Parameters<DaemonConfigSetInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = build_daemon_config_set_args(&input);
-        self.run_tool("animus.daemon.config-set", args, input.project_root).await
+        Ok(self.daemon_config_set_inproc(params.0))
     }
 
     #[tool(

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -829,63 +829,6 @@ fn build_daemon_start_args_includes_stale_threshold_hours() {
 }
 
 #[test]
-fn build_daemon_config_set_args_defaults_minimal() {
-    let input = DaemonConfigSetInput::default();
-    let args = build_daemon_config_set_args(&input);
-    assert_eq!(args, vec!["daemon".to_string(), "config".to_string()]);
-}
-
-#[test]
-fn build_daemon_config_set_args_wires_pool_size() {
-    let input = DaemonConfigSetInput { pool_size: Some(8), ..Default::default() };
-    let args = build_daemon_config_set_args(&input);
-    assert_eq!(args, vec!["daemon", "config", "--pool-size", "8"].into_iter().map(String::from).collect::<Vec<_>>());
-}
-
-#[test]
-fn build_daemon_config_set_args_wires_interval_secs() {
-    let input = DaemonConfigSetInput { interval_secs: Some(15), ..Default::default() };
-    let args = build_daemon_config_set_args(&input);
-    assert_eq!(
-        args,
-        vec!["daemon", "config", "--interval-secs", "15"].into_iter().map(String::from).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn build_daemon_config_set_args_wires_max_tasks_per_tick() {
-    let input = DaemonConfigSetInput { max_tasks_per_tick: Some(10), ..Default::default() };
-    let args = build_daemon_config_set_args(&input);
-    assert_eq!(
-        args,
-        vec!["daemon", "config", "--max-tasks-per-tick", "10"].into_iter().map(String::from).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn build_daemon_config_set_args_wires_all_runtime_settings() {
-    let input = DaemonConfigSetInput {
-        pool_size: Some(4),
-        interval_secs: Some(10),
-        max_tasks_per_tick: Some(5),
-        stale_threshold_hours: Some(48),
-        phase_timeout_secs: Some(300),
-        ..Default::default()
-    };
-    let args = build_daemon_config_set_args(&input);
-    assert!(args.contains(&"--pool-size".to_string()));
-    assert!(args.contains(&"4".to_string()));
-    assert!(args.contains(&"--interval-secs".to_string()));
-    assert!(args.contains(&"10".to_string()));
-    assert!(args.contains(&"--max-tasks-per-tick".to_string()));
-    assert!(args.contains(&"5".to_string()));
-    assert!(args.contains(&"--stale-threshold-hours".to_string()));
-    assert!(args.contains(&"48".to_string()));
-    assert!(args.contains(&"--phase-timeout-secs".to_string()));
-    assert!(args.contains(&"300".to_string()));
-}
-
-#[test]
 fn build_agent_run_args_defaults_detach_and_stream() {
     let input = AgentRunInput {
         tool: "codex".to_string(),

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
@@ -674,11 +674,28 @@ fn save_pm_config(project_root: &str, value: &serde_json::Value) -> Result<()> {
     Ok(())
 }
 
-fn handle_daemon_config(args: DaemonConfigArgs, project_root: &str, json: bool) -> Result<()> {
-    if args.notification_config_json.is_some() && args.notification_config_file.is_some() {
-        anyhow::bail!("--notification-config-json and --notification-config-file cannot be used together");
-    }
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DaemonConfigApplicationRequest {
+    pub(crate) pool_size: Option<usize>,
+    pub(crate) interval_secs: Option<u64>,
+    pub(crate) max_tasks_per_tick: Option<usize>,
+    pub(crate) stale_threshold_hours: Option<u64>,
+    pub(crate) phase_timeout_secs: Option<u64>,
+    pub(crate) max_daily_usd: Option<f64>,
+    pub(crate) silent_threshold_mins: Option<u64>,
+    pub(crate) notification_config: Option<serde_json::Value>,
+    pub(crate) clear_notification_config: bool,
+}
 
+pub(crate) fn daemon_config_application(
+    project_root: &str,
+    request: DaemonConfigApplicationRequest,
+) -> Result<serde_json::Value> {
+    if request.notification_config.is_some() && request.clear_notification_config {
+        return Err(crate::invalid_input_error(
+            "notification_config and clear_notification_config cannot be used together",
+        ));
+    }
     let mut config = load_pm_config(project_root)?;
     if !config.is_object() {
         config = serde_json::json!({});
@@ -687,27 +704,27 @@ fn handle_daemon_config(args: DaemonConfigArgs, project_root: &str, json: bool) 
     let mut updated = false;
 
     // Runtime-reconfigurable settings (hot-reloaded by daemon)
-    if let Some(v) = args.pool_size {
+    if let Some(v) = request.pool_size {
         config["pool_size"] = serde_json::json!(v);
         updated = true;
     }
-    if let Some(v) = args.interval_secs {
+    if let Some(v) = request.interval_secs {
         config["interval_secs"] = serde_json::json!(v);
         updated = true;
     }
-    if let Some(v) = args.max_tasks_per_tick {
+    if let Some(v) = request.max_tasks_per_tick {
         config["max_tasks_per_tick"] = serde_json::json!(v);
         updated = true;
     }
-    if let Some(v) = args.stale_threshold_hours {
+    if let Some(v) = request.stale_threshold_hours {
         config["stale_threshold_hours"] = serde_json::json!(v);
         updated = true;
     }
-    if let Some(v) = args.phase_timeout_secs {
+    if let Some(v) = request.phase_timeout_secs {
         config["phase_timeout_secs"] = serde_json::json!(v);
         updated = true;
     }
-    if let Some(v) = args.max_daily_usd {
+    if let Some(v) = request.max_daily_usd {
         // Store the cap as a top-level key the daemon's cost layer reads
         // (`daily_cap::read_max_daily_usd`). A non-positive value persists as
         // an EXPLICIT "uncapped" override (clamped to 0) so it overrides any
@@ -715,27 +732,16 @@ fn handle_daemon_config(args: DaemonConfigArgs, project_root: &str, json: bool) 
         config["max_daily_usd"] = serde_json::json!(v.max(0.0));
         updated = true;
     }
-    if let Some(v) = args.silent_threshold_mins {
+    if let Some(v) = request.silent_threshold_mins {
         config["silent_threshold_mins"] = serde_json::json!(v);
         updated = true;
     }
-    if args.clear_notification_config {
+    if request.clear_notification_config {
         clear_notification_config(&mut config);
         updated = true;
     }
 
-    if let Some(raw_json) = args.notification_config_json.as_deref() {
-        let value: serde_json::Value =
-            serde_json::from_str(raw_json).context("failed to parse --notification-config-json")?;
-        config["notification_config"] = value;
-        updated = true;
-    }
-
-    if let Some(config_path) = args.notification_config_file.as_deref() {
-        let raw_json = fs::read_to_string(config_path)
-            .with_context(|| format!("failed to read daemon notification config file at {}", config_path))?;
-        let value: serde_json::Value = serde_json::from_str(raw_json.as_str())
-            .with_context(|| format!("failed to parse daemon notification config file at {}", config_path))?;
+    if let Some(value) = request.notification_config {
         config["notification_config"] = value;
         updated = true;
     }
@@ -746,22 +752,59 @@ fn handle_daemon_config(args: DaemonConfigArgs, project_root: &str, json: bool) 
 
     let notification_config = read_notification_config_from_pm_config(&config);
 
+    Ok(serde_json::json!({
+        "config_path": pm_config_path(project_root).display().to_string(),
+        "pool_size": config.get("pool_size").and_then(serde_json::Value::as_u64),
+        "interval_secs": config.get("interval_secs").and_then(serde_json::Value::as_u64),
+        "max_tasks_per_tick": config.get("max_tasks_per_tick").and_then(serde_json::Value::as_u64),
+        "stale_threshold_hours": config.get("stale_threshold_hours").and_then(serde_json::Value::as_u64),
+        "phase_timeout_secs": config.get("phase_timeout_secs").and_then(serde_json::Value::as_u64),
+        "max_daily_usd": config.get("max_daily_usd").and_then(serde_json::Value::as_f64),
+        "silent_threshold_mins": config.get("silent_threshold_mins")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(orchestrator_core::DEFAULT_SILENT_THRESHOLD_MINS),
+        "notification_config_schema": NOTIFICATION_CONFIG_SCHEMA,
+        "notification_config": notification_config,
+        "updated": updated
+    }))
+}
+
+fn handle_daemon_config(args: DaemonConfigArgs, project_root: &str, json: bool) -> Result<()> {
+    if args.notification_config_json.is_some() && args.notification_config_file.is_some() {
+        return Err(crate::invalid_input_error(
+            "--notification-config-json and --notification-config-file cannot be used together",
+        ));
+    }
+    let notification_config = match (args.notification_config_json, args.notification_config_file) {
+        (Some(raw_json), None) => {
+            Some(serde_json::from_str(&raw_json).context("failed to parse --notification-config-json")?)
+        }
+        (None, Some(config_path)) => {
+            let raw_json = fs::read_to_string(&config_path)
+                .with_context(|| format!("failed to read daemon notification config file at {config_path}"))?;
+            Some(
+                serde_json::from_str(&raw_json)
+                    .with_context(|| format!("failed to parse daemon notification config file at {config_path}"))?,
+            )
+        }
+        (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("conflict checked above"),
+    };
     print_value(
-        serde_json::json!({
-            "config_path": pm_config_path(project_root).display().to_string(),
-            "pool_size": config.get("pool_size").and_then(serde_json::Value::as_u64),
-            "interval_secs": config.get("interval_secs").and_then(serde_json::Value::as_u64),
-            "max_tasks_per_tick": config.get("max_tasks_per_tick").and_then(serde_json::Value::as_u64),
-            "stale_threshold_hours": config.get("stale_threshold_hours").and_then(serde_json::Value::as_u64),
-            "phase_timeout_secs": config.get("phase_timeout_secs").and_then(serde_json::Value::as_u64),
-            "max_daily_usd": config.get("max_daily_usd").and_then(serde_json::Value::as_f64),
-            "silent_threshold_mins": config.get("silent_threshold_mins")
-                .and_then(serde_json::Value::as_u64)
-                .unwrap_or(orchestrator_core::DEFAULT_SILENT_THRESHOLD_MINS),
-            "notification_config_schema": NOTIFICATION_CONFIG_SCHEMA,
-            "notification_config": notification_config,
-            "updated": updated
-        }),
+        daemon_config_application(
+            project_root,
+            DaemonConfigApplicationRequest {
+                pool_size: args.pool_size,
+                interval_secs: args.interval_secs,
+                max_tasks_per_tick: args.max_tasks_per_tick,
+                stale_threshold_hours: args.stale_threshold_hours,
+                phase_timeout_secs: args.phase_timeout_secs,
+                max_daily_usd: args.max_daily_usd,
+                silent_threshold_mins: args.silent_threshold_mins,
+                notification_config,
+                clear_notification_config: args.clear_notification_config,
+            },
+        )?,
         json,
     )
 }

--- a/docs/architecture/actor-bound-application-contract.md
+++ b/docs/architecture/actor-bound-application-contract.md
@@ -204,6 +204,11 @@ These surfaces remain absent from actor-bound MCP until their protocols change:
 - Output monitor/JSONL/artifact reads: these inputs are not yet guaranteed to
   identify an actor-owned workflow, so they remain management-only even though
   their MCP handlers now use typed in-process services.
+- Cost/budget and daemon configuration: their MCP handlers use shared typed
+  in-process services, including one daemon-configuration write path for the
+  fleet daily budget. The underlying cost state and daemon configuration are
+  still global stores with no actor field or authorization context, so these
+  tools remain management-only.
 - MCP resources: list/read resource requests need the same typed actor/request
   context and backend enforcement.
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -229,6 +229,7 @@ dispatch control.
 { "pool_size": 3, "auto_install": true }                    // animus.daemon.start (always detaches)
 { "skip_preflight": true }                  // animus.daemon.start (dev escape hatch)
 { "pool_size": 4, "interval_secs": 10 }     // animus.daemon.config-set
+{ "notification_config": { "desktop": { "enabled": true } } } // structured config-set
 { "limit": 50 }                              // animus.daemon.events
 { "project_root": "/repo" }                  // animus.queue.list / stats
 { "task_id": "TASK-001" }                    // animus.queue.enqueue (task)
@@ -242,6 +243,14 @@ dispatch control.
 `auto_install` when you want the daemon to remediate missing required plugins
 from its recommended defaults before continuing; use `skip_preflight` only for
 dev or intentionally degraded runs.
+
+Daemon configuration and all cost/budget MCP tools execute through typed
+in-process services. `animus.budget.set` shares the daemon configuration write
+path, so the MCP and CLI surfaces cannot drift. Prefer the structured
+`notification_config` object; `notification_config_json` and
+`notification_config_file` remain mutually exclusive compatibility inputs.
+These fleet-wide stores are management-only until their protocols support
+actor-partitioned authorization.
 
 ## Output and Logs Operations
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -157,8 +157,8 @@ approval gate stays human-only.
 | `animus.daemon.events` | List recent daemon events for debugging and monitoring | `limit`, `project_root` |
 | `animus.daemon.agents` | List currently running agent tasks and their status | `project_root` |
 | `animus.daemon.logs` | Read recent daemon log entries | `limit`, `search`, `project_root` |
-| `animus.daemon.config` | Read current daemon automation settings | `project_root` |
-| `animus.daemon.config-set` | Update daemon runtime settings and notification config | `pool_size` (alias: `max_agents`), `interval_secs`, `max_tasks_per_tick`, `stale_threshold_hours`, `phase_timeout_secs`, `max_daily_usd`, `notification_config_json`, `notification_config_file`, `clear_notification_config`, `project_root` |
+| `animus.daemon.config` | Read current daemon automation settings through the typed in-process configuration service | `project_root` |
+| `animus.daemon.config-set` | Update daemon runtime settings and notification config through the same typed in-process service. Prefer structured `notification_config`; the JSON-string and file fields are mutually exclusive compatibility inputs | `pool_size` (alias: `max_agents`), `interval_secs`, `max_tasks_per_tick`, `stale_threshold_hours`, `phase_timeout_secs`, `max_daily_usd`, `silent_threshold_mins`, `notification_config`, `notification_config_json`, `notification_config_file`, `clear_notification_config`, `project_root` |
 | `animus.daemon.observe` | Routing front-door over the existing observability surfaces: returns the merged, chronological window of daemon events + logs (or routes to a single `source`). Non-streaming — always returns and never follows live. Works offline (reads scoped event/log history; the daemon need not be running) | `since`, `source` (`logs`/`events`/`stream`/`workflow`), `workflow_id`, `limit`, `project_root` |
 
 ---
@@ -167,9 +167,14 @@ approval gate stays human-only.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `animus.cost.decisions` | List recorded budget-cap breaches from the scoped breach log. Works offline (reads the scoped breach log; the daemon need not be running) | `since`, `project_root` |
-| `animus.budget.get` | Read the fleet budget posture: fleet daily spend cap, today's rolling-24h spend, remaining headroom, whether the cap is exceeded, whether dispatch is paused on the cap, and every configured per-workflow / per-phase budget cap. Works offline | `project_root` |
-| `animus.budget.set` | Set or clear the fleet daily spend cap (admin). Wraps `daemon config --max-daily-usd`; hot-reloaded by the running daemon | `max_daily_usd`, `clear`, `project_root` |
+| `animus.cost.decisions` | List recorded budget-cap breaches from the scoped breach log through a typed in-process service. Works offline (reads the scoped breach log; the daemon need not be running) | `since`, `project_root` |
+| `animus.budget.get` | Read the fleet budget posture through a typed in-process service: fleet daily spend cap, today's rolling-24h spend, remaining headroom, whether the cap is exceeded, whether dispatch is paused on the cap, and every configured per-workflow / per-phase budget cap. Works offline | `project_root` |
+| `animus.budget.set` | Set or clear the fleet daily spend cap (admin) through the shared typed daemon-configuration service; hot-reloaded by the running daemon | `max_daily_usd`, `clear`, `project_root` |
+
+The cost, budget, and daemon configuration tools above no longer spawn a child
+CLI or reconstruct command-line arguments. They remain management-only because
+the fleet cost state and daemon configuration are global stores without an
+actor-partitioned authorization protocol.
 
 ---
 


### PR DESCRIPTION
## Summary

- route cost decisions and budget reads/writes through typed in-process application services
- share one daemon-configuration service between CLI, daemon config MCP, and budget mutation
- accept structured notification configuration while retaining mutually exclusive JSON/file compatibility inputs
- document the management-only ownership boundary for global fleet state

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p orchestrator-cli --tests --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo animus-lint`
- `cargo test -p orchestrator-cli --locked -- --test-threads=1` (1,430 unit tests plus all integration suites)