### PR TITLE
Isolate runner terminal-projection test state

### DIFF
--- a/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
+++ b/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
@@ -234,6 +234,15 @@ mod tests {
 
     #[tokio::test]
     async fn runner_failure_projection_preserves_reason_and_cancel_remains_distinct() {
+        let _env_lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        // This test exercises terminal projection semantics, not journal-plugin
+        // discovery. Pin both WorkflowStateManager instances to SQLite while
+        // holding the process-wide environment guard. Without this boundary,
+        // parallel runtime tests can temporarily redirect HOME/plugin state
+        // between FileServiceHub construction and the fixture's direct manager
+        // load, producing a nondeterministic "workflow not found" failure.
+        let _journal_backend =
+            protocol::test_utils::EnvVarGuard::set("ANIMUS_DISABLE_WORKFLOW_JOURNAL_PLUGIN", Some("1"));
         let root = tempfile::tempdir().expect("project root");
         let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root.path()).expect("file service hub"));
         let _config_source_seam =

--- a/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
+++ b/crates/orchestrator-cli/src/services/runtime/execution_fact_projection/reconcile_completed_processes.rs
@@ -233,6 +233,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: guards process-global env mutation across async fixture setup
     async fn runner_failure_projection_preserves_reason_and_cancel_remains_distinct() {
         let _env_lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         // This test exercises terminal projection semantics, not journal-plugin


### PR DESCRIPTION
## Root cause

The runner terminal-projection regression creates a FileServiceHub and then a second WorkflowStateManager while other tests can temporarily change process-global HOME/plugin/journal discovery state. Unlike neighboring runtime fixtures, it did not hold the shared environment lock or pin the journal backend. In a full parallel suite this intermittently made the second manager look in a different backend and fail with "workflow not found"; exact isolation passed.

## Change

- hold the orchestrator-cli process-wide test environment lock for the fixture
- force the test-only SQLite journal path while the guard is held
- leave all production code and runner terminal projection behavior unchanged

## Verification

- cargo fmt --all -- --check
- exact regression: 1/1 passed outside the filesystem sandbox
- parallel runtime slice with 16 test threads: 342/342 passed
- complete orchestrator-cli run: the repaired test passed; 1,435/1,436 passed, with one unrelated pre-existing plugin-discovery race selecting animus-queue-default instead of the fixture animus-postgres
- exact rerun of that unrelated plugin-discovery test: 1/1 passed

Board: TASK-1197, linked to REQUIREMENT-076.

No runtime release or production deployment is implied by this test-only change.
