### PR TITLE
Fix built-in subject routing during queue reservation

### DIFF
--- a/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/operations/subject_id_dispatch.rs
@@ -75,6 +75,19 @@ fn subject_ref_preserving_key(kind: &str, qualified: &str, bare_native: &str) ->
     }
 }
 
+fn plugin_subject_kind(kind: &str) -> &str {
+    match kind {
+        SUBJECT_KIND_TASK => "task",
+        SUBJECT_KIND_REQUIREMENT => "requirement",
+        other => other,
+    }
+}
+
+fn plugin_subject_get_request(subject: &SubjectRef) -> (String, String) {
+    let kind = plugin_subject_kind(subject.kind());
+    (format!("{kind}/get"), crate::qualify_subject_id(subject.id(), kind))
+}
+
 /// Abstraction over the subject router used to resolve a bare id's real kind.
 /// Split out as a trait so the resolution logic is unit-testable with a stub
 /// router (no plugin processes spawned).
@@ -207,9 +220,8 @@ impl RouterSubjectProbe {
     /// uses the record's explicit git fields to allocate an immutable
     /// repository/head reservation before any daemon can lease the entry.
     pub(crate) async fn subject_record(&self, subject: &SubjectRef) -> Result<Value> {
-        let kind = subject.kind();
-        let qualified_id = crate::qualify_subject_id(subject.id(), kind);
-        let method = format!("{kind}/get");
+        let kind = plugin_subject_kind(subject.kind());
+        let (method, qualified_id) = plugin_subject_get_request(subject);
         let params = Some(json!({ "id": qualified_id }));
         let result = match self.actor.as_ref() {
             Some(actor) => self.dispatch.route_actor_call(&method, params, actor).await,
@@ -312,6 +324,29 @@ mod tests {
         let blog = subject_ref_for_kind("blog", "blog:BLOG-001");
         assert_eq!(blog.kind(), "blog");
         assert_eq!(blog.id(), "blog:BLOG-001");
+    }
+
+    #[test]
+    fn plugin_subject_kind_uses_backend_aliases_for_builtins() {
+        assert_eq!(plugin_subject_kind(SUBJECT_KIND_TASK), "task");
+        assert_eq!(plugin_subject_kind(SUBJECT_KIND_REQUIREMENT), "requirement");
+        assert_eq!(plugin_subject_kind("transcript"), "transcript");
+    }
+
+    #[test]
+    fn plugin_subject_get_request_preserves_qualified_id_and_uses_backend_kind() {
+        assert_eq!(
+            plugin_subject_get_request(&SubjectRef::task("task:TASK-1216".to_string())),
+            ("task/get".to_string(), "task:TASK-1216".to_string())
+        );
+        assert_eq!(
+            plugin_subject_get_request(&SubjectRef::requirement("requirement:REQ-1".to_string())),
+            ("requirement/get".to_string(), "requirement:REQ-1".to_string())
+        );
+        assert_eq!(
+            plugin_subject_get_request(&SubjectRef::new("transcript".to_string(), "TRANSCRIPT-1".to_string())),
+            ("transcript/get".to_string(), "transcript:TRANSCRIPT-1".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Root cause

Qualified task and requirement dispatches resolve to canonical protocol kinds such as animus.task. Queue-v2 then performs a second full-record fetch for generation-fenced repository reservation, but it routed that fetch to animus.task/get. The Portal Postgres backend exposes the documented task/get alias, so production rejected task:TASK-1216 before enqueue and no queue row was created.

Change

Map canonical built-in protocol kinds back to the documented plugin aliases only at the subject-record fetch boundary. Preserve the qualified subject ID and leave dynamic kinds unchanged. Add exact request-shape regression coverage for task, requirement, and dynamic subjects.

User impact

Restores Portal MCP and CLI queue enqueue for qualified task and requirement IDs while retaining queue dedupe keys, actor routing, generation fencing, and dynamic-kind behavior.

Verification

- subject-dispatch tests: 15 passed
- full orchestrator-cli suite unsandboxed: 1,443 unit tests and every integration suite passed
- cargo fmt check passed
- clippy for orchestrator-cli all targets with warnings denied passed
- git diff check passed

Release and deployment

This is kernel runtime code. Source merge alone does not fix production. Publish a new write-once CLI prerelease from the exact merge, independently verify archive and inner-binary hashes, update coordinated Portal pins, publish a new signed runtime, activate it, and rerun TASK-1216 through the real queue path.