### PR TITLE
Fix queue admission for blocked tasks

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/queue_tools.rs
@@ -22,7 +22,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.queue.enqueue",
-        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using any subject kind or a custom title plus optional workflow/input override. Prerequisites: Subjects must exist; custom subjects require a title. Pass subject_id for any subject kind (task, requirement, or dynamic kinds like blog/post) — a qualified id (task:TASK-001, blog:BLOG-001) is trusted, a bare id (TASK-001) is resolved via the subject router. Example: {\"subject_id\": \"TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
+        description = "Enqueue a subject dispatch. Purpose: Add a SubjectDispatch to the daemon queue using any subject kind or a custom title plus optional workflow/input override. Prerequisites: Subjects must exist; task subjects must be ready or in-progress; custom subjects require a title. Blocked, on-hold, backlog, done, and cancelled tasks fail closed until explicitly transitioned. Pass subject_id for any subject kind (task, requirement, or dynamic kinds like blog/post) — a qualified id (task:TASK-001, blog:BLOG-001) is trusted, a bare id (TASK-001) is resolved via the subject router. Example: {\"subject_id\": \"TASK-001\", \"workflow_ref\": \"ops\"} or {\"subject_id\": \"blog:BLOG-001\"}. Sequencing: Use animus.queue.list to inspect position or animus.queue.reorder to adjust ordering.",
         input_schema = ao_schema_for_type::<QueueEnqueueInput>()
     )]
     async fn ao_queue_enqueue(&self, params: Parameters<QueueEnqueueInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-cli/src/services/operations/ops_queue.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue.rs
@@ -110,6 +110,47 @@ fn record_string_field(record: &serde_json::Value, names: &[&str]) -> Option<Str
     })
 }
 
