### PR TITLE
refactor(mcp): type environment and log services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_environment.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_environment.rs
@@ -1,45 +1,161 @@
 use std::path::Path;
 
 use anyhow::Result;
-use orchestrator_core::EnvironmentClient;
-use serde_json::json;
+use orchestrator_core::{EnvironmentClient, EnvironmentNode};
+use serde::Serialize;
 
 use crate::{print_value, EnvironmentCommand};
+
+#[derive(Debug, Serialize)]
+pub(crate) struct EnvironmentListView {
+    environment: String,
+    nodes: Vec<EnvironmentNode>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct EnvironmentGetView {
+    environment: String,
+    node: Option<EnvironmentNode>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct EnvironmentTeardownView {
+    environment: String,
+    deleted: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct EnvironmentReapView {
+    environment: String,
+    deleted: Vec<String>,
+    kept: Vec<EnvironmentNode>,
+    dry_run: bool,
+}
+
+fn resolve_environment_client(project_root: &str, environment: Option<&str>) -> Result<EnvironmentClient> {
+    EnvironmentClient::resolve(Path::new(project_root), environment.unwrap_or(""))
+}
+
+pub(crate) fn environment_list_application(
+    project_root: &str,
+    environment: Option<&str>,
+) -> Result<EnvironmentListView> {
+    let client = resolve_environment_client(project_root, environment)?;
+    Ok(EnvironmentListView { environment: client.plugin_name().to_string(), nodes: client.list_nodes()? })
+}
+
+pub(crate) fn environment_get_application(
+    project_root: &str,
+    environment: Option<&str>,
+    id: &str,
+) -> Result<EnvironmentGetView> {
+    let client = resolve_environment_client(project_root, environment)?;
+    Ok(EnvironmentGetView { environment: client.plugin_name().to_string(), node: client.get_node(id)? })
+}
+
+pub(crate) fn environment_teardown_application(
+    project_root: &str,
+    environment: Option<&str>,
+    id: &str,
+) -> Result<EnvironmentTeardownView> {
+    let client = resolve_environment_client(project_root, environment)?;
+    Ok(EnvironmentTeardownView { environment: client.plugin_name().to_string(), deleted: client.teardown_node(id)? })
+}
+
+pub(crate) fn environment_reap_application(
+    project_root: &str,
+    environment: Option<&str>,
+    all: bool,
+    force: bool,
+    dry_run: bool,
+    older_than_secs: Option<u64>,
+) -> Result<EnvironmentReapView> {
+    let client = resolve_environment_client(project_root, environment)?;
+    let report = client.reap(all, force, dry_run, older_than_secs)?;
+    Ok(EnvironmentReapView {
+        environment: client.plugin_name().to_string(),
+        deleted: report.deleted,
+        kept: report.kept,
+        dry_run: report.dry_run,
+    })
+}
 
 /// Handle `animus environment {list,get,teardown,reap}` by driving the installed
 /// environment plugin's node-management surface. Each verb resolves the plugin
 /// (the sole installed one, or `--environment <id>`), issues the role call, and
 /// emits the `animus.cli.v1` envelope.
 pub async fn handle_environment(command: EnvironmentCommand, project_root: &str, json_output: bool) -> Result<()> {
-    let project_root = Path::new(project_root);
     match command {
         EnvironmentCommand::List(args) => {
-            let client = EnvironmentClient::resolve(project_root, args.environment.as_deref().unwrap_or(""))?;
-            let nodes = client.list_nodes()?;
-            print_value(json!({ "environment": client.plugin_name(), "nodes": nodes }), json_output)
+            print_value(environment_list_application(project_root, args.environment.as_deref())?, json_output)
         }
         EnvironmentCommand::Get(args) => {
-            let client = EnvironmentClient::resolve(project_root, args.environment.as_deref().unwrap_or(""))?;
-            let node = client.get_node(&args.id)?;
-            print_value(json!({ "environment": client.plugin_name(), "node": node }), json_output)
+            print_value(environment_get_application(project_root, args.environment.as_deref(), &args.id)?, json_output)
         }
-        EnvironmentCommand::Teardown(args) => {
-            let client = EnvironmentClient::resolve(project_root, args.environment.as_deref().unwrap_or(""))?;
-            let deleted = client.teardown_node(&args.id)?;
-            print_value(json!({ "environment": client.plugin_name(), "deleted": deleted }), json_output)
+        EnvironmentCommand::Teardown(args) => print_value(
+            environment_teardown_application(project_root, args.environment.as_deref(), &args.id)?,
+            json_output,
+        ),
+        EnvironmentCommand::Reap(args) => print_value(
+            environment_reap_application(
+                project_root,
+                args.environment.as_deref(),
+                args.all,
+                args.force,
+                args.dry_run,
+                args.older_than_secs,
+            )?,
+            json_output,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orchestrator_core::EnvironmentNode;
+    use serde_json::Value;
+
+    use super::{EnvironmentGetView, EnvironmentListView, EnvironmentReapView, EnvironmentTeardownView};
+
+    fn node() -> EnvironmentNode {
+        EnvironmentNode {
+            id: "node-1".to_string(),
+            name: "animus-run-1".to_string(),
+            state: "SUCCESS".to_string(),
+            run_id: Some("run-1".to_string()),
+            image: Some("animus:latest".to_string()),
+            created_at: Some("2026-07-29T00:00:00Z".to_string()),
+            orphan: false,
         }
-        EnvironmentCommand::Reap(args) => {
-            let client = EnvironmentClient::resolve(project_root, args.environment.as_deref().unwrap_or(""))?;
-            let report = client.reap(args.all, args.force, args.dry_run, args.older_than_secs)?;
-            print_value(
-                json!({
-                    "environment": client.plugin_name(),
-                    "deleted": report.deleted,
-                    "kept": report.kept,
-                    "dry_run": report.dry_run,
-                }),
-                json_output,
-            )
-        }
+    }
+
+    #[test]
+    fn typed_environment_views_preserve_the_existing_json_contract() {
+        let list =
+            serde_json::to_value(EnvironmentListView { environment: "fake-env".to_string(), nodes: vec![node()] })
+                .expect("serialize list");
+        assert_eq!(list.pointer("/nodes/0/run_id").and_then(Value::as_str), Some("run-1"));
+        assert_eq!(list.pointer("/nodes/0/orphan").and_then(Value::as_bool), Some(false));
+
+        let get = serde_json::to_value(EnvironmentGetView { environment: "fake-env".to_string(), node: Some(node()) })
+            .expect("serialize get");
+        assert_eq!(get.pointer("/node/image").and_then(Value::as_str), Some("animus:latest"));
+
+        let teardown = serde_json::to_value(EnvironmentTeardownView {
+            environment: "fake-env".to_string(),
+            deleted: vec!["node-1".to_string()],
+        })
+        .expect("serialize teardown");
+        assert_eq!(teardown.pointer("/deleted/0").and_then(Value::as_str), Some("node-1"));
+
+        let reap = serde_json::to_value(EnvironmentReapView {
+            environment: "fake-env".to_string(),
+            deleted: vec!["node-2".to_string()],
+            kept: vec![node()],
+            dry_run: true,
+        })
+        .expect("serialize reap");
+        assert_eq!(reap.get("dry_run").and_then(Value::as_bool), Some(true));
+        assert_eq!(reap.pointer("/kept/0/name").and_then(Value::as_str), Some("animus-run-1"));
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_logs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_logs.rs
@@ -17,7 +17,7 @@ use crate::{print_value, LogsCommand, LogsTailArgs};
 /// the wire branch projects back into the same response shape the
 /// in-tree branch emits.
 #[derive(Debug, Serialize)]
-struct WireLogEntryView {
+pub(crate) struct WireLogEntryView {
     ts: String,
     level: String,
     cat: String,
@@ -29,7 +29,7 @@ struct WireLogEntryView {
 }
 
 #[derive(Debug, Serialize)]
-struct LogsTailResponse {
+pub(crate) struct LogsTailResponse {
     backend: &'static str,
     plugin_name: Option<String>,
     project_root: String,
@@ -41,7 +41,7 @@ struct LogsTailResponse {
 }
 
 #[derive(Debug, Serialize)]
-struct WireLogsTailResponse {
+pub(crate) struct WireLogsTailResponse {
     backend: &'static str,
     plugin_name: Option<String>,
     project_root: String,
@@ -49,18 +49,99 @@ struct WireLogsTailResponse {
     entries: Vec<WireLogEntryView>,
 }
 
-pub(crate) async fn handle_logs(command: LogsCommand, project_root: &str, json: bool) -> Result<()> {
-    match command {
-        LogsCommand::Tail(args) => handle_logs_tail(args, project_root, json).await,
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum LogsTailApplicationResponse {
+    Local(LogsTailResponse),
+    Wire(WireLogsTailResponse),
+}
+
+impl LogsTailApplicationResponse {
+    fn entries_are_empty(&self) -> bool {
+        match self {
+            Self::Local(response) => response.entries.is_empty(),
+            Self::Wire(response) => response.entries.is_empty(),
+        }
+    }
+
+    fn local_plugin_fallback(&self) -> Option<&str> {
+        match self {
+            Self::Local(response) if response.backend == "plugin" && response.transport == "local" => {
+                response.plugin_name.as_deref()
+            }
+            _ => None,
+        }
+    }
+
+    fn render_human(&self) {
+        match self {
+            Self::Local(response) => {
+                for entry in &response.entries {
+                    let plugin_suffix =
+                        entry.provider.as_deref().map(|provider| format!(" [{provider}]")).unwrap_or_default();
+                    println!("{} {:>5} {}{} :: {}", entry.ts, entry.level, entry.cat, plugin_suffix, entry.msg);
+                }
+            }
+            Self::Wire(response) => {
+                for entry in &response.entries {
+                    let plugin_suffix =
+                        entry.provider.as_deref().map(|provider| format!(" [{provider}]")).unwrap_or_default();
+                    println!("{} {:>5} {}{} :: {}", entry.ts, entry.level, entry.cat, plugin_suffix, entry.msg);
+                }
+            }
+        }
     }
 }
 
-async fn handle_logs_tail(args: LogsTailArgs, project_root: &str, json: bool) -> Result<()> {
-    let level = parse_level(&args.level)?;
-    let since_duration = parse_duration(&args.since)?;
+#[derive(Debug, Clone)]
+pub(crate) struct LogsTailApplicationRequest {
+    pub(crate) plugin: Option<String>,
+    pub(crate) level: String,
+    pub(crate) since: String,
+    pub(crate) limit: usize,
+}
+
+impl From<LogsTailArgs> for LogsTailApplicationRequest {
+    fn from(args: LogsTailArgs) -> Self {
+        Self { plugin: args.plugin, level: args.level, since: args.since, limit: args.limit }
+    }
+}
+
+pub(crate) async fn handle_logs(command: LogsCommand, project_root: &str, json: bool) -> Result<()> {
+    match command {
+        LogsCommand::Tail(args) => {
+            let request = LogsTailApplicationRequest::from(args);
+            let response = logs_tail_application(request.clone(), project_root).await?;
+            if json {
+                return print_value(response, true);
+            }
+            if let Some(plugin) = response.local_plugin_fallback() {
+                eprintln!(
+                    "note: active backend is plugin '{}' but daemon is not running; \
+                     reading in-tree events.jsonl. Start the daemon (`animus daemon start`) \
+                     to route through the plugin.",
+                    plugin
+                );
+            }
+            if response.entries_are_empty() {
+                print_empty_logs_hint(&request.since, &request.level);
+            }
+            response.render_human();
+            Ok(())
+        }
+    }
+}
+
+pub(crate) async fn logs_tail_application(
+    request: LogsTailApplicationRequest,
+    project_root: &str,
+) -> Result<LogsTailApplicationResponse> {
+    let level = parse_level(&request.level).map_err(|error| crate::invalid_input_error(error.to_string()))?;
+    let since_duration =
+        parse_duration(&request.since).map_err(|error| crate::invalid_input_error(error.to_string()))?;
     let since_dt = Utc::now() - since_duration;
     let since_ts = since_dt.to_rfc3339();
-    let limit = args.limit.max(1);
+    let limit = request.limit.max(1);
 
     let resolution = resolve_log_storage_dispatch(Path::new(project_root))?;
     let backend_label: &'static str = match resolution.selected.as_ref() {
@@ -76,21 +157,15 @@ async fn handle_logs_tail(args: LogsTailArgs, project_root: &str, json: bool) ->
     // down: fall back to direct events.jsonl read so `animus logs tail`
     // keeps working without a daemon process.
     if let Some(entries) =
-        try_daemon_logs_via_control(project_root, level, &since_dt, args.plugin.as_deref(), limit).await?
+        try_daemon_logs_via_control(project_root, level, &since_dt, request.plugin.as_deref(), limit).await?
     {
-        if entries.is_empty() && !json {
-            print_empty_logs_hint(&args.since, &args.level);
-        }
-        return emit_wire_response(
-            WireLogsTailResponse {
-                backend: backend_label,
-                plugin_name,
-                project_root: project_root_for_response,
-                transport: "wire",
-                entries,
-            },
-            json,
-        );
+        return Ok(LogsTailApplicationResponse::Wire(WireLogsTailResponse {
+            backend: backend_label,
+            plugin_name,
+            project_root: project_root_for_response,
+            transport: "wire",
+            entries,
+        }));
     }
 
     // Daemon-down fallback: open events.jsonl directly through the
@@ -98,47 +173,28 @@ async fn handle_logs_tail(args: LogsTailArgs, project_root: &str, json: bool) ->
     match resolution.selected.as_ref() {
         LogStorageDispatch::InTree { project_root: pr } => {
             let logger = Logger::for_project(pr);
-            let entries = read_in_tree_entries(&logger, limit, level, since_ts.as_str(), args.plugin.as_deref());
-            if entries.is_empty() && !json {
-                print_empty_logs_hint(&args.since, &args.level);
-            }
-            emit_response(
-                LogsTailResponse {
-                    backend: "in_tree",
-                    plugin_name: None,
-                    project_root: pr.display().to_string(),
-                    transport: "local",
-                    entries,
-                },
-                json,
-            )
+            let entries = read_in_tree_entries(&logger, limit, level, since_ts.as_str(), request.plugin.as_deref());
+            Ok(LogsTailApplicationResponse::Local(LogsTailResponse {
+                backend: "in_tree",
+                plugin_name: None,
+                project_root: pr.display().to_string(),
+                transport: "local",
+                entries,
+            }))
         }
         LogStorageDispatch::Plugin { project_root: pr, plugin } => {
             // Daemon down: we can't reach the plugin, so degrade to the
-            // in-tree fallback file and tell the operator what happened.
+            // in-tree fallback file. The CLI renderer tells the operator what
+            // happened; typed application callers receive transport="local".
             let logger = Logger::for_project(pr);
-            let entries = read_in_tree_entries(&logger, limit, level, since_ts.as_str(), args.plugin.as_deref());
-            if !json {
-                eprintln!(
-                    "note: active backend is plugin '{}' but daemon is not running; \
-                     reading in-tree events.jsonl. Start the daemon (`animus daemon start`) \
-                     to route through the plugin.",
-                    plugin.name
-                );
-                if entries.is_empty() {
-                    print_empty_logs_hint(&args.since, &args.level);
-                }
-            }
-            emit_response(
-                LogsTailResponse {
-                    backend: "plugin",
-                    plugin_name: Some(plugin.name.clone()),
-                    project_root: pr.display().to_string(),
-                    transport: "local",
-                    entries,
-                },
-                json,
-            )
+            let entries = read_in_tree_entries(&logger, limit, level, since_ts.as_str(), request.plugin.as_deref());
+            Ok(LogsTailApplicationResponse::Local(LogsTailResponse {
+                backend: "plugin",
+                plugin_name: Some(plugin.name.clone()),
+                project_root: pr.display().to_string(),
+                transport: "local",
+                entries,
+            }))
         }
     }
 }
@@ -211,30 +267,6 @@ fn print_empty_logs_hint(since: &str, level: &str) {
         "no log entries in the last {since} (default --since 1h, --level {level}); \
          try --since 24h or --level debug"
     );
-}
-
-fn emit_response(response: LogsTailResponse, json: bool) -> Result<()> {
-    if json {
-        print_value(response, true)
-    } else {
-        for entry in &response.entries {
-            let plugin_suffix = entry.provider.as_deref().map(|p| format!(" [{}]", p)).unwrap_or_default();
-            println!("{} {:>5} {}{} :: {}", entry.ts, entry.level, entry.cat, plugin_suffix, entry.msg);
-        }
-        Ok(())
-    }
-}
-
-fn emit_wire_response(response: WireLogsTailResponse, json: bool) -> Result<()> {
-    if json {
-        print_value(response, true)
-    } else {
-        for entry in &response.entries {
-            let plugin_suffix = entry.provider.as_deref().map(|p| format!(" [{}]", p)).unwrap_or_default();
-            println!("{} {:>5} {}{} :: {}", entry.ts, entry.level, entry.cat, plugin_suffix, entry.msg);
-        }
-        Ok(())
-    }
 }
 
 fn read_in_tree_entries(

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -51,6 +51,8 @@ mod daemon_inproc;
 mod daemon_inputs;
 #[path = "ops_mcp/daemon_tools.rs"]
 mod daemon_tools;
+#[path = "ops_mcp/environment_inproc.rs"]
+mod environment_inproc;
 #[path = "ops_mcp/environment_tools.rs"]
 mod environment_tools;
 #[path = "ops_mcp/exec.rs"]
@@ -67,6 +69,8 @@ mod list_guard;
 mod list_profiles;
 #[path = "ops_mcp/list_types.rs"]
 mod list_types;
+#[path = "ops_mcp/logs_inproc.rs"]
+mod logs_inproc;
 #[path = "ops_mcp/logs_tools.rs"]
 mod logs_tools;
 #[path = "ops_mcp/memory_tools.rs"]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/environment_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/environment_inproc.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use rmcp::model::CallToolResult;
+use serde::Serialize;
+use serde_json::json;
+
+use super::daemon_inproc::resolve_project_root;
+use super::environment_tools::{
+    EnvironmentGetInput, EnvironmentListInput, EnvironmentReapInput, EnvironmentTeardownInput,
+};
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::AoMcpServer;
+use crate::services::operations::{
+    environment_get_application, environment_list_application, environment_reap_application,
+    environment_teardown_application,
+};
+
+impl AoMcpServer {
+    fn run_environment_application<T, F>(
+        &self,
+        tool_name: &str,
+        project_root: Option<String>,
+        call: F,
+    ) -> CallToolResult
+    where
+        T: Serialize,
+        F: FnOnce(&str) -> Result<T>,
+    {
+        self.audit_actor_tool_decision(tool_name, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        match call(&project_root) {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)),
+        }
+    }
+
+    pub(super) fn environment_list_inproc(&self, input: EnvironmentListInput) -> CallToolResult {
+        self.run_environment_application("animus.environment.list", input.project_root, |root| {
+            environment_list_application(root, input.environment.as_deref())
+        })
+    }
+
+    pub(super) fn environment_get_inproc(&self, input: EnvironmentGetInput) -> CallToolResult {
+        self.run_environment_application("animus.environment.get", input.project_root, |root| {
+            environment_get_application(root, input.environment.as_deref(), &input.id)
+        })
+    }
+
+    pub(super) fn environment_teardown_inproc(&self, input: EnvironmentTeardownInput) -> CallToolResult {
+        self.run_environment_application("animus.environment.teardown", input.project_root, |root| {
+            environment_teardown_application(root, input.environment.as_deref(), &input.id)
+        })
+    }
+
+    pub(super) fn environment_reap_inproc(&self, input: EnvironmentReapInput) -> CallToolResult {
+        self.run_environment_application("animus.environment.reap", input.project_root, |root| {
+            environment_reap_application(
+                root,
+                input.environment.as_deref(),
+                input.all,
+                input.force,
+                input.dry_run,
+                input.older_than_secs,
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::super::environment_tools::EnvironmentListInput;
+    use super::super::new_ao_mcp_server;
+
+    #[test]
+    fn environment_mcp_uses_the_typed_service_and_returns_structured_errors() {
+        let temp = tempfile::tempdir().expect("project root");
+        let server = new_ao_mcp_server(temp.path().to_string_lossy().as_ref());
+        let result = server.environment_list_inproc(EnvironmentListInput { environment: None, project_root: None });
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed environment error");
+        assert_eq!(payload.get("tool").and_then(Value::as_str), Some("animus.environment.list"));
+        assert!(
+            payload
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| message.contains("no environment plugin is installed")),
+            "{payload}"
+        );
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/environment_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/environment_tools.rs
@@ -1,10 +1,9 @@
 //! `animus.environment.*` MCP tools.
 //!
 //! Surface the CLI's `animus environment {list,get,teardown,reap}` node-
-//! management verbs through MCP so agents + the portal can inspect and reap
-//! ephemeral run nodes without shelling out. Mirrors the logs_tools pattern —
-//! typed input struct, args builder, `run_tool` shell-out — so the environment
-//! plugin's node-management logic is shared between the CLI and MCP callers.
+//! management verbs through typed application services so agents + the portal
+//! can inspect and reap ephemeral run nodes without a child CLI. The installed
+//! environment plugin remains the intentional out-of-process state owner.
 
 use super::*;
 
@@ -57,43 +56,6 @@ pub(super) struct EnvironmentReapInput {
     pub(super) project_root: Option<String>,
 }
 
-pub(super) fn build_environment_list_args(input: &EnvironmentListInput) -> Vec<String> {
-    let mut args = vec!["environment".to_string(), "list".to_string()];
-    push_opt(&mut args, "--environment", input.environment.clone());
-    args
-}
-
-pub(super) fn build_environment_get_args(input: &EnvironmentGetInput) -> Vec<String> {
-    let mut args = vec!["environment".to_string(), "get".to_string(), input.id.clone()];
-    push_opt(&mut args, "--environment", input.environment.clone());
-    args
-}
-
-pub(super) fn build_environment_teardown_args(input: &EnvironmentTeardownInput) -> Vec<String> {
-    let mut args = vec!["environment".to_string(), "teardown".to_string(), input.id.clone()];
-    push_opt(&mut args, "--environment", input.environment.clone());
-    args
-}
-
-pub(super) fn build_environment_reap_args(input: &EnvironmentReapInput) -> Vec<String> {
-    let mut args = vec!["environment".to_string(), "reap".to_string()];
-    if input.all {
-        args.push("--all".to_string());
-    }
-    if input.force {
-        args.push("--force".to_string());
-    }
-    if input.dry_run {
-        args.push("--dry-run".to_string());
-    }
-    if let Some(secs) = input.older_than_secs {
-        args.push("--older-than-secs".to_string());
-        args.push(secs.to_string());
-    }
-    push_opt(&mut args, "--environment", input.environment.clone());
-    args
-}
-
 #[tool_router(router = environment_tool_router, vis = "pub(super)")]
 impl AoMcpServer {
     #[tool(
@@ -102,10 +64,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<EnvironmentListInput>()
     )]
     async fn ao_environment_list(&self, params: Parameters<EnvironmentListInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let project_root = input.project_root.clone();
-        let args = build_environment_list_args(&input);
-        self.run_tool("animus.environment.list", args, project_root).await
+        Ok(self.environment_list_inproc(params.0))
     }
 
     #[tool(
@@ -114,10 +73,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<EnvironmentGetInput>()
     )]
     async fn ao_environment_get(&self, params: Parameters<EnvironmentGetInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let project_root = input.project_root.clone();
-        let args = build_environment_get_args(&input);
-        self.run_tool("animus.environment.get", args, project_root).await
+        Ok(self.environment_get_inproc(params.0))
     }
 
     #[tool(
@@ -129,10 +85,7 @@ impl AoMcpServer {
         &self,
         params: Parameters<EnvironmentTeardownInput>,
     ) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let project_root = input.project_root.clone();
-        let args = build_environment_teardown_args(&input);
-        self.run_tool("animus.environment.teardown", args, project_root).await
+        Ok(self.environment_teardown_inproc(params.0))
     }
 
     #[tool(
@@ -141,9 +94,6 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<EnvironmentReapInput>()
     )]
     async fn ao_environment_reap(&self, params: Parameters<EnvironmentReapInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let project_root = input.project_root.clone();
-        let args = build_environment_reap_args(&input);
-        self.run_tool("animus.environment.reap", args, project_root).await
+        Ok(self.environment_reap_inproc(params.0))
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/logs_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/logs_inproc.rs
@@ -1,0 +1,60 @@
+use rmcp::model::CallToolResult;
+use serde_json::json;
+
+use super::daemon_inproc::resolve_project_root;
+use super::exec_errors::build_inproc_tool_error_payload;
+use super::logs_tools::LogsTailInput;
+use super::AoMcpServer;
+use crate::services::operations::{logs_tail_application, LogsTailApplicationRequest};
+
+impl AoMcpServer {
+    pub(super) async fn logs_tail_inproc(&self, input: LogsTailInput) -> CallToolResult {
+        self.audit_actor_tool_decision("animus.logs.tail", false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, input.project_root);
+        let request = LogsTailApplicationRequest {
+            plugin: input.plugin,
+            level: input.level.unwrap_or_else(|| "info".to_string()),
+            since: input.since.unwrap_or_else(|| "1h".to_string()),
+            limit: input.limit.map(|limit| limit as usize).unwrap_or(100),
+        };
+        match logs_tail_application(request, &project_root).await {
+            Ok(result) => CallToolResult::structured(json!({ "tool": "animus.logs.tail", "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload("animus.logs.tail", &error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::super::logs_tools::LogsTailInput;
+    use super::super::new_ao_mcp_server;
+
+    #[tokio::test]
+    async fn logs_tail_validation_is_typed_and_in_process() {
+        let temp = tempfile::tempdir().expect("project root");
+        let server = new_ao_mcp_server(temp.path().to_string_lossy().as_ref());
+        let result = server
+            .logs_tail_inproc(LogsTailInput {
+                plugin: None,
+                level: Some("trace".to_string()),
+                since: None,
+                limit: None,
+                project_root: None,
+            })
+            .await;
+
+        assert_eq!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed log error");
+        assert_eq!(payload.get("tool").and_then(Value::as_str), Some("animus.logs.tail"));
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"));
+        assert!(
+            payload
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| message.contains("expected one of debug|info|warn|error")),
+            "{payload}"
+        );
+    }
+}

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/logs_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/logs_tools.rs
@@ -1,10 +1,9 @@
 //! `animus.logs.*` MCP tools.
 //!
-//! v0.4.7 Item 2: surface the CLI's `animus logs tail` through MCP so
-//! agents can pull the daemon's log tail without shelling out. Mirrors
-//! the subject_tools pattern — typed input struct, args builder,
-//! `run_tool` shell-out — so the wire/local fallback logic in
-//! `ops_logs::handle_logs_tail` is shared between CLI and MCP callers.
+//! Surface the CLI's `animus logs tail` through a typed application service so
+//! agents can pull the daemon's log tail without a child CLI. The service keeps
+//! the daemon control-wire and local events.jsonl fallback logic shared between
+//! CLI and MCP callers.
 
 use super::*;
 
@@ -29,18 +28,6 @@ pub(super) struct LogsTailInput {
     pub(super) project_root: Option<String>,
 }
 
-pub(super) fn build_logs_tail_args(input: &LogsTailInput) -> Vec<String> {
-    let mut args = vec!["logs".to_string(), "tail".to_string()];
-    push_opt(&mut args, "--plugin", input.plugin.clone());
-    push_opt(&mut args, "--level", input.level.clone());
-    push_opt(&mut args, "--since", input.since.clone());
-    if let Some(limit) = input.limit {
-        args.push("--limit".to_string());
-        args.push(limit.to_string());
-    }
-    args
-}
-
 #[tool_router(router = logs_tool_router, vis = "pub(super)")]
 impl AoMcpServer {
     #[tool(
@@ -49,52 +36,6 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<LogsTailInput>()
     )]
     async fn ao_logs_tail(&self, params: Parameters<LogsTailInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let project_root = input.project_root.clone();
-        let args = build_logs_tail_args(&input);
-        self.run_tool("animus.logs.tail", args, project_root).await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tail_args_defaults_to_logs_tail() {
-        let input = LogsTailInput { plugin: None, level: None, since: None, limit: None, project_root: None };
-        let args = build_logs_tail_args(&input);
-        assert_eq!(args, vec!["logs", "tail"]);
-    }
-
-    #[test]
-    fn tail_args_includes_optional_flags_when_provided() {
-        let input = LogsTailInput {
-            plugin: Some("kimi-code".to_string()),
-            level: Some("warn".to_string()),
-            since: Some("30m".to_string()),
-            limit: Some(25),
-            project_root: None,
-        };
-        let args = build_logs_tail_args(&input);
-        assert_eq!(
-            args,
-            vec!["logs", "tail", "--plugin", "kimi-code", "--level", "warn", "--since", "30m", "--limit", "25"]
-        );
-    }
-
-    #[test]
-    fn tail_args_project_root_does_not_leak_into_cli_args() {
-        // project_root is consumed by run_tool's working-dir override, not
-        // emitted as a CLI flag; the args list should be free of it.
-        let input = LogsTailInput {
-            plugin: None,
-            level: None,
-            since: None,
-            limit: None,
-            project_root: Some("/tmp/somewhere".to_string()),
-        };
-        let args = build_logs_tail_args(&input);
-        assert!(!args.iter().any(|a| a.contains("/tmp/somewhere")));
+        Ok(self.logs_tail_inproc(params.0).await)
     }
 }

--- a/docs/architecture/actor-bound-application-contract.md
+++ b/docs/architecture/actor-bound-application-contract.md
@@ -209,6 +209,15 @@ These surfaces remain absent from actor-bound MCP until their protocols change:
   fleet daily budget. The underlying cost state and daemon configuration are
   still global stores with no actor field or authorization context, so these
   tools remain management-only.
+- Environment node management: list/get/teardown/reap use shared typed
+  in-process application services, then call the installed environment plugin
+  through its typed protocol. That protocol has no actor field and the plugin's
+  nodes are not yet guaranteed to be user/tenant partitioned, so the tools
+  remain management-only.
+- Log tail: the CLI and MCP share one typed service for daemon-wire and local
+  fallback reads, but project log records are not uniformly actor-attributable
+  and the log-storage protocol has no actor authorization context. The tool
+  remains management-only.
 - MCP resources: list/read resource requests need the same typed actor/request
   context and backend enforcement.
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -252,11 +252,35 @@ path, so the MCP and CLI surfaces cannot drift. Prefer the structured
 These fleet-wide stores are management-only until their protocols support
 actor-partitioned authorization.
 
+## Environment Operations
+
+Environment list/get/teardown/reap tools share typed in-process application
+services with the CLI. The installed environment plugin still owns the remote
+node lifecycle through its typed protocol; MCP no longer rebuilds CLI argv or
+spawns a child Animus process.
+
+```json
+{}                                                   // animus.environment.list
+{ "id": "animus-run-abc123" }                        // animus.environment.get
+{ "id": "animus-run-abc123" }                        // animus.environment.teardown
+{ "dry_run": true, "older_than_secs": 3600 }         // animus.environment.reap preview
+{ "all": true, "force": true }                       // also reap healthy orphans
+```
+
+These tools remain management-only until the environment node-management
+protocol carries an authenticated actor and the owning plugin enforces its
+user/tenant partition.
+
 ## Output and Logs Operations
 
 Use output tools for run artifacts and structured execution streams. Use
 `animus.logs.tail` for recent daemon-level logs. This MCP tool is a bounded
 pull, not a live follow stream.
+
+Log tail also executes through a shared typed in-process service. It preserves
+the daemon control-wire path and local `events.jsonl` fallback without a child
+CLI. It remains management-only because project logs and the log-storage
+protocol are not actor-partitioned.
 
 Output reads execute through typed in-process services rather than a child CLI.
 Actor-bound application hosts expose run and phase-output reads only; both

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -200,9 +200,10 @@ plugin (e.g. `linear`, `jira`, `github-issue`).
 
 ## Log Operations (1 tool)
 
-Surfaces the CLI's `animus logs tail` to MCP callers. Routes through the daemon
+Surfaces the CLI's `animus logs tail` to MCP callers through the same typed
+in-process application service used by the CLI. It routes through the daemon
 control wire when the daemon is running, otherwise reads the in-tree
-`events.jsonl` fallback directly.
+`events.jsonl` fallback directly; it no longer spawns a child CLI.
 
 Unlike the CLI, the MCP surface does not expose `--follow`; this tool is a
 bounded fetch for recent entries, not a live stream.
@@ -211,16 +212,22 @@ bounded fetch for recent entries, not a live stream.
 |---|---|---|
 | `animus.logs.tail` | Tail recent log entries from the active `log_storage_backend` | `plugin`, `level`, `since`, `limit`, `project_root` |
 
+Log tail remains management-only because project log entries are not uniformly
+attributable to an authenticated actor and the storage protocol has no actor
+authorization context.
+
 ---
 
 ## Environment Operations (4 tools)
 
 Surface the CLI's `animus environment {list,get,teardown,reap}` node-management
-verbs to MCP callers. They drive the installed `environment` plugin's node-
-management surface (`environment/list` · `/get` · `/teardown_node` · `/reap`) so
-agents + the portal can inspect and reap ephemeral run nodes without a dashboard
-delete. `reap` defaults to deleting only DEAD (FAILED/CRASHED) nodes — always
-safe, since a live node is never dead; `all`+`force` also reaps healthy orphans.
+verbs to MCP callers through the same typed in-process application services used
+by the CLI. Those services drive the installed `environment` plugin's typed
+node-management protocol (`environment/list` · `/get` · `/teardown_node` ·
+`/reap`), so the plugin remains the intentional out-of-process state owner while
+the redundant child-CLI/argv hop is removed. `reap` defaults to deleting only
+DEAD (FAILED/CRASHED) nodes — always safe, since a live node is never dead;
+`all`+`force` also reaps healthy orphans.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
@@ -228,6 +235,9 @@ safe, since a live node is never dead; `all`+`force` also reaps healthy orphans.
 | `animus.environment.get` | Describe one managed node by substrate id or name | `id`, `environment`, `project_root` |
 | `animus.environment.teardown` | Destroy one managed node by substrate id or name (idempotent) | `id`, `environment`, `project_root` |
 | `animus.environment.reap` | Reap orphaned/dead nodes (default: only dead) | `all`, `force`, `dry_run`, `older_than_secs`, `environment`, `project_root` |
+
+Environment tools remain management-only because the node-management protocol
+does not carry an authenticated actor or partition nodes by user and tenant.
 
 ---
 


### PR DESCRIPTION
## Summary
- route environment list/get/teardown/reap through shared typed in-process application services
- route log tail through a shared typed service while preserving daemon-wire and local fallback behavior
- remove redundant MCP child-CLI argv hops and document the management-only actor boundaries

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo check -p orchestrator-cli --tests --locked`
- focused environment and log MCP/contract tests
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo animus-lint`
- `cargo test -p orchestrator-cli --locked -- --test-threads=1` (1,430 unit tests plus all integration suites passed)