### PR TITLE
Expose durable queue enqueue idempotency

### DIFF
--- a/crates/orchestrator-cli/src/cli_types/queue_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/queue_types.rs
@@ -54,6 +54,12 @@ pub(crate) struct QueueEnqueueArgs {
     #[arg(long, value_name = "JSON", help = INPUT_JSON_PRECEDENCE_HELP)]
     pub(crate) input_json: Option<String>,
     #[arg(
+        long = "idempotency-key",
+        value_name = "KEY",
+        help = "Stable producer key for durable enqueue. An identical retry returns the original queue receipt; changed content with the same key fails closed."
+    )]
+    pub(crate) idempotency_key: Option<String>,
+    #[arg(
         long = "at",
         value_name = "WHEN",
         help = "Defer dispatch until this time. Accepts an RFC 3339 timestamp (2026-06-13T15:00:00Z) or a relative offset (90s, 30m, 2h, 3d). The entry stays queued but is not dispatched until then."

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inproc.rs
@@ -123,6 +123,7 @@ fn queue_enqueue_request(input: QueueEnqueueInput) -> Result<QueueEnqueueRequest
         description: input.description,
         workflow_ref: input.workflow_ref,
         input: typed_input,
+        idempotency_key: input.idempotency_key,
         run_at: input.run_at,
         expire_after_secs,
         adhoc: false,
