### PR TITLE
refactor(mcp): type daemon lifecycle services

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp.rs
@@ -128,9 +128,7 @@ use common_types::*;
 #[cfg(test)]
 use compaction::compact_json_str;
 use compaction::compact_json_text;
-use daemon::{
-    build_daemon_events_poll_result, build_daemon_logs_result, build_daemon_observe_args, build_daemon_start_args,
-};
+use daemon::{build_daemon_events_poll_result, build_daemon_logs_result};
 #[cfg(test)]
 use daemon::{daemon_events_poll_limit, resolve_daemon_events_project_root};
 use daemon_inputs::*;
@@ -221,21 +219,7 @@ fn push_opt(args: &mut Vec<String>, flag: &str, value: Option<String>) {
     }
 }
 
-fn push_bool_set(args: &mut Vec<String>, flag: &str, value: Option<bool>) {
-    if let Some(v) = value {
-        args.push(flag.to_string());
-        args.push(v.to_string());
-    }
-}
-
 fn push_opt_num(args: &mut Vec<String>, flag: &str, value: Option<u64>) {
-    if let Some(v) = value {
-        args.push(flag.to_string());
-        args.push(v.to_string());
-    }
-}
-
-fn push_opt_usize(args: &mut Vec<String>, flag: &str, value: Option<usize>) {
     if let Some(v) = value {
         args.push(flag.to_string());
         args.push(v.to_string());

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon.rs
@@ -1,35 +1,8 @@
-use super::{
-    push_bool_set, push_opt, push_opt_num, push_opt_usize, DaemonEventsInput, DaemonLogsInput, DaemonObserveInput,
-    DaemonStartInput, DEFAULT_DAEMON_EVENTS_LIMIT, MAX_DAEMON_EVENTS_LIMIT,
-};
+use super::{DaemonEventsInput, DaemonLogsInput, DEFAULT_DAEMON_EVENTS_LIMIT, MAX_DAEMON_EVENTS_LIMIT};
 use anyhow::Result;
 use serde_json::{json, Value};
 
 const DEFAULT_DAEMON_LOGS_LIMIT: usize = 100;
-
-pub(super) fn build_daemon_start_args(input: &DaemonStartInput) -> Vec<String> {
-    let mut args = vec!["daemon".to_string(), "start".to_string()];
-    push_opt_usize(&mut args, "--pool-size", input.pool_size);
-    push_opt_num(&mut args, "--interval-secs", input.interval_secs);
-    push_opt_num(&mut args, "--stale-threshold-hours", input.stale_threshold_hours);
-    push_opt_usize(&mut args, "--max-tasks-per-tick", input.max_tasks_per_tick);
-    push_opt_num(&mut args, "--phase-timeout-secs", input.phase_timeout_secs);
-    push_bool_set(&mut args, "--startup-cleanup", input.startup_cleanup);
-    push_bool_set(&mut args, "--reconcile-stale", input.reconcile_stale);
-    args
-}
-
-/// Builds args for `daemon observe`. The MCP surface deliberately never sets
-/// `--follow`: it returns the merged window the CLI's non-streaming path
-/// produces, so the tool always terminates.
-pub(super) fn build_daemon_observe_args(input: &DaemonObserveInput) -> Vec<String> {
-    let mut args = vec!["daemon".to_string(), "observe".to_string()];
-    push_opt(&mut args, "--since", input.since.clone());
-    push_opt(&mut args, "--source", input.source.clone());
-    push_opt(&mut args, "--workflow", input.workflow_id.clone());
-    push_opt_usize(&mut args, "--limit", input.limit);
-    args
-}
 
 pub(super) fn daemon_events_poll_limit(limit: Option<usize>) -> usize {
     let normalized = limit.unwrap_or(DEFAULT_DAEMON_EVENTS_LIMIT).max(1);
@@ -89,47 +62,4 @@ pub(super) fn build_daemon_logs_result(default_project_root: &str, input: Daemon
         "lines": lines,
         "has_more": has_more,
     }))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn build_daemon_observe_args_defaults_minimal() {
-        let args = build_daemon_observe_args(&DaemonObserveInput::default());
-        assert_eq!(args, vec!["daemon".to_string(), "observe".to_string()]);
-        // Never streams: --follow must never appear.
-        assert!(!args.contains(&"--follow".to_string()));
-    }
-
-    #[test]
-    fn build_daemon_observe_args_wires_all_params_without_follow() {
-        let input = DaemonObserveInput {
-            since: Some("2h".to_string()),
-            source: Some("events".to_string()),
-            workflow_id: Some("wf-abc123".to_string()),
-            limit: Some(50),
-            project_root: Some("/repo".to_string()),
-        };
-
-        let args = build_daemon_observe_args(&input);
-
-        assert_eq!(
-            args,
-            vec![
-                "daemon".to_string(),
-                "observe".to_string(),
-                "--since".to_string(),
-                "2h".to_string(),
-                "--source".to_string(),
-                "events".to_string(),
-                "--workflow".to_string(),
-                "wf-abc123".to_string(),
-                "--limit".to_string(),
-                "50".to_string(),
-            ]
-        );
-        assert!(!args.contains(&"--follow".to_string()));
-    }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inproc.rs
@@ -1,16 +1,20 @@
 use anyhow::{Context, Result};
-use orchestrator_core::DaemonStatus;
+use orchestrator_core::{DaemonStatus, FileServiceHub};
 use orchestrator_daemon_runtime::control::ControlClient;
 use protocol::is_process_alive;
 use serde_json::{json, Value};
 use std::path::Path;
+use std::sync::Arc;
 
 use super::exec_errors::build_inproc_tool_error_payload;
 use super::AoMcpServer;
 use crate::services::runtime::{
-    canonicalize_lossy, daemon_config_application, overlay_budget_health, overlay_daily_cap_status,
-    overlay_runtime_pause, read_daemon_pid, remove_daemon_pid, set_daemon_pid, DaemonConfigApplicationRequest,
+    canonicalize_lossy, daemon_config_application, daemon_observe_application, daemon_pause_application,
+    daemon_resume_application, daemon_start_application, daemon_stop_application, overlay_budget_health,
+    overlay_daily_cap_status, overlay_runtime_pause, read_daemon_pid, remove_daemon_pid, set_daemon_pid,
+    DaemonConfigApplicationRequest, DaemonObserveApplicationRequest,
 };
+use crate::{DaemonSchedulerArgs, DaemonStartArgs, ObserveSource};
 use rmcp::model::CallToolResult;
 
 pub(super) fn resolve_project_root(default_root: &str, override_value: Option<String>) -> String {
@@ -150,6 +154,130 @@ fn notification_config_from_input(input: &super::DaemonConfigSetInput) -> Result
 }
 
 impl AoMcpServer {
+    fn daemon_start_args(input: &super::DaemonStartInput) -> Result<DaemonStartArgs> {
+        fn require_positive<T>(name: &str, value: Option<T>) -> Result<()>
+        where
+            T: PartialEq + From<u8>,
+        {
+            if value.is_some_and(|value| value == T::from(0)) {
+                return Err(crate::invalid_input_error(format!("{name} must be greater than zero")));
+            }
+            Ok(())
+        }
+
+        require_positive("pool_size", input.pool_size)?;
+        require_positive("interval_secs", input.interval_secs)?;
+        require_positive("stale_threshold_hours", input.stale_threshold_hours)?;
+        require_positive("max_tasks_per_tick", input.max_tasks_per_tick)?;
+        require_positive("phase_timeout_secs", input.phase_timeout_secs)?;
+
+        Ok(DaemonStartArgs {
+            scheduler: DaemonSchedulerArgs {
+                pool_size: input.pool_size,
+                interval_secs: input.interval_secs,
+                startup_cleanup: input.startup_cleanup.unwrap_or(true),
+                reconcile_stale: input.reconcile_stale.unwrap_or(true),
+                stale_threshold_hours: input.stale_threshold_hours,
+                max_tasks_per_tick: input.max_tasks_per_tick,
+                phase_timeout_secs: input.phase_timeout_secs,
+            },
+            auto_install: input.auto_install,
+            skip_preflight: input.skip_preflight,
+        })
+    }
+
+    fn daemon_observe_request(input: super::DaemonObserveInput) -> Result<DaemonObserveApplicationRequest> {
+        if input.limit == Some(0) {
+            return Err(crate::invalid_input_error("limit must be greater than zero"));
+        }
+        let source = match input.source.as_deref() {
+            None => None,
+            Some("events") => Some(ObserveSource::Events),
+            Some("logs") => Some(ObserveSource::Logs),
+            Some("stream") => Some(ObserveSource::Stream),
+            Some("workflow") => Some(ObserveSource::Workflow),
+            Some(value) => {
+                return Err(crate::invalid_input_error(format!(
+                    "invalid source '{value}'; expected events|logs|stream|workflow"
+                )));
+            }
+        };
+        Ok(DaemonObserveApplicationRequest {
+            since: input.since,
+            source,
+            workflow: input.workflow_id,
+            limit: input.limit.unwrap_or(20),
+        })
+    }
+
+    pub(super) async fn daemon_start_inproc(&self, input: super::DaemonStartInput) -> CallToolResult {
+        const TOOL: &str = "animus.daemon.start";
+        self.audit_actor_tool_decision(TOOL, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, input.project_root.clone());
+        let args = match Self::daemon_start_args(&input) {
+            Ok(args) => args,
+            Err(error) => return CallToolResult::structured_error(build_inproc_tool_error_payload(TOOL, &error)),
+        };
+        match daemon_start_application(args, &project_root).await {
+            Ok(result) => CallToolResult::structured(json!({ "tool": TOOL, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(TOOL, &error)),
+        }
+    }
+
+    pub(super) async fn daemon_stop_inproc(&self, project_root: Option<String>) -> CallToolResult {
+        const TOOL: &str = "animus.daemon.stop";
+        self.audit_actor_tool_decision(TOOL, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        let result = FileServiceHub::new(&project_root).map(Arc::new);
+        match result {
+            Ok(hub) => match daemon_stop_application(hub, &project_root, 60).await {
+                Ok(result) => CallToolResult::structured(json!({ "tool": TOOL, "result": result })),
+                Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(TOOL, &error)),
+            },
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(TOOL, &error)),
+        }
+    }
+
+    async fn daemon_pause_resume_inproc(&self, tool: &'static str, project_root: Option<String>) -> CallToolResult {
+        self.audit_actor_tool_decision(tool, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        let hub = match FileServiceHub::new(&project_root) {
+            Ok(hub) => Arc::new(hub),
+            Err(error) => return CallToolResult::structured_error(build_inproc_tool_error_payload(tool, &error)),
+        };
+        let result = if tool == "animus.daemon.pause" {
+            daemon_pause_application(hub, &project_root).await
+        } else {
+            daemon_resume_application(hub, &project_root).await
+        };
+        match result {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool, &error)),
+        }
+    }
+
+    pub(super) async fn daemon_pause_inproc(&self, project_root: Option<String>) -> CallToolResult {
+        self.daemon_pause_resume_inproc("animus.daemon.pause", project_root).await
+    }
+
+    pub(super) async fn daemon_resume_inproc(&self, project_root: Option<String>) -> CallToolResult {
+        self.daemon_pause_resume_inproc("animus.daemon.resume", project_root).await
+    }
+
+    pub(super) fn daemon_observe_inproc(&self, input: super::DaemonObserveInput) -> CallToolResult {
+        const TOOL: &str = "animus.daemon.observe";
+        self.audit_actor_tool_decision(TOOL, false, "management-only");
+        let project_root = resolve_project_root(&self.default_project_root, input.project_root.clone());
+        let request = match Self::daemon_observe_request(input) {
+            Ok(request) => request,
+            Err(error) => return CallToolResult::structured_error(build_inproc_tool_error_payload(TOOL, &error)),
+        };
+        match daemon_observe_application(request, &project_root) {
+            Ok(result) => CallToolResult::structured(json!({ "tool": TOOL, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(TOOL, &error)),
+        }
+    }
+
     fn run_daemon_config_application(
         &self,
         tool_name: &str,
@@ -267,5 +395,51 @@ mod config_tests {
         assert_eq!(result.is_error, Some(true));
         let payload = result.structured_content.expect("typed conflict error");
         assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"), "{payload}");
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use serde_json::Value;
+
+    use super::super::{new_ao_mcp_server, DaemonObserveInput, DaemonStartInput};
+
+    #[test]
+    fn daemon_start_input_is_typed_and_rejects_zero_before_spawning() {
+        let input = DaemonStartInput { interval_secs: Some(0), ..Default::default() };
+        let error = super::AoMcpServer::daemon_start_args(&input).expect_err("zero interval must be rejected");
+        assert!(error.to_string().contains("interval_secs must be greater than zero"), "{error:#}");
+
+        let input = DaemonStartInput {
+            pool_size: Some(4),
+            startup_cleanup: Some(false),
+            reconcile_stale: Some(false),
+            auto_install: true,
+            skip_preflight: true,
+            ..Default::default()
+        };
+        let args = super::AoMcpServer::daemon_start_args(&input).expect("typed start args");
+        assert_eq!(args.scheduler.pool_size, Some(4));
+        assert!(!args.scheduler.startup_cleanup);
+        assert!(!args.scheduler.reconcile_stale);
+        assert!(args.auto_install);
+        assert!(args.skip_preflight);
+    }
+
+    #[test]
+    fn daemon_observe_runs_in_process_and_returns_structured_validation_errors() {
+        let temp = tempfile::tempdir().expect("project root");
+        let server = new_ao_mcp_server(temp.path().to_string_lossy().as_ref());
+        let invalid = server
+            .daemon_observe_inproc(DaemonObserveInput { source: Some("unknown".to_string()), ..Default::default() });
+        assert_eq!(invalid.is_error, Some(true));
+        let payload = invalid.structured_content.expect("typed error payload");
+        assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("invalid_input"));
+
+        let result = server.daemon_observe_inproc(DaemonObserveInput::default());
+        assert_ne!(result.is_error, Some(true));
+        let payload = result.structured_content.expect("typed observe payload");
+        assert!(payload.pointer("/result/matrix").and_then(Value::as_array).is_some());
+        assert!(payload.pointer("/result/recent").and_then(Value::as_array).is_some());
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_inputs.rs
@@ -17,6 +17,10 @@ pub(super) struct DaemonStartInput {
     #[serde(default)]
     pub(super) reconcile_stale: Option<bool>,
     #[serde(default)]
+    pub(super) auto_install: bool,
+    #[serde(default)]
+    pub(super) skip_preflight: bool,
+    #[serde(default)]
     pub(super) project_root: Option<String>,
 }
 

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/daemon_tools.rs
@@ -10,9 +10,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<DaemonStartInput>()
     )]
     async fn ao_daemon_start(&self, params: Parameters<DaemonStartInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = build_daemon_start_args(&input);
-        self.run_tool("animus.daemon.start", args, input.project_root).await
+        Ok(self.daemon_start_inproc(params.0).await)
     }
 
     #[tool(
@@ -21,7 +19,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ProjectRootInput>()
     )]
     async fn ao_daemon_stop(&self, params: Parameters<ProjectRootInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool("animus.daemon.stop", vec!["daemon".to_string(), "stop".to_string()], params.0.project_root).await
+        Ok(self.daemon_stop_inproc(params.0.project_root).await)
     }
 
     #[tool(
@@ -64,8 +62,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ProjectRootInput>()
     )]
     async fn ao_daemon_pause(&self, params: Parameters<ProjectRootInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool("animus.daemon.pause", vec!["daemon".to_string(), "pause".to_string()], params.0.project_root)
-            .await
+        Ok(self.daemon_pause_inproc(params.0.project_root).await)
     }
 
     #[tool(
