### PR TITLE
Isolate plugin discovery test state

### DIFF
--- a/crates/orchestrator-cli/src/services/plugin_clients.rs
+++ b/crates/orchestrator-cli/src/services/plugin_clients.rs
@@ -654,6 +654,7 @@ mod tests {
 
     #[test]
     fn workflow_runner_environment_is_limited_to_workflow_dependencies() {
+        let _env_lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         const PROVIDER_SECRET: &str = "ANIMUS_TEST_SELECTED_PROVIDER_SECRET";
         const TRIGGER_SECRET: &str = "ANIMUS_TEST_UNRELATED_TRIGGER_SECRET";
 
@@ -735,6 +736,7 @@ mod tests {
     /// the daemon, rather than by primary kind or default name/repo (TASK-228).
     #[test]
     fn find_plugin_for_kind_resolves_multi_role_plugin_by_queue_role() {
+        let _env_lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempfile::tempdir().expect("tempdir");
         let project_root = temp.path().join("project");
         fs::create_dir_all(&project_root).expect("project dir");


### PR DESCRIPTION
## What changed

- acquire the shared process-environment test lock in both `plugin_clients` fixtures that override plugin discovery paths
- keep the test-only registry and secret overrides isolated from concurrent CLI tests
- leave production plugin discovery behavior unchanged

## Root cause

The fixtures used `EnvVarGuard` to mutate `ANIMUS_CONFIG_DIR`, `ANIMUS_PLUGIN_DIR`, and test secret variables without participating in the crate-wide environment lock. Under the parallel full suite, another fixture could replace the registry path and make the multi-role test resolve `animus-queue-default` instead of its local `animus-postgres` stub.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p orchestrator-cli services::plugin_clients::tests -- --test-threads=16` — 2/2 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p orchestrator-cli -- --test-threads=16` — 1,439/1,440 passed; both plugin-client tests passed, and the only failure was the independent runner-projection fixture tracked by TASK-1197 / PR #379

Board: TASK-1198
