### PR TITLE
fix: close TASK-1174 daemon projection review gap

### DIFF
--- a/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
+++ b/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
@@ -144,7 +144,7 @@ async fn project_runner_terminal_state(
             let reason = failure_reason
                 .map(str::to_string)
                 .unwrap_or_else(|| format!("workflow runner exited with status {exit_code:?}"));
-            hub.workflows().fail_current_phase(workflow_id, reason).await?
+            hub.workflows().fail_external_execution(workflow_id, reason).await?
         }
         Some(TerminalProjection::Cancelled) => hub.workflows().cancel(workflow_id).await?,
         None => return Ok(None),
@@ -220,7 +220,9 @@ async fn finalize_plugin_queue_entry(root: &str, fact: &protocol::SubjectExecuti
 mod tests {
     use super::*;
 
-    use orchestrator_core::{services::FileServiceHub, WorkflowRunInput, WorkflowStatus};
+    use orchestrator_core::{
+        services::FileServiceHub, workflow::WorkflowStateManager, WorkflowRunInput, WorkflowStatus,
+    };
 
     #[test]
     fn failed_runner_exit_is_not_projected_as_operator_cancellation() {
@@ -242,6 +244,15 @@ mod tests {
             .run(WorkflowRunInput::for_task("TASK-failed".to_string(), Some("standard-workflow".to_string())), None)
             .await
             .expect("failed workflow fixture");
+        let manager = WorkflowStateManager::new(root.path());
+        let mut before = manager.load(&failed.id).expect("load workflow fixture");
+        before.phases[before.current_phase_index].attempt = 2;
+        before.rework_counts.insert("implementation".to_string(), 2);
+        before.total_reworks = 2;
+        manager.save(&before).expect("persist retry/rework fixture");
+        let attempts_before: Vec<_> = before.phases.iter().map(|phase| phase.attempt).collect();
+        let rework_counts_before = before.rework_counts.clone();
+        let total_reworks_before = before.total_reworks;
         let reason = "environment/prepare failed: Railway service cap reached";
         let projected = project_runner_terminal_state(hub.clone(), &failed.id, "failed", Some(reason), Some(1))
             .await
@@ -249,6 +260,9 @@ mod tests {
             .expect("non-terminal workflow should be projected");
         assert_eq!(projected.status, WorkflowStatus::Failed);
         assert_eq!(projected.failure_reason.as_deref(), Some(reason));
+        assert_eq!(projected.phases.iter().map(|phase| phase.attempt).collect::<Vec<_>>(), attempts_before);
+        assert_eq!(projected.rework_counts, rework_counts_before);
+        assert_eq!(projected.total_reworks, total_reworks_before);
 
         let cancelled = hub
             .workflows()

--- a/crates/orchestrator-core/src/services.rs
+++ b/crates/orchestrator-core/src/services.rs
@@ -195,6 +195,10 @@ pub trait WorkflowServiceApi: Send + Sync {
         decision: Option<PhaseDecision>,
     ) -> Result<OrchestratorWorkflow>;
     async fn fail_current_phase(&self, id: &str, error: String) -> Result<OrchestratorWorkflow>;
+    /// Terminalize a non-terminal workflow because its external runner exited
+    /// before it could record a phase outcome. This bypasses phase retry,
+    /// routing, and attempt accounting while preserving the exact reason.
+    async fn fail_external_execution(&self, id: &str, error: String) -> Result<OrchestratorWorkflow>;
     async fn mark_completed_failed(&self, id: &str, error: String) -> Result<OrchestratorWorkflow>;
     async fn mark_merge_conflict(&self, id: &str, error: String) -> Result<OrchestratorWorkflow>;
     async fn resolve_merge_conflict(&self, id: &str) -> Result<OrchestratorWorkflow>;

--- a/crates/orchestrator-core/src/services/workflow_impl.rs
+++ b/crates/orchestrator-core/src/services/workflow_impl.rs
@@ -296,6 +296,13 @@ impl WorkflowServiceApi for InMemoryServiceHub {
         Ok(workflow.clone())
     }
 
+    async fn fail_external_execution(&self, id: &str, error: String) -> Result<OrchestratorWorkflow> {
+        let mut lock = self.state.write().await;
+        let workflow = lock.workflows.get_mut(id).ok_or_else(|| not_found(format!("workflow not found: {id}")))?;
+        WorkflowLifecycleExecutor::default().mark_external_execution_failed(workflow, error);
+        Ok(workflow.clone())
+    }
+
     async fn mark_completed_failed(&self, id: &str, error: String) -> Result<OrchestratorWorkflow> {
         let mut lock = self.state.write().await;
         let workflow = lock.workflows.get_mut(id).ok_or_else(|| not_found(format!("workflow not found: {id}")))?;
@@ -711,6 +718,17 @@ impl WorkflowServiceApi for FileServiceHub {
             state_machines,
         )
         .mark_current_phase_failed(&mut workflow, error)?;
+        manager.save(&workflow)?;
+        let workflow = manager.save_checkpoint(&workflow, CheckpointReason::StatusChange)?;
+
+        self.state.write().await.workflows.insert(id.to_string(), workflow.clone());
+        Ok(workflow)
+    }
+
+    async fn fail_external_execution(&self, id: &str, error: String) -> Result<OrchestratorWorkflow> {
+        let manager = self.workflow_manager();
+        let mut workflow = manager.load(id)?;
+        WorkflowLifecycleExecutor::default().mark_external_execution_failed(&mut workflow, error);
         manager.save(&workflow)?;
         let workflow = manager.save_checkpoint(&workflow, CheckpointReason::StatusChange)?;
 

--- a/crates/orchestrator-core/src/workflow/lifecycle_executor.rs
+++ b/crates/orchestrator-core/src/workflow/lifecycle_executor.rs
@@ -1147,6 +1147,35 @@ impl WorkflowLifecycleExecutor {
         Ok(())
     }
 
+    /// Record a terminal failure reported by the external workflow runner.
+    /// Unlike `mark_current_phase_failed`, this is not a phase transition: the
+    /// runner may have exited before the phase started, and daemon
+    /// reconciliation must not consume retry or rework accounting while
+    /// repairing the persisted workflow row.
+    pub fn mark_external_execution_failed(&self, workflow: &mut OrchestratorWorkflow, error: String) {
+        if matches!(
+            workflow.status,
+            WorkflowStatus::Completed | WorkflowStatus::Failed | WorkflowStatus::Escalated | WorkflowStatus::Cancelled
+        ) {
+            return;
+        }
+
+        let phase_id = workflow.current_phase.clone().unwrap_or_else(|| "external-runner".to_string());
+        workflow.machine_state = WorkflowMachineState::Failed;
+        workflow.sync_status();
+        workflow.failure_reason = Some(error.clone());
+        workflow.completed_at = Some(Utc::now());
+        workflow.current_phase = None;
+        workflow.decision_history.push(self.decision_record(
+            phase_id,
+            WorkflowDecisionAction::Fail,
+            None,
+            error,
+            1.0,
+            WorkflowDecisionRisk::High,
+        ));
+    }
+
     pub fn mark_completed_failed(&self, workflow: &mut OrchestratorWorkflow, error: String) {
         if workflow.status != WorkflowStatus::Completed {
             return;


### PR DESCRIPTION
Follow-up to #371/#372. Adds a dedicated external-runner failure transition so daemon reconciliation terminalizes directly, preserves the exact runner reason, and bypasses phase retry, attempt, and rework accounting. Regression verifies cancellation remains distinct and counters are unchanged. Validation: cargo fmt --check; targeted projection test; cargo clippy for orchestrator-core and orchestrator-cli with all targets and warnings denied.