@@ -74,8 +71,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<ProjectRootInput>()
     )]
     async fn ao_daemon_resume(&self, params: Parameters<ProjectRootInput>) -> Result<CallToolResult, McpError> {
-        self.run_tool("animus.daemon.resume", vec!["daemon".to_string(), "resume".to_string()], params.0.project_root)
-            .await
+        Ok(self.daemon_resume_inproc(params.0.project_root).await)
     }
 
     #[tool(
@@ -155,8 +151,6 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<DaemonObserveInput>()
     )]
     async fn ao_daemon_observe(&self, params: Parameters<DaemonObserveInput>) -> Result<CallToolResult, McpError> {
-        let input = params.0;
-        let args = build_daemon_observe_args(&input);
-        self.run_tool("animus.daemon.observe", args, input.project_root).await
+        Ok(self.daemon_observe_inproc(params.0))
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/tests.rs
@@ -805,30 +805,6 @@ fn build_guarded_list_result_rejects_non_array_payloads() {
 }
 
 #[test]
-fn build_daemon_start_args_defaults_minimal() {
-    let input = DaemonStartInput::default();
-    let args = build_daemon_start_args(&input);
-    assert_eq!(args, vec!["daemon".to_string(), "start".to_string()]);
-}
-
-#[test]
-fn build_daemon_start_args_with_flags() {
-    let input = DaemonStartInput { pool_size: Some(4), ..Default::default() };
-    let args = build_daemon_start_args(&input);
-    assert_eq!(args, vec!["daemon".to_string(), "start".to_string(), "--pool-size".to_string(), "4".to_string(),]);
-}
-
-#[test]
-fn build_daemon_start_args_includes_stale_threshold_hours() {
-    let input = DaemonStartInput { stale_threshold_hours: Some(48), ..Default::default() };
-    let args = build_daemon_start_args(&input);
-    assert_eq!(
-        args,
-        vec!["daemon".to_string(), "start".to_string(), "--stale-threshold-hours".to_string(), "48".to_string(),]
-    );
-}
-
-#[test]
 fn build_agent_run_args_defaults_detach_and_stream() {
     let input = AgentRunInput {
         tool: "codex".to_string(),

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use orchestrator_core::services::ServiceHub;
 use orchestrator_core::DaemonStatus;
 use orchestrator_daemon_runtime::DaemonRuntimeState;
+use serde::Serialize;
 
 const NOTIFICATION_CONFIG_SCHEMA: &str = "animus.daemon-notification-config.v1";
 const NOTIFICATION_CONFIG_PM_KEY: &str = "notification_config";
@@ -57,6 +58,37 @@ struct AutonomousDaemonSpawn {
     child: Child,
     log_path: PathBuf,
     startup_log_offset: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct DaemonStartApplicationView {
+    message: &'static str,
+    autonomous: bool,
+    detached: bool,
+    daemon_pid: u32,
+    log_path: String,
+    #[serde(skip)]
+    pub(crate) already_running: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct DaemonStopApplicationView {
+    message: &'static str,
+    graceful: bool,
+    shutdown_timeout_secs: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct DaemonLifecycleApplicationView {
+    pub(crate) message: &'static str,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaemonObserveApplicationRequest {
+    pub(crate) since: Option<String>,
+    pub(crate) source: Option<ObserveSource>,
+    pub(crate) workflow: Option<String>,
+    pub(crate) limit: usize,
 }
 
 pub(crate) fn canonicalize_lossy(path: &str) -> String {
@@ -1050,24 +1082,14 @@ pub(crate) async fn handle_daemon(
             Ok(())
         }
         DaemonCommand::Pause => {
-            let result = daemon.pause().await;
-            if result.is_ok() {
-                let _ = set_runtime_paused(project_root, true);
-                // Wake a parked daemon loop so it observes the pause now
-                // instead of on the next heartbeat. Fire-and-forget.
-                orchestrator_daemon_runtime::control::nudge_daemon_scheduler_best_effort(Path::new(project_root)).await;
-            }
-            result.map(|_| print_ok("daemon paused", json))
+            let result = daemon_pause_application(hub.clone(), project_root).await?;
+            print_ok(result.message, json);
+            Ok(())
         }
         DaemonCommand::Resume => {
-            let result = daemon.resume().await;
-            if result.is_ok() {
-                let _ = set_runtime_paused(project_root, false);
-                // Wake a parked daemon loop so ready work dispatches now
-                // instead of on the next heartbeat. Fire-and-forget.
-                orchestrator_daemon_runtime::control::nudge_daemon_scheduler_best_effort(Path::new(project_root)).await;
-            }
-            result.map(|_| print_ok("daemon resumed", json))
+            let result = daemon_resume_application(hub.clone(), project_root).await?;
+            print_ok(result.message, json);
+            Ok(())
         }
         DaemonCommand::Status => handle_daemon_status_command(project_root, json).await,
         DaemonCommand::Health => handle_daemon_health_command(project_root, json).await,
@@ -1108,41 +1130,48 @@ async fn handle_daemon_start(args: DaemonStartArgs, project_root: &str, json: bo
     if !json {
         let _ = crate::services::metrics::maybe_prompt_first_run(std::path::Path::new(project_root));
     }
+    let result = daemon_start_application(args, project_root).await?;
+    if json {
+        return print_value(result, true);
+    }
+    if result.already_running {
+        return print_value(result, false);
+    }
+    println!("daemon started in background (pid {})", result.daemon_pid);
+    println!("logs: {}", result.log_path);
+    println!("note: `animus daemon start` now always detaches; use `animus daemon run` to stay in the foreground.");
+    Ok(())
+}
+
+pub(crate) async fn daemon_start_application(
+    args: DaemonStartArgs,
+    project_root: &str,
+) -> Result<DaemonStartApplicationView> {
     let log_path = autonomous_daemon_log_path(project_root);
     if let Some(existing_pid) = get_daemon_pid(project_root)? {
         if is_process_alive(existing_pid) {
             let _ = set_runtime_paused(project_root, false);
-            return print_value(
-                serde_json::json!({
-                    "message": "daemon already running",
-                    "autonomous": true,
-                    "detached": true,
-                    "daemon_pid": existing_pid,
-                    "log_path": log_path.display().to_string(),
-                }),
-                json,
-            );
+            return Ok(DaemonStartApplicationView {
+                message: "daemon already running",
+                autonomous: true,
+                detached: true,
+                daemon_pid: existing_pid,
+                log_path: log_path.display().to_string(),
+                already_running: true,
+            });
         }
         let _ = set_daemon_pid(project_root, None);
     }
 
     let daemon_pid = start_autonomous_daemon(project_root, &args).await?;
-    if json {
-        return print_value(
-            serde_json::json!({
-                "message": "daemon started in background",
-                "autonomous": true,
-                "detached": true,
-                "daemon_pid": daemon_pid,
-                "log_path": log_path.display().to_string(),
-            }),
-            json,
-        );
-    }
-    println!("daemon started in background (pid {daemon_pid})");
-    println!("logs: {}", log_path.display());
-    println!("note: `animus daemon start` now always detaches; use `animus daemon run` to stay in the foreground.");
-    Ok(())
+    Ok(DaemonStartApplicationView {
+        message: "daemon started in background",
+        autonomous: true,
+        detached: true,
+        daemon_pid,
+        log_path: log_path.display().to_string(),
+        already_running: false,
+    })
 }
 
 async fn start_autonomous_daemon(project_root: &str, args: &DaemonStartArgs) -> Result<u32> {
@@ -1354,6 +1383,21 @@ fn render_daemon_metrics_snapshot(
 /// `events` / `logs` / `stream` handler, or merges their existing readers for
 /// the window/bare views.
 async fn handle_daemon_observe(args: DaemonObserveArgs, project_root: &str, json: bool) -> Result<()> {
+    if json && !args.follow {
+        return print_value(
+            daemon_observe_application(
+                DaemonObserveApplicationRequest {
+                    since: args.since,
+                    source: args.source,
+                    workflow: args.workflow,
+                    limit: args.limit,
+                },
+                project_root,
+            )?,
+            true,
+        );
+    }
+
     // Parse --since once into a window (u64::MAX = no time bound) so every
     // branch that reads from the merged collectors honors it.
     let window_secs = match args.since.as_deref() {
@@ -1480,6 +1524,33 @@ async fn handle_daemon_observe(args: DaemonObserveArgs, project_root: &str, json
     let lines =
         collect_observe_window(project_root, u64::MAX, args.workflow.as_deref(), args.limit, ObserveSources::Both);
     render_observe_lines(&lines, json)
+}
+
+pub(crate) fn daemon_observe_application(
+    request: DaemonObserveApplicationRequest,
+    project_root: &str,
+) -> Result<serde_json::Value> {
+    let window_secs = match request.since.as_deref() {
+        Some(since) => crate::cli_types::parse_duration_secs(since, 60)
+            .map_err(|error| crate::invalid_input_error(format!("invalid --since value '{since}': {error}")))?,
+        None => u64::MAX,
+    };
+    let sources = match request.source {
+        Some(ObserveSource::Events) => ObserveSources::EventsOnly,
+        Some(ObserveSource::Logs | ObserveSource::Stream | ObserveSource::Workflow) => ObserveSources::LogsOnly,
+        None => ObserveSources::Both,
+    };
+    let lines =
+        collect_observe_window(project_root, window_secs, request.workflow.as_deref(), request.limit.max(1), sources);
+
+    if request.source.is_some() || window_secs != u64::MAX {
+        return Ok(observe_lines_json(&lines));
+    }
+
+    Ok(serde_json::json!({
+        "matrix": observe_matrix_json(),
+        "recent": lines.iter().map(observe_line_json).collect::<Vec<_>>(),
+    }))
 }
 
 /// Which underlying readers `collect_observe_window` pulls from. Lets the
@@ -1675,16 +1746,7 @@ fn rfc3339_to_unix(ts: &str) -> Option<u64> {
 
 fn render_observe_lines(lines: &[ObserveLine], json: bool) -> Result<()> {
     if json {
-        return print_value(
-            serde_json::json!({
-                "lines": lines.iter().map(|l| serde_json::json!({
-                    "source": l.source,
-                    "timestamp": l.timestamp,
-                    "text": l.text,
-                })).collect::<Vec<_>>(),
-            }),
-            json,
-        );
+        return print_value(observe_lines_json(lines), true);
     }
     if lines.is_empty() {
         println!("(no recent events or logs)");
@@ -1694,6 +1756,20 @@ fn render_observe_lines(lines: &[ObserveLine], json: bool) -> Result<()> {
         println!("{:<7} {} {}", line.source, line.timestamp, line.text);
     }
     Ok(())
+}
+
+fn observe_line_json(line: &ObserveLine) -> serde_json::Value {
+    serde_json::json!({
+        "source": line.source,
+        "timestamp": line.timestamp,
+        "text": line.text,
+    })
+}
+
+fn observe_lines_json(lines: &[ObserveLine]) -> serde_json::Value {
+    serde_json::json!({
+        "lines": lines.iter().map(observe_line_json).collect::<Vec<_>>(),
+    })
 }
 
 /// Rows of the `observe` data-source matrix: verb | data source | live? |
@@ -2157,18 +2233,39 @@ async fn handle_daemon_stop(
     project_root: &str,
     json: bool,
 ) -> Result<()> {
-    let outcome = stop_daemon(hub.as_ref(), project_root, args.shutdown_timeout_secs).await?;
+    print_value(daemon_stop_application(hub, project_root, args.shutdown_timeout_secs).await?, json)
+}
+
+pub(crate) async fn daemon_stop_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    shutdown_timeout_secs: u64,
+) -> Result<DaemonStopApplicationView> {
+    let outcome = stop_daemon(hub.as_ref(), project_root, shutdown_timeout_secs).await?;
 
     let graceful = outcome.existing_pid.map(|pid| !outcome.forced && !is_process_alive(pid)).unwrap_or(true);
 
-    print_value(
-        serde_json::json!({
-            "message": "daemon stopped",
-            "graceful": graceful,
-            "shutdown_timeout_secs": args.shutdown_timeout_secs,
-        }),
-        json,
-    )
+    Ok(DaemonStopApplicationView { message: "daemon stopped", graceful, shutdown_timeout_secs })
+}
+
+pub(crate) async fn daemon_pause_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+) -> Result<DaemonLifecycleApplicationView> {
+    hub.daemon().pause().await?;
+    let _ = set_runtime_paused(project_root, true);
+    orchestrator_daemon_runtime::control::nudge_daemon_scheduler_best_effort(Path::new(project_root)).await;
+    Ok(DaemonLifecycleApplicationView { message: "daemon paused" })
+}
+
+pub(crate) async fn daemon_resume_application(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+) -> Result<DaemonLifecycleApplicationView> {
+    hub.daemon().resume().await?;
+    let _ = set_runtime_paused(project_root, false);
+    orchestrator_daemon_runtime::control::nudge_daemon_scheduler_best_effort(Path::new(project_root)).await;
+    Ok(DaemonLifecycleApplicationView { message: "daemon resumed" })
 }
 
 const DEFAULT_DAEMON_LOG_LINES: usize = 100;

--- a/docs/architecture/actor-bound-application-contract.md
+++ b/docs/architecture/actor-bound-application-contract.md
@@ -209,6 +209,11 @@ These surfaces remain absent from actor-bound MCP until their protocols change:
   fleet daily budget. The underlying cost state and daemon configuration are
   still global stores with no actor field or authorization context, so these
   tools remain management-only.
+- Daemon lifecycle and observation: start/stop/pause/resume/observe use shared
+  typed in-process services, while the detached daemon process, control wire,
+  and scoped history files remain their intentional state owners. Those
+  operations control or expose project-wide state without an actor-aware
+  authorization protocol, so the daemon family remains management-only.
 - Environment node management: list/get/teardown/reap use shared typed
   in-process application services, then call the installed environment plugin
   through its typed protocol. That protocol has no actor field and the plugin's

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -244,6 +244,13 @@ dispatch control.
 from its recommended defaults before continuing; use `skip_preflight` only for
 dev or intentionally degraded runs.
 
+Daemon start/stop/pause/resume/observe and the existing status, health, events,
+agents, logs, and configuration tools all use typed in-process application
+services. Detached start still launches the daemon process itself; the removed
+process was only the redundant child CLI between MCP and that service. Daemon
+management remains unavailable to actor-bound agent servers because daemon
+lifecycle and project-wide observation are not user/tenant partitioned.
+
 Daemon configuration and all cost/budget MCP tools execute through typed
 in-process services. `animus.budget.set` shares the daemon configuration write
 path, so the MCP and CLI surfaces cannot drift. Prefer the structured

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -148,7 +148,7 @@ approval gate stays human-only.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `animus.daemon.start` | Start the Animus daemon for task scheduling and agent management | `pool_size` (alias: `max_agents`), `interval_secs`, `startup_cleanup`, `resume_interrupted`, `reconcile_stale`, `stale_threshold_hours`, `max_tasks_per_tick`, `phase_timeout_secs`, `auto_install`, `skip_preflight`, `project_root` |
+| `animus.daemon.start` | Start the Animus daemon for task scheduling and agent management | `pool_size` (alias: `max_agents`), `interval_secs`, `startup_cleanup`, `reconcile_stale`, `stale_threshold_hours`, `max_tasks_per_tick`, `phase_timeout_secs`, `auto_install`, `skip_preflight`, `project_root` |
 | `animus.daemon.stop` | Stop the daemon gracefully | `project_root` |
 | `animus.daemon.status` | Check if daemon is running and view basic state | `project_root` |
 | `animus.daemon.health` | Get detailed health metrics (active agents, queue, capacity); payload carries an additive `healthy` boolean verdict (false when the daemon is down/crashed or any plugin is unhealthy; a paused runtime stays true) | `project_root` |
@@ -160,6 +160,13 @@ approval gate stays human-only.
 | `animus.daemon.config` | Read current daemon automation settings through the typed in-process configuration service | `project_root` |
 | `animus.daemon.config-set` | Update daemon runtime settings and notification config through the same typed in-process service. Prefer structured `notification_config`; the JSON-string and file fields are mutually exclusive compatibility inputs | `pool_size` (alias: `max_agents`), `interval_secs`, `max_tasks_per_tick`, `stale_threshold_hours`, `phase_timeout_secs`, `max_daily_usd`, `silent_threshold_mins`, `notification_config`, `notification_config_json`, `notification_config_file`, `clear_notification_config`, `project_root` |
 | `animus.daemon.observe` | Routing front-door over the existing observability surfaces: returns the merged, chronological window of daemon events + logs (or routes to a single `source`). Non-streaming — always returns and never follows live. Works offline (reads scoped event/log history; the daemon need not be running) | `since`, `source` (`logs`/`events`/`stream`/`workflow`), `workflow_id`, `limit`, `project_root` |
+
+All daemon-management MCP tools execute through typed in-process services; none
+reconstructs CLI arguments or spawns a child Animus CLI. Detached start still
+launches the real daemon process, and status/health/log paths retain their
+control-wire, plugin, and on-disk state owners. The daemon family remains
+management-only because lifecycle and project-wide observability state is not
+partitioned or authorized by an authenticated actor.
 
 ---
 


### PR DESCRIPTION
## Summary
- route daemon start/stop/pause/resume/observe through shared typed in-process application services
- preserve detached daemon spawning, control-wire nudges, scoped observation readers, and existing CLI JSON/human contracts
- expose the already-documented `auto_install` and `skip_preflight` start inputs and reject invalid values before effects
- remove obsolete daemon argv builders/helpers and document the management-only ownership boundary

## Validation
- `cargo fmt --all`
- `git diff --check`
- focused daemon lifecycle and observe tests
- daemon CLI E2E: 10/10
- daemon E2E: 7/7
- `cargo check -p orchestrator-cli --tests --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo animus-lint`
- unsandboxed `cargo test -p orchestrator-cli --locked -- --test-threads=1` (1,427 unit tests plus every integration/binary target passed)