@@ -141,6 +142,7 @@ mod tests {
             workflow_ref: Some("coding".to_string()),
             input_json: None,
             input: None,
+            idempotency_key: None,
             run_at: None,
             expire_after: None,
             project_root: None,
@@ -153,6 +155,16 @@ mod tests {
         input.input = Some(json!({ "nested": { "count": 7 }, "items": [true, null, "x"] }));
         let request = queue_enqueue_request(input).expect("typed request");
         assert_eq!(request.input.unwrap()["nested"]["count"], 7);
+    }
+
+    #[test]
+    fn typed_enqueue_preserves_durable_producer_key() {
+        let mut input = input();
+        input.idempotency_key = Some("github:trigger-1177:delivery-1177".to_string());
+        assert_eq!(
+            queue_enqueue_request(input).unwrap().idempotency_key.as_deref(),
+            Some("github:trigger-1177:delivery-1177")
+        );
     }
 
     #[test]

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_inputs.rs
@@ -20,6 +20,10 @@ pub(super) struct QueueEnqueueInput {
     /// retained for compatibility with older MCP clients.
     #[serde(default)]
     pub(super) input: Option<serde_json::Value>,
+    /// Stable producer key for durable enqueue. Exact retries return the
+    /// original receipt; changed content with the same key fails closed.
+    #[serde(default)]
+    pub(super) idempotency_key: Option<String>,
     /// Defer dispatch until this time: an RFC 3339 timestamp or a relative
     /// offset (`90s`, `30m`, `2h`, `3d`). The entry stays queued but is not
     /// leased until then. Omit to dispatch as soon as capacity allows.

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -249,6 +249,7 @@ pub(crate) struct QueueEnqueueRequest {
     pub(crate) description: Option<String>,
     pub(crate) workflow_ref: Option<String>,
     pub(crate) input: Option<serde_json::Value>,
+    pub(crate) idempotency_key: Option<String>,
     pub(crate) run_at: Option<String>,
     pub(crate) expire_after_secs: Option<u64>,
     pub(crate) adhoc: bool,
@@ -307,7 +308,7 @@ pub(crate) async fn queue_enqueue_application(
         repository_reservation_from_dispatch(&dispatch, (!subject_record.is_null()).then_some(&subject_record))?;
     let plugin_request = animus_queue_protocol::QueueEnqueueV2Request {
         subject_dispatch: plugin_dispatch,
-        idempotency_key: None,
+        idempotency_key: request.idempotency_key,
         repository,
         run_at: run_at.clone(),
         expire_after_secs: request.expire_after_secs,
@@ -378,6 +379,7 @@ pub(crate) async fn handle_queue(
                     description: args.description,
                     workflow_ref: args.workflow_ref,
                     input: args.input_json.map(|value| serde_json::from_str(&value)).transpose()?,
+                    idempotency_key: args.idempotency_key,
                     run_at: args.run_at,
                     expire_after_secs: args.expire_after_secs,
                     adhoc: args.adhoc,

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -232,8 +232,9 @@ dispatch control.
 { "notification_config": { "desktop": { "enabled": true } } } // structured config-set
 { "limit": 50 }                              // animus.daemon.events
 { "project_root": "/repo" }                  // animus.queue.list / stats
-{ "task_id": "TASK-001" }                    // animus.queue.enqueue (task)
+{ "subject_id": "task:TASK-001" }            // animus.queue.enqueue (task)
 { "subject_id": "blog:BLOG-001" }            // animus.queue.enqueue (BaaS dynamic kind — kernel resolves the kind)
+{ "subject_id": "task:TASK-1177", "workflow_ref": "coding", "idempotency_key": "github:trigger-1177:delivery-1177" } // durable producer retry
 { "subject_id": "task:TASK-001" }            // animus.queue.hold / release / drop
 { "subject_ids": ["task:TASK-001", "task:TASK-002"] } // animus.queue.hold / release / drop (bulk)
 { "subject_ids": ["task:TASK-003", "task:TASK-001"] } // animus.queue.reorder

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -913,6 +913,8 @@ has capacity.
 ```bash
 animus queue enqueue --subject-id TASK-001
 animus queue enqueue --subject-id requirement:REQ-042 --workflow-ref ops
+animus queue enqueue --subject-id task:TASK-1177 --workflow-ref coding \
+  --idempotency-key github:trigger-1177:delivery-1177
 animus queue enqueue --title "Investigate flaky test" --description "Fails on CI"
 animus queue enqueue --subject-id blog:BLOG-001                      # dynamic kind
 animus queue enqueue --adhoc --workflow-ref relate                   # subjectless (ad-hoc) run
@@ -956,11 +958,14 @@ animus queue enqueue --subject-id TASK-001 --at 2h --expire-after 10m  # drop if
 | Flag | Description |
 |---|---|
 | `--adhoc` | Dispatch a subjectless (ad-hoc) run with no bound subject. Requires `--workflow-ref`; mutually exclusive with the subject selectors. |
+| `--idempotency-key <KEY>` | Bind the effective queue request to a stable producer key. An exact retry returns the original entry receipt; changed content with the same key fails closed. |
 | `--at <WHEN>` | Defer until an RFC 3339 timestamp or a relative offset (`90s`, `30m`, `2h`, `3d`; bare number = seconds). Omit for immediate dispatch. |
 | `--expire-after <DURATION>` | Grace window after `--at`. If still pending past `--at + this`, the entry is dropped instead of dispatched late. Requires `--at`; omit to always fire late. |
 
-Enqueue is **not deduplicated** (immediate or deferred): every enqueue
-creates a new entry. When another entry already targets the same subject,
+Without `--idempotency-key`, enqueue is **not deduplicated** (immediate or
+deferred): every enqueue creates a new entry. With a key, the queue durably
+deduplicates across processes and restarts and returns the original entry id
+for an exact retry. When another unkeyed entry already targets the same subject,
 the enqueue still succeeds and returns a `warning` (in the human output and
 the `animus.cli.v1` envelope's `warning` field) — the caller decides whether
 to `drop` the duplicate. Lease-side exclusivity still prevents two entries

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -304,7 +304,7 @@ because the config write protocol does not yet carry an authenticated actor.
 |---|---|---|
 | `animus.queue.list` | List queued subject dispatches | `project_root` |
 | `animus.queue.stats` | Get aggregate queue depth and status counts | `project_root` |
-| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). Pass `subject_id` for any kind — qualified `task:TASK-001` / `blog:BLOG-001` (kind trusted) or bare `TASK-001` (kind resolved by the router) | `title`, `subject_id`, `description`, `workflow_ref`, `input_json`, `run_at`, `expire_after`, `project_root` |
+| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). Pass `subject_id` for any kind — qualified `task:TASK-001` / `blog:BLOG-001` (kind trusted) or bare `TASK-001` (kind resolved by the router) | `title`, `subject_id`, `description`, `workflow_ref`, `input`, `input_json`, `idempotency_key`, `run_at`, `expire_after`, `project_root` |
 | `animus.queue.reorder` | Set preferred dispatch order | `subject_ids[]`, `project_root` |
 | `animus.queue.hold` | Hold one or more pending subjects from dispatch | `subject_id`, `subject_ids[]`, `project_root` |
 | `animus.queue.release` | Release one or more held subjects for dispatch | `subject_id`, `subject_ids[]`, `project_root` |
@@ -314,9 +314,11 @@ because the config write protocol does not yet carry an authenticated actor.
 offset like `90s` / `30m` / `2h` / `3d`) to **defer** dispatch: the entry
 stays queued but is not leased until the time passes. `expire_after` (e.g.
 `10m`) sets a grace window after `run_at` past which a still-pending entry is
-dropped instead of dispatched late. Enqueue is never deduplicated (immediate
-or deferred) — a collision with an existing entry for the same subject still
-enqueues and returns a `warning` in the result for the agent to act on. This
+dropped instead of dispatched late. Pass `idempotency_key` for durable
+producer-level deduplication: an exact retry returns the original receipt and
+changed content with the same key fails closed. Without a key, a collision with
+an existing entry for the same subject still enqueues and returns a `warning`.
+This
 is the path an agent uses to schedule a one-off run for a specific time. The
 daemon is queue-only: it executes only enqueued work plus cron schedules and
 never auto-dispatches `Ready` tasks from the subject backend.


### PR DESCRIPTION
Completes the producer side of TASK-1177 crash-safe GitHub trigger replay. queue enqueue and animus.queue.enqueue now accept an idempotency key and pass it to the existing generation-fenced queue v2 request instead of hardcoding no key. Exact retries recover the original receipt; changed content with the same key fails closed in the backend. CLI and MCP docs are updated.\n\nSafe release dependency: merge and release animus-postgres PR 14 before releasing this CLI change.\n\nVerification: 46 queue-focused tests, the new typed MCP preservation regression, cargo check, formatting, and diff check pass.