+fn subject_record_status(record: &serde_json::Value) -> Option<&str> {
+    record
+        .get("subject")
+        .unwrap_or(record)
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|status| !status.is_empty())
+}
+
+/// Reject automation-driven queue admission for tasks whose lifecycle says
+/// they are not dispatchable. This deliberately lives at the queue boundary:
+/// direct `workflow run` remains an explicit operator escape hatch, while a
+/// webhook/reworker cannot silently resurrect blocked or terminal work.
+pub(super) fn ensure_queue_subject_is_dispatchable(
+    dispatch: &SubjectDispatch,
+    subject_record: &serde_json::Value,
+) -> Result<()> {
+    let Some(subject) = dispatch.subject() else {
+        return Ok(());
+    };
+    if subject.kind() != protocol::orchestrator::SUBJECT_KIND_TASK {
+        return Ok(());
+    }
+
+    let qualified_id = crate::qualify_subject_id(subject.id(), subject.kind());
+    let status = subject_record_status(subject_record).ok_or_else(|| {
+        invalid_input_error(format!(
+            "task '{qualified_id}' has no lifecycle status; queue admission requires an explicit 'ready' or 'in-progress' status"
+        ))
+    })?;
+    let normalized = status.trim().to_ascii_lowercase().replace('_', "-");
+    if matches!(normalized.as_str(), "ready" | "in-progress") {
+        return Ok(());
+    }
+
+    Err(invalid_input_error(format!(
+        "task '{qualified_id}' is not dispatchable while its status is '{status}'; explicitly transition it to 'ready' or 'in-progress' before queueing it"
+    )))
+}
+
 fn dispatch_string_field(dispatch: &SubjectDispatch, names: &[&str]) -> Option<String> {
     dispatch.vars.iter().find_map(|(key, value)| {
         (names.iter().any(|name| key.eq_ignore_ascii_case(name)) && !value.trim().is_empty())
@@ -300,6 +341,9 @@ pub(crate) async fn queue_enqueue_application(
         return Err(invalid_input_error(
             "subjectless (--adhoc) enqueue is not yet supported through the installed queue plugin: its queue RPC protocol still requires a subject. Dispatch the workflow directly instead.",
         ));
+    }
+    if !subject_record.is_null() {
+        ensure_queue_subject_is_dispatchable(&dispatch, &subject_record)?;
     }
     let dispatch_value = serde_json::to_value(&dispatch).context("encoding subject_dispatch for queue plugin")?;
     let plugin_dispatch = serde_json::from_value(dispatch_value)
@@ -933,6 +977,49 @@ mod tests {
         assert_eq!(reservation.repository, "https://github.com/launchapp-dev/animus-cli.git");
         assert_eq!(reservation.base_ref, "refs/heads/main");
         assert_eq!(reservation.head_ref, "refs/heads/animus/TASK-1175");
+    }
+
+    #[test]
+    fn queue_admission_allows_ready_and_in_progress_tasks() {
+        let dispatch = SubjectDispatch::for_task("task:TASK-1177", "coding");
+        for status in ["ready", "in-progress", "in_progress"] {
+            let record = serde_json::json!({ "subject": { "status": status } });
+            ensure_queue_subject_is_dispatchable(&dispatch, &record)
+                .unwrap_or_else(|error| panic!("{status} should be dispatchable: {error}"));
+        }
+    }
+
+    #[test]
+    fn queue_admission_rejects_non_dispatchable_task_lifecycles() {
+        let dispatch = SubjectDispatch::for_task("task:TASK-1195", "coding");
+        for status in ["backlog", "blocked", "on-hold", "on_hold", "done", "cancelled"] {
+            let record = serde_json::json!({ "status": status });
+            let error = ensure_queue_subject_is_dispatchable(&dispatch, &record)
+                .expect_err("non-dispatchable task status must fail closed");
+            assert!(error.to_string().contains(status), "error should name {status}: {error}");
+            assert_eq!(crate::classify_cli_error_kind(&error), CliErrorKind::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn queue_admission_rejects_task_records_without_status() {
+        let dispatch = SubjectDispatch::for_task("task:TASK-1195", "coding");
+        let error = ensure_queue_subject_is_dispatchable(&dispatch, &serde_json::json!({ "subject": {} }))
+            .expect_err("task without lifecycle status must fail closed");
+        assert!(error.to_string().contains("no lifecycle status"));
+        assert_eq!(crate::classify_cli_error_kind(&error), CliErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn queue_admission_does_not_impose_task_lifecycle_on_dynamic_subjects() {
+        let dispatch = SubjectDispatch::for_subject_with_metadata(
+            protocol::orchestrator::SubjectRef::new("transcript", "TRANSCRIPT-001"),
+            "relate",
+            "manual-queue-enqueue",
+            chrono::Utc::now(),
+        );
+        ensure_queue_subject_is_dispatchable(&dispatch, &serde_json::json!({}))
+            .expect("dynamic subject dispatch keeps its backend-defined lifecycle");
     }
 
     #[test]

--- a/crates/orchestrator-cli/src/services/operations/ops_queue/control_routing.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_queue/control_routing.rs
@@ -225,8 +225,13 @@ impl QueueRouting for QueueRoutingImpl {
         // engages — mirroring the workflow-run path (ops_workflow). Without this,
         // control-routed enqueue of any plugin-backed subject failed with
         // "task not found", silently breaking the queue trigger over the transports.
-        let (resolved_id, workflow_ref, plugin_backed) = match hub.tasks().get(&request.task_id).await {
-            Ok(task) => (task.id.clone(), workflow_ref_for_task(&task), false),
+        let (resolved_id, workflow_ref, plugin_backed, in_tree_record) = match hub.tasks().get(&request.task_id).await {
+            Ok(task) => (
+                task.id.clone(),
+                workflow_ref_for_task(&task),
+                false,
+                Some(serde_json::json!({ "status": task.status.to_string() })),
+            ),
             Err(in_tree_err) => {
                 // Derive the subject kind from the qualified id prefix
                 // (`<kind>:<native>`) so plugin-backed custom kinds (e.g. a
@@ -241,6 +246,7 @@ impl QueueRouting for QueueRoutingImpl {
                             .config
                             .default_workflow_ref,
                         true,
+                        None,
                     ),
                     Err(plugin_err) => {
                         return Err(ControlError::Internal(format!(
@@ -280,8 +286,12 @@ impl QueueRouting for QueueRoutingImpl {
             let subject = dispatch.subject.as_ref().expect("control enqueue always has a subject");
             Some(probe.subject_record(subject).await.map_err(internal_err)?)
         } else {
-            None
+            in_tree_record
         };
+        if let Some(record) = subject_record.as_ref() {
+            super::ensure_queue_subject_is_dispatchable(&dispatch, record)
+                .map_err(|error| ControlError::InvalidRequest(format!("queue enqueue rejected: {error:#}")))?;
+        }
         let repository =
             super::repository_reservation_from_dispatch(&dispatch, subject_record.as_ref()).map_err(internal_err)?;
         let plugin_request = queue_proto::QueueEnqueueV2Request {

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -240,6 +240,12 @@ dispatch control.
 { "subject_ids": ["task:TASK-003", "task:TASK-001"] } // animus.queue.reorder
 ```
 
+Queueing a task is lifecycle-gated: only `ready` and `in-progress` tasks are
+accepted. Treat blocked, on-hold, backlog, done, and cancelled as a no-op until
+an operator explicitly transitions the task; do not revive those states from
+webhook or rework automation. Direct `workflow run` remains the deliberate
+operator path when queue admission is not appropriate.
+
 `animus.daemon.start` runs the same startup plugin preflight as the CLI. Use
 `auto_install` when you want the daemon to remediate missing required plugins
 from its recommended defaults before continuing; use `skip_preflight` only for

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -944,6 +944,13 @@ the qualified form. The resolved kind is preserved in the dispatch, so the
 queue lease and runner resolve the subject via `<kind>/get`. `--subject-id` is
 mutually exclusive with `--title` / `--adhoc`.
 
+For task subjects, queue admission fails closed unless the canonical lifecycle
+status is `ready` or `in-progress`. A task in backlog, blocked, on-hold, done,
+or cancelled must be explicitly transitioned before it can be queued; webhook
+and rework automation cannot silently resurrect it. This guard applies to the
+queue only—an operator can still use `animus workflow run` for a deliberate
+direct execution.
+
 **Deferred dispatch.** `--at` schedules the entry for a future time; it stays
 queued (counted under `pending`, and broken out as `deferred` in
 `queue stats`) but is not leased until the time passes, then dispatches on

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -304,7 +304,7 @@ because the config write protocol does not yet carry an authenticated actor.
 |---|---|---|
 | `animus.queue.list` | List queued subject dispatches | `project_root` |
 | `animus.queue.stats` | Get aggregate queue depth and status counts | `project_root` |
-| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). Pass `subject_id` for any kind — qualified `task:TASK-001` / `blog:BLOG-001` (kind trusted) or bare `TASK-001` (kind resolved by the router) | `title`, `subject_id`, `description`, `workflow_ref`, `input`, `input_json`, `idempotency_key`, `run_at`, `expire_after`, `project_root` |
+| `animus.queue.enqueue` | Add a subject dispatch to the queue (immediate, or deferred via `run_at`). Task subjects must be `ready` or `in-progress`; other task states fail closed. Pass `subject_id` for any kind — qualified `task:TASK-001` / `blog:BLOG-001` (kind trusted) or bare `TASK-001` (kind resolved by the router) | `title`, `subject_id`, `description`, `workflow_ref`, `input`, `input_json`, `idempotency_key`, `run_at`, `expire_after`, `project_root` |
 | `animus.queue.reorder` | Set preferred dispatch order | `subject_ids[]`, `project_root` |
 | `animus.queue.hold` | Hold one or more pending subjects from dispatch | `subject_id`, `subject_ids[]`, `project_root` |
 | `animus.queue.release` | Release one or more held subjects for dispatch | `subject_id`, `subject_ids[]`, `project_root` |
@@ -318,6 +318,9 @@ dropped instead of dispatched late. Pass `idempotency_key` for durable
 producer-level deduplication: an exact retry returns the original receipt and
 changed content with the same key fails closed. Without a key, a collision with
 an existing entry for the same subject still enqueues and returns a `warning`.
+Task subjects additionally fail admission unless their canonical status is
+`ready` or `in-progress`; blocked, on-hold, backlog, done, and cancelled tasks
+require an explicit lifecycle transition before queueing.
 This
 is the path an agent uses to schedule a one-off run for a specific time. The
 daemon is queue-only: it executes only enqueued work plus cron schedules and


### PR DESCRIPTION
## Root cause

Queue enqueue fetched the canonical subject record for repository metadata but ignored the task lifecycle status. GitHub rework automation could therefore enqueue an externally blocked or terminal task and start another paid coding node.

## Change

- Allow queued task admission only from ready or in-progress.
- Reject backlog, blocked, on-hold, done, cancelled, unknown, or missing task status with a typed invalid-input error.
- Apply the invariant to CLI/MCP enqueue and daemon control routing.
- Leave dynamic subjects and deliberate direct workflow run behavior unchanged.
- Document the lifecycle contract and add regression coverage.

## Verification

- cargo animus-fmt-check
- cargo animus-bin-check
- focused queue suite: 28 passed
- full elevated orchestrator-cli run: 1,439 passed; one unrelated parallel workflow-fixture race failed, then passed in exact isolation
- production TASK-1195 payload confirms canonical top-level status is blocked

## Release impact

Requires merge and a new immutable CLI release before the coordinated Portal runtime can enforce this in production. Portal PR #235 independently adds the v2 no-mutation/no-enqueue reworker